### PR TITLE
Make the JavaScript port prominent (README + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # skaters
 
-Fast univariate online time series models. Zero dependencies. Runs in [Pyodide](https://pyodide.org/).
+Fast univariate online time series models — in **Python _and_ JavaScript**. Zero dependencies. Runs natively in the browser or in [Pyodide](https://pyodide.org/).
+
+<p align="center">
+  <a href="https://skaters.microprediction.org/"><img src="https://img.shields.io/badge/docs%20%26%20live%20demos-skaters.microprediction.org-4a3aff?style=for-the-badge" alt="Documentation and live demos"></a>
+  <a href="#javascript--the-browser"><img src="https://img.shields.io/badge/implementations-Python%20%7C%20JavaScript-1a8c4a?style=for-the-badge" alt="Python and JavaScript"></a>
+</p>
+
+> **Python and JavaScript, verified identical.** The full library is ported to zero-dependency
+> JavaScript and checked against the Python reference to 1e-6. Use it [natively in the
+> browser](#javascript--the-browser) or via Pyodide — see the
+> [live demos](https://skaters.microprediction.org/demos/).
 
 ## Install
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,14 +26,22 @@
 
   <main>
     <h1>skaters</h1>
-    <p class="subtitle">Fast online univariate time series. Zero dependencies. Runs in <a href="https://pyodide.org/">Pyodide</a>.</p>
+    <p class="subtitle">Fast online univariate time series, in <strong>Python <em>and</em> JavaScript</strong>. Zero dependencies. Runs natively in the browser or in <a href="https://pyodide.org/">Pyodide</a>.</p>
 
     <div class="tag-row">
+      <span class="tag">Python + JavaScript</span>
       <span class="tag">distributional</span>
       <span class="tag">O(1) per observation</span>
-      <span class="tag">pure Python</span>
-      <span class="tag">browser-compatible</span>
+      <span class="tag">zero dependencies</span>
+      <span class="tag">browser-native</span>
       <span class="tag">composable</span>
+    </div>
+
+    <div class="callout">
+      <strong>Two implementations, verified identical.</strong> The whole library is also a
+      zero-dependency <a href="#javascript">JavaScript port</a> — checked against the Python
+      reference to 1e-6. Use it natively in the browser, try the
+      <a href="./demos/">live demos</a>, or <code>pip install skaters</code> for Python.
     </div>
 
     <p>
@@ -60,7 +68,7 @@ for y in observations:
       facets of the same object.
     </p>
 
-    <h2>JavaScript &amp; the browser</h2>
+    <h2 id="javascript">JavaScript &amp; the browser</h2>
     <p>
       The whole library is also a zero-dependency <strong>JavaScript port</strong> — every
       transform, ensemble, and named policy. A parity suite checks 76,000+ values against the


### PR DESCRIPTION
The full JavaScript port shipped in #2, but its existence is buried (bottom of the README, low-key on the docs page). This surfaces it prominently in both, with no behavior changes.

**README**
- Tagline now reads "in **Python _and_ JavaScript**".
- A `docs & live demos` badge and an `implementations: Python | JavaScript` badge under the title.
- A top callout: "Python and JavaScript, verified identical" linking to the JS section and live demos.

**Docs landing page**
- Subtitle and tag row surface the JS port; a hero callout up top; the JS section gets an `id` for anchoring.

Built on top of current `main`, so the recent README edits are preserved.

> Note: the earlier JS-prominence commits were stranded on `gitignore-parity-vectors` (that branch was merged at an earlier state, before these commits were pushed). This PR redoes the work cleanly on a fresh branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)