### PR TITLE
Harden Dist/transform numerics: kill std=0, prune crash, yeo overflow

### DIFF
--- a/docs/js/skaters/dist.mjs
+++ b/docs/js/skaters/dist.mjs
@@ -168,10 +168,12 @@ export class Dist {
   }
 
   get var() {
+    // centered form: avoids catastrophic cancellation when means are large
+    // relative to spreads (which would otherwise yield var=0, std=0).
     const mu = this.mean;
     let total = 0.0;
-    for (const [w, m, s] of this.components) total += w * (s * s + m * m);
-    return total - mu * mu;
+    for (const [w, m, s] of this.components) total += w * (s * s + (m - mu) * (m - mu));
+    return total;
   }
 
   get std() {
@@ -199,6 +201,7 @@ export class Dist {
   // --- pruning ---
 
   prune(maxComponents = 20) {
+    maxComponents = Math.max(1, maxComponents);   // a Dist needs >=1 component
     let comps = this.components.map((c) => c.slice());
     while (comps.length > maxComponents) {
       let bestDist = Infinity;
@@ -224,7 +227,8 @@ export class Dist {
       } else {
         mNew = (wi * mi + wj * mj) / wNew;
         const vNew =
-          (wi * (si * si + mi * mi) + wj * (sj * sj + mj * mj)) / wNew - mNew * mNew;
+          (wi * (si * si + (mi - mNew) * (mi - mNew))
+            + wj * (sj * sj + (mj - mNew) * (mj - mNew))) / wNew;
         sNew = Math.sqrt(Math.max(vNew, 0.0));
       }
       comps[bestI] = [wNew, mNew, sNew];

--- a/docs/js/skaters/transform.mjs
+++ b/docs/js/skaters/transform.mjs
@@ -346,20 +346,21 @@ export function yeoJohnson(lmbda = 0.0) {
     if (L === 2.0) return -Math.log1p(-y);
     return -((Math.pow(-y + 1.0, 2.0 - L) - 1.0) / (2.0 - L));
   };
+  // clamp exp args so squaring the result in var() stays finite (exp(350)~1e152).
   const inv = (yp) => {
     if (yp >= 0.0) {
-      if (L === 0.0) return Math.expm1(yp);
+      if (L === 0.0) return Math.expm1(Math.min(yp, 350.0));
       return Math.pow(Math.max(L * yp + 1.0, 1e-12), 1.0 / L) - 1.0;
     }
-    if (L === 2.0) return 1.0 - Math.exp(-yp);
+    if (L === 2.0) return 1.0 - Math.exp(Math.min(-yp, 350.0));
     return 1.0 - Math.pow(Math.max(-(2.0 - L) * yp + 1.0, 1e-12), 1.0 / (2.0 - L));
   };
   const dinv = (yp) => {
     if (yp >= 0.0) {
-      if (L === 0.0) return Math.exp(yp);
+      if (L === 0.0) return Math.exp(Math.min(yp, 350.0));
       return Math.pow(Math.max(L * yp + 1.0, 1e-12), 1.0 / L - 1.0);
     }
-    if (L === 2.0) return Math.exp(-yp);
+    if (L === 2.0) return Math.exp(Math.min(-yp, 350.0));
     return Math.pow(Math.max(-(2.0 - L) * yp + 1.0, 1e-12), 1.0 / (2.0 - L) - 1.0);
   };
 

--- a/src/skaters/dist.py
+++ b/src/skaters/dist.py
@@ -129,9 +129,15 @@ class Dist:
 
     @property
     def var(self) -> float:
-        """Variance of the mixture (law of total variance)."""
+        """Variance of the mixture (law of total variance).
+
+        Centered form ``sum w (s^2 + (m - mu)^2)`` rather than
+        ``sum w (s^2 + m^2) - mu^2``: the latter catastrophically cancels when
+        the means are large relative to the spreads (e.g. a tight component at
+        a large mean), silently yielding var=0 and std=0 — an invalid Dist.
+        """
         mu = self.mean
-        return sum(w * (s * s + m * m) for w, m, s in self.components) - mu * mu
+        return sum(w * (s * s + (m - mu) * (m - mu)) for w, m, s in self.components)
 
     @property
     def std(self) -> float:
@@ -160,6 +166,7 @@ class Dist:
 
     def prune(self, max_components: int = 20) -> Dist:
         """Reduce component count by merging closest pairs."""
+        max_components = max(1, max_components)   # a Dist needs >=1 component
         comps = list(self.components)
         while len(comps) > max_components:
             # Find closest pair (by mean distance, weighted by mass)
@@ -182,7 +189,9 @@ class Dist:
                 s_new = max(si, sj, 1e-12)
             else:
                 m_new = (wi * mi + wj * mj) / w_new
-                v_new = (wi * (si * si + mi * mi) + wj * (sj * sj + mj * mj)) / w_new - m_new * m_new
+                # centered form — avoids the same cancellation as Dist.var
+                v_new = (wi * (si * si + (mi - m_new) ** 2)
+                         + wj * (sj * sj + (mj - m_new) ** 2)) / w_new
                 s_new = math.sqrt(max(v_new, 0.0))
             comps[best_i] = (w_new, m_new, s_new)
             comps.pop(best_j)

--- a/src/skaters/transform.py
+++ b/src/skaters/transform.py
@@ -590,13 +590,15 @@ def yeo_johnson(lmbda: float = 0.0):
         return -(((-y + 1.0) ** (2.0 - L) - 1.0) / (2.0 - L))
 
     def _inv(yp: float) -> float:
+        # clamp exp arguments to avoid OverflowError on pathological inputs
+        # (exp(350) ~ 1e152 keeps var (its square) finite); the value is huge-but-finite, not NaN.
         if yp >= 0.0:                       # forward is monotone, sign-preserving
             if L == 0.0:
-                return math.expm1(yp)
+                return math.expm1(min(yp, 350.0))
             base = max(L * yp + 1.0, 1e-12)
             return base ** (1.0 / L) - 1.0
         if L == 2.0:
-            return 1.0 - math.exp(-yp)
+            return 1.0 - math.exp(min(-yp, 350.0))
         base = max(-(2.0 - L) * yp + 1.0, 1e-12)
         return 1.0 - base ** (1.0 / (2.0 - L))
 
@@ -604,11 +606,11 @@ def yeo_johnson(lmbda: float = 0.0):
         """d inv / dy' at yp (for the delta-method std)."""
         if yp >= 0.0:
             if L == 0.0:
-                return math.exp(yp)
+                return math.exp(min(yp, 350.0))
             base = max(L * yp + 1.0, 1e-12)
             return base ** (1.0 / L - 1.0)
         if L == 2.0:
-            return math.exp(-yp)
+            return math.exp(min(-yp, 350.0))
         base = max(-(2.0 - L) * yp + 1.0, 1e-12)
         return base ** (1.0 / (2.0 - L) - 1.0)
 

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -1,0 +1,69 @@
+"""Edge-case / robustness regression tests.
+
+Every prediction must be a *valid* Dist: finite mean, std strictly positive and
+finite, monotone quantiles. These guard the numerical fixes for catastrophic
+cancellation in the variance, pruning degeneracies, and transform overflow.
+"""
+
+import math
+
+import pytest
+
+from skaters.dist import Dist
+from skaters.transform import yeo_johnson
+from skaters.api import (
+    skater, holt, hosking, laplace, wald, samuelson, dantzig, kahneman, dirac,
+)
+
+POLICIES = [skater, holt, hosking, laplace, wald, samuelson, dantzig, kahneman, dirac]
+
+DEGENERATE_SERIES = {
+    "constant": [3.0] * 40,
+    "all_zero": [0.0] * 40,
+    "single_obs": [5.0],
+    "huge_alternating": [1e12, -1e12] * 20,
+    "tiny": [1e-12 * i for i in range(40)],
+    "all_negative": [-(i + 1.0) for i in range(40)],
+    "monotonic": [float(i) for i in range(40)],
+    "alternating": [1.0 if i % 2 else -1.0 for i in range(40)],
+    "step": [0.0] * 20 + [100.0] * 20,
+}
+
+
+def _is_valid(d):
+    if not math.isfinite(d.mean):
+        return False
+    if not (d.std > 0 and math.isfinite(d.std)):
+        return False
+    return d.quantile(0.9) >= d.quantile(0.1) - 1e-6
+
+
+@pytest.mark.parametrize("factory", POLICIES, ids=lambda f: f.__name__)
+@pytest.mark.parametrize("series", DEGENERATE_SERIES.values(), ids=DEGENERATE_SERIES.keys())
+def test_policies_emit_valid_dist_on_degenerate_input(factory, series):
+    f = factory(1)
+    state, last = None, None
+    for y in series:
+        dists, state = f(y, state)
+        last = dists[0]
+    assert _is_valid(last), f"invalid Dist: mean={last.mean} std={last.std}"
+
+
+def test_var_stable_under_large_mean():
+    # E[X^2] - E[X]^2 cancels here (9e16 - 9e16 = 0); the centered form does not.
+    assert abs(Dist([(1.0, 1e8, 1.0)]).std - 1.0) < 1e-3
+    # a tight component at a large mean must keep std > 0
+    assert Dist([(1.0, 3.0, 1e-16)]).std > 0
+
+
+def test_prune_degenerate_does_not_crash():
+    assert len(Dist([(0.5, 0.0, 1.0), (0.5, 5.0, 1.0)]).prune(0).components) == 1
+    assert len(Dist([(1.0, 0.0, 1.0)]).prune(0).components) == 1
+    assert len(Dist([(1.0, 0.0, 1.0)]).prune(5).components) == 1
+
+
+def test_yeo_johnson_inverse_no_overflow():
+    # an absurd transformed mean must give a finite (if huge) std, not crash/inf
+    out = yeo_johnson(0.0)[1]([Dist([(1.0, 800.0, 1.0)])], {})[0]
+    assert math.isfinite(out.std) and out.std > 0
+    assert math.isfinite(out.mean)


### PR DESCRIPTION
A robustness pass (audit + empirical stress: every policy × 9 degenerate series). Found and fixed **four real bugs**, each of which produced an *invalid* `Dist` (std ≤ 0 / inf / crash) from finite input — violating the package's core invariant.

1. **`Dist.var` catastrophic cancellation.** It computed `E[X²] − E[X]²`, which cancels to 0 when means are large relative to spreads. `N(1e8,1).std` was **0**, and `dantzig` emitted **std=0** on constant/alternating series. Fixed to the centered form `Σ w (s² + (m−μ)²)` — and the same fix inside `prune()`'s merge.
2. **`prune` crash.** `prune(max_components ≤ 0)` (or pruning a 1-component `Dist`) raised `IndexError`. Floor at 1.
3. **Yeo-Johnson inverse overflow.** `exp()` on a pathological transformed mean raised `OverflowError`, then gave `std=inf` when squared. Clamp the exp args to 350 so the value *and its square* stay finite.

(Two agent-flagged items — terminal NaN on all-−inf weights, and a power-transform overflow — did **not** reproduce, so they're left alone.)

**After:** 0 invalid Dists across 9 policies × 9 degenerate series. JS port updated to match; parity green (99,778 values). 84 new robustness tests (parametrized over policy × series + the four unit repros).

🤖 Generated with [Claude Code](https://claude.com/claude-code)