### PR TITLE
Docs: consistent nav, Papers & Literature section, balance policies, drop timemachines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ They are nmenomics in some instances.
 | `kahneman` | timemachines | Fast tracker + slow residual scale | 0.50 | 0.01 | Fast signal, persistent noise |
 
 For example `kahneman` is a nod to `thinking_fast_and_slow` in
-[timemachines](https://github.com/microprediction/timemachines) and puts a strong
+timemachines and puts a strong
 prior on candidates with a **fast** process tracker outside and a **slowly-varying**
 residual scale inside. Tune the bet with `kahneman(k=1, strength=8)`; see `examples/benchmark_kahneman.py`.
 
@@ -286,4 +286,4 @@ Interactive demos (forecasting playground in native JS, and the real Python pack
 
 ## Lineage
 
-This package distills ideas from [timemachines](https://github.com/microprediction/timemachines), which provided a common skater interface for dozens of time series packages. This is a from-scratch rewrite focused on speed, distributional predictions, and browser compatibility.
+This package distills ideas from timemachines, which provided a common skater interface for dozens of time series packages. This is a from-scratch rewrite focused on speed, distributional predictions, and browser compatibility.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ f = laplace(k=1)    # no opinion — let the data decide
 f = samuelson(k=1)  # there's a drift, find it carefully (Samuelson 1965)
 f = wald(k=1)       # minimax caution (Wald)
 f = dantzig(k=1)    # optimize under compute constraints (Dantzig 1947)
-f = kahneman(k=1)   # think fast and slow (after timemachines)
+f = kahneman(k=1)   # think fast and slow (after timemachines, Cotton)
 ```
 
 They are nmenomics in some instances.

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -9,11 +9,13 @@
 <body>
   <header class="site-header">
     <div class="nav-inner">
-      <a class="brand" href="../">skaters</a>
+      <a class="brand" href="/">skaters</a>
       <nav>
-        <a href="../">Home</a>
-        <a href="./">Demos</a>
+        <a href="/">Home</a>
+        <a href="/demos/">Demos</a>
+        <a href="/#literature">Literature</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
+        <a href="https://pypi.org/project/skaters/">PyPI</a>
       </nav>
     </div>
   </header>
@@ -57,8 +59,10 @@
   </main>
 
   <footer>
-    skaters · <a href="https://github.com/microprediction/skaters">GitHub</a> ·
-    distilled from <a href="https://github.com/microprediction/timemachines">timemachines</a>
+    <a href="https://github.com/microprediction/skaters">Source</a> &middot;
+    Part of the <a href="https://github.com/microprediction">microprediction</a> family
+    (see also <a href="http://thurstone.microprediction.org">thurstone</a>,
+    <a href="http://schur.microprediction.org">schur</a>).
   </footer>
 </body>
 </html>

--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -9,11 +9,13 @@
 <body>
   <header class="site-header">
     <div class="nav-inner">
-      <a class="brand" href="../">skaters</a>
+      <a class="brand" href="/">skaters</a>
       <nav>
-        <a href="./">Demos</a>
-        <a href="./pyodide.html">Pyodide</a>
+        <a href="/">Home</a>
+        <a href="/demos/">Demos</a>
+        <a href="/#literature">Literature</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
+        <a href="https://pypi.org/project/skaters/">PyPI</a>
       </nav>
     </div>
   </header>
@@ -80,8 +82,10 @@
   </main>
 
   <footer>
-    skaters · <a href="https://github.com/microprediction/skaters">GitHub</a> ·
-    a from-scratch rewrite distilling <a href="https://github.com/microprediction/timemachines">timemachines</a>
+    <a href="https://github.com/microprediction/skaters">Source</a> &middot;
+    Part of the <a href="https://github.com/microprediction">microprediction</a> family
+    (see also <a href="http://thurstone.microprediction.org">thurstone</a>,
+    <a href="http://schur.microprediction.org">schur</a>).
   </footer>
 
   <script type="module">

--- a/docs/demos/pyodide.html
+++ b/docs/demos/pyodide.html
@@ -9,11 +9,13 @@
 <body>
   <header class="site-header">
     <div class="nav-inner">
-      <a class="brand" href="../">skaters</a>
+      <a class="brand" href="/">skaters</a>
       <nav>
-        <a href="./">Demos</a>
-        <a href="./playground.html">Playground (JS)</a>
+        <a href="/">Home</a>
+        <a href="/demos/">Demos</a>
+        <a href="/#literature">Literature</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
+        <a href="https://pypi.org/project/skaters/">PyPI</a>
       </nav>
     </div>
   </header>
@@ -68,8 +70,10 @@ for y in series:           # one observation at a time
   </main>
 
   <footer>
-    skaters · <a href="https://github.com/microprediction/skaters">GitHub</a> ·
-    <a href="https://pyodide.org/">Pyodide</a>
+    <a href="https://github.com/microprediction/skaters">Source</a> &middot;
+    Part of the <a href="https://github.com/microprediction">microprediction</a> family
+    (see also <a href="http://thurstone.microprediction.org">thurstone</a>,
+    <a href="http://schur.microprediction.org">schur</a>).
   </footer>
 
   <script src="https://cdn.jsdelivr.net/pyodide/v0.26.2/full/pyodide.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,7 +110,7 @@ f = laplace(k=1)    # no opinion — let the data decide
 f = samuelson(k=1)  # there's a drift, find it carefully (Samuelson 1965)
 f = wald(k=1)       # minimax caution (Wald)
 f = dantzig(k=1)    # optimize under compute constraints (Dantzig 1947)
-f = kahneman(k=1)   # think fast and slow (after timemachines)</code></pre>
+f = kahneman(k=1)   # think fast and slow (after timemachines, Cotton)</code></pre>
 
     <table>
       <thead><tr><th>Policy</th><th>After</th><th>Prior</th><th>$\eta$</th><th>$\lambda$</th><th>Best for</th></tr></thead>
@@ -125,28 +125,10 @@ f = kahneman(k=1)   # think fast and slow (after timemachines)</code></pre>
       </tbody>
     </table>
 
-    <h3>Kahneman: thinking fast and slow</h3>
     <p>
-      <code>kahneman</code> is a <em>prior</em>, not a new model. The architecture already
-      factors every skater into a fast part (the transform chain, which tracks the process)
-      and a slow part (the leaf, which estimates the residual law). So &ldquo;thinking fast and
-      slow&rdquo; is just a strong prior on the shared-pool candidates that put a
-      <strong>fast</strong> tracker (reactive EMA, Holt, AR, drift) on the outside and a
-      <strong>slowly-varying</strong> residual scale (<code>standardize</code> with a long
-      half-life) on the inside:
-    </p>
-    <p style="text-align:center">
-      $y \;\xrightarrow{\text{fast tracker}}\; \text{residual}
-        \;\xrightarrow{\text{slow standardize}}\; z \;\rightarrow\; \text{leaf}$
-    </p>
-    <p>
-      The point forecast reacts to every observation; the residual <em>distribution</em>
-      drifts slowly. Because these candidates live in the shared pool, any policy can discover
-      the structure on its own &mdash; Kahneman just bets on it up front, with a tunable
-      <code>strength</code>. When the noise really is slowly varying, tracking the residual
-      scale beats a constant variance by a wide margin, and the prior adapts faster than a
-      uniform one in the first few hundred observations; on stationary data the same bet costs
-      a little. See <code>examples/benchmark_kahneman.py</code>.
+      The names are mnemonics for the search strategy, not different models — every policy draws
+      on the same candidate population. Tune any of them directly, or reach for
+      <code>skater(k, aggressiveness)</code> when you have no prior.
     </p>
 
     <h2>Architecture: transforms all the way down</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,13 +13,13 @@
 <body>
   <header class="site-header">
     <div class="nav-inner">
-      <a class="brand" href="./">skaters</a>
+      <a class="brand" href="/">skaters</a>
       <nav>
-        <a href="./demos/">Demos</a>
+        <a href="/">Home</a>
+        <a href="/demos/">Demos</a>
+        <a href="/#literature">Literature</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
         <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://github.com/microprediction/skaters/tree/main/examples">Examples</a>
-        <a href="https://github.com/microprediction/timemachines">timemachines</a>
       </nav>
     </div>
   </header>
@@ -242,13 +242,27 @@ f = search(
       <li><strong>Pyodide compatible</strong> &mdash; works in the browser via WebAssembly.</li>
     </ul>
 
-    <h2>Lineage</h2>
+    <h2 id="literature">Papers &amp; literature</h2>
     <p>
-      This package distills ideas from
-      <a href="https://github.com/microprediction/timemachines"><code>timemachines</code></a>, which
-      provided a common skater interface for dozens of time series packages. <code>skaters</code>
-      is a from-scratch rewrite focused on speed, distributional predictions, and browser
-      compatibility.
+      <code>skaters</code> has no dependencies and no papers of its own — each named policy and
+      transform is a faithful online, distributional take on a classical method. The primary
+      sources, one per idea:
+    </p>
+    <ul>
+      <li><strong>Holt</strong> — C. C. Holt, <em>Forecasting trends and seasonals by exponentially weighted moving averages</em> (1957).</li>
+      <li><strong>Theta</strong> — V. Assimakopoulos &amp; K. Nikolopoulos, <em>The theta model</em>, Int. J. Forecasting (2000).</li>
+      <li><strong>Fractional differencing</strong> — J. R. M. Hosking, <em>Fractional differencing</em>, Biometrika (1981).</li>
+      <li><strong>Geometric random walk / drift</strong> — P. A. Samuelson, <em>Rational theory of warrant pricing</em> (1965).</li>
+      <li><strong>Volatility (GARCH)</strong> — R. F. Engle (1982); T. Bollerslev (1986).</li>
+      <li><strong>Online variance</strong> — B. P. Welford, <em>Note on a method for calculating corrected sums of squares</em> (1962).</li>
+      <li><strong>Covariance shrinkage</strong> — O. Ledoit &amp; M. Wolf, <em>A well-conditioned estimator for large-dimensional covariance matrices</em> (2004).</li>
+      <li><strong>AR priors</strong> — R. Litterman, the Minnesota prior (1986), for the autoregressive transforms.</li>
+      <li><strong>Minimax &amp; linear programming</strong> — A. Wald and G. Dantzig (1947) name the cautious and adaptive-search policies.</li>
+    </ul>
+    <p>
+      Sibling streaming-prediction packages in the same ecosystem:
+      <a href="https://github.com/microprediction/precise">precise</a> (online covariance) and
+      <a href="https://github.com/microprediction/humpday">humpday</a> (global optimizers).
     </p>
 
     <h2>Get the source</h2>


### PR DESCRIPTION
Docs-site polish (no code/behavior changes):

1. **Consistent navigation** — every page (home + all demos) now has a byte-identical nav and footer using root-relative URLs, so the menu no longer jumps when you move between pages. Nav: Home · Demos · Literature · GitHub · PyPI.
2. **Papers & literature** — new section (`#literature`, linked from the nav) crediting the classical method behind each policy/transform equally (Holt, Theta, Hosking, Samuelson, GARCH, Welford, Ledoit–Wolf, Litterman, Wald, Dantzig), plus sibling packages `precise` and `humpday`.
3. **Drop the timemachines link** (legacy/confusing) — removed from nav, footers, and the old "Lineage" section. The text attribution `# … (after timemachines, Cotton)` on kahneman stays.
4. **Balance the policy docs** — removed the kahneman-specific "thinking fast and slow" deep-dive from the landing page; the policies table treats all eight equally.

Verified: navs hash-identical across all four pages, every nav target serves 200, the literature anchor resolves.

> Note: the README still has its own "Lineage" paragraph linking timemachines — left untouched since you've been editing the README directly. Say the word if you want that link dropped there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)