### PR TITLE
Add doob: committed martingale + learned volatility clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Every skater returns `list[Dist]` — a weighted Gaussian mixture for each horiz
 Every named function builds a Bayesian ensemble over the same full candidate population. The names represent different **search strategies** — different priors, learning rates, and complexity penalties — not different models. 
 
 ```python
-from skaters import holt, hosking, laplace, samuelson, wald, dantzig, kahneman, dirac
+from skaters import holt, hosking, laplace, samuelson, wald, dantzig, kahneman, dirac, doob
 
 f = holt(k=1)       # expect trends (Holt 1957)
 f = hosking(k=1)    # expect long memory (Hosking 1981)
@@ -51,6 +51,7 @@ f = wald(k=1)       # minimax caution (Wald)
 f = dantzig(k=1)    # optimize under compute constraints (Dantzig 1947)
 f = kahneman(k=1)   # think fast and slow (after timemachines, Cotton)
 f = dirac(k=1)      # bet on repetition — atoms on the lattice it revisits (after Paul Dirac)
+f = doob(k=1)       # martingale + learned volatility clock; feed levels (after Joseph Doob)
 ```
 
 They are nmenomics in some instances.
@@ -65,6 +66,7 @@ They are nmenomics in some instances.
 | `dantzig` | Dantzig 1947 | Adaptive search | 0.30 | 0.01 | Adaptive (grows pool online) |
 | `kahneman` | timemachines | Fast tracker + slow residual scale | 0.50 | 0.01 | Fast signal, persistent noise |
 | `dirac` | Paul Dirac | Lattice projection over `skater` | — | — | Repeating / grid-quoted series (policy rates, posted prices) |
+| `doob` | Joseph Doob | Martingale mean + learned volatility clock | — | — | Near-martingale **levels** (prices, indices) |
 
 For example `kahneman` is a nod to `thinking_fast_and_slow` in
 timemachines and puts a strong
@@ -86,6 +88,17 @@ Every policy also draws on a **Yeo-Johnson coordinate** candidate group (a coars
 grid of the signed Box-Cox family), so the ensemble can *learn the coordinate* a
 series is simple in — log/multiplicative, sqrt, or linear — online, rather than
 committing to one up front.
+
+`doob` is the one **committed** policy (after Joseph Doob): it pins the mean to a
+**martingale** (the last value — no drift, no mean reversion) and only learns how
+the **volatility breathes**, Bayesian-averaging several martingale predictives
+that differ in their volatility clock (constant, GARCH, slowly-varying, heavy
+tailed). By Dambis–Dubins–Schwarz any continuous martingale is a *time-changed
+Brownian motion*, so the bet is exactly "BM on a stochastic clock". Feed it the
+**level** series (prices, indices, rates), not pre-differenced changes: when the
+martingale prior holds it beats the diffuse `laplace` ensemble by committing the
+mean and spending its capacity on the clock; on genuinely mean-reverting series
+(e.g. the VIX) the prior is wrong and it gives ground — a deliberately sharp tool.
 
 Or tune directly:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,7 +102,7 @@ for y in observations:
       The names represent different <em>search strategies</em> &mdash; different priors, learning
       rates, and complexity penalties &mdash; not different models.
     </p>
-<pre><code>from skaters import holt, hosking, laplace, samuelson, wald, dantzig, kahneman, dirac
+<pre><code>from skaters import holt, hosking, laplace, samuelson, wald, dantzig, kahneman, dirac, doob
 
 f = holt(k=1)       # expect trends (Holt 1957)
 f = hosking(k=1)    # expect long memory (Hosking 1981)
@@ -111,7 +111,8 @@ f = samuelson(k=1)  # there's a drift, find it carefully (Samuelson 1965)
 f = wald(k=1)       # minimax caution (Wald)
 f = dantzig(k=1)    # optimize under compute constraints (Dantzig 1947)
 f = kahneman(k=1)   # think fast and slow (after timemachines, Cotton)
-f = dirac(k=1)      # bet on repetition — atoms on the lattice it revisits (after Paul Dirac)</code></pre>
+f = dirac(k=1)      # bet on repetition — atoms on the lattice it revisits (after Paul Dirac)
+f = doob(k=1)       # martingale + learned volatility clock; feed levels (after Joseph Doob)</code></pre>
 
     <table>
       <thead><tr><th>Policy</th><th>After</th><th>Prior</th><th>$\eta$</th><th>$\lambda$</th><th>Best for</th></tr></thead>
@@ -124,6 +125,7 @@ f = dirac(k=1)      # bet on repetition — atoms on the lattice it revisits (af
         <tr><td><code>dantzig</code></td><td>Dantzig 1947</td><td>Adaptive search</td><td>0.30</td><td>0.01</td><td>Adaptive (grows pool online)</td></tr>
         <tr><td><code>kahneman</code></td><td>timemachines</td><td>Fast tracker + slow residual scale</td><td>0.50</td><td>0.01</td><td>Fast signal, persistent noise</td></tr>
         <tr><td><code>dirac</code></td><td>Paul Dirac</td><td>Lattice projection over <code>skater</code></td><td>&mdash;</td><td>&mdash;</td><td>Repeating / grid-quoted series (policy rates, posted prices)</td></tr>
+        <tr><td><code>doob</code></td><td>Joseph Doob</td><td>Martingale mean + learned volatility clock</td><td>&mdash;</td><td>&mdash;</td><td>Near-martingale <strong>levels</strong> (prices, indices)</td></tr>
       </tbody>
     </table>
 

--- a/docs/js/skaters/api.mjs
+++ b/docs/js/skaters/api.mjs
@@ -5,9 +5,10 @@
 // complexity penalty — i.e., the search strategy. (dantzig lives in
 // search.mjs because it uses adaptive search.)
 
-import { leaf } from "./leaf.mjs";
+import { leaf, scaleMixtureLeaf } from "./leaf.mjs";
 import { conjugate } from "./conjugate.mjs";
 import { terminalLeafEnsemble } from "./terminal.mjs";
+import { bayesianEnsemble } from "./bayesian.mjs";
 import { search } from "./search.mjs";
 import { sticky } from "./sticky.mjs";
 import {
@@ -224,5 +225,20 @@ export function dirac(k = 1, spikeFrac = 0.003) {
   // projection = mean-preserving sticky atom; pull is left to the trunk.
   const f = sticky(skater(k), k, 0.05, spikeFrac);
   f.skaterName = `dirac(k=${k})`;
+  return f;
+}
+
+export function doob(k = 1) {
+  // committed martingale mean + learned volatility clock (time-changed BM).
+  // Same mean across candidates -> BMA blends vol clocks without washing kurtosis.
+  const cands = [
+    conjugate(leaf(k), difference(), k),
+    conjugate(conjugate(leaf(k), garch(), k), difference(), k),
+    conjugate(conjugate(leaf(k), standardize(0.02), k), difference(), k),
+    conjugate(conjugate(scaleMixtureLeaf(k), garch(), k), difference(), k),
+    conjugate(scaleMixtureLeaf(k), difference(), k),
+  ];
+  const f = bayesianEnsemble(cands, { k, learningRate: 0.5, depths: [1, 2, 2, 2, 1], maxComponents: 30 });
+  f.skaterName = `doob(k=${k})`;
   return f;
 }

--- a/docs/js/skaters/index.mjs
+++ b/docs/js/skaters/index.mjs
@@ -19,7 +19,7 @@ export { terminalLeafEnsemble } from "./terminal.mjs";
 export { search, TRANSFORMS } from "./search.mjs";
 export { periodDetector, topPeriods, DEFAULT_LAGS } from "./periodicity.mjs";
 export {
-  buildCandidates, skater, holt, hosking, laplace, wald, samuelson, dantzig, kahneman, dirac,
+  buildCandidates, skater, holt, hosking, laplace, wald, samuelson, dantzig, kahneman, dirac, doob,
 } from "./api.mjs";
 export { sticky } from "./sticky.mjs";
 export {

--- a/parity/gen_vectors.py
+++ b/parity/gen_vectors.py
@@ -26,7 +26,7 @@ from skaters.transform import (
     drift, holt_linear, garch, seasonal_difference, power_transform, ar,
     grouped_ar, yeo_johnson,
 )
-from skaters.api import skater, holt, hosking, laplace, wald, samuelson, kahneman, dantzig, dirac
+from skaters.api import skater, holt, hosking, laplace, wald, samuelson, kahneman, dantzig, dirac, doob
 from skaters.sticky import sticky
 from skaters.search import search as adaptive_search
 from skaters import spec as S
@@ -81,7 +81,7 @@ def build_scenarios():
     # Named policies (the full shared-pool ensembles)
     for nm, fac in [("skater", skater), ("holt", holt), ("hosking", hosking),
                     ("laplace", laplace), ("wald", wald), ("samuelson", samuelson),
-                    ("kahneman", kahneman)]:
+                    ("kahneman", kahneman), ("doob", doob)]:
         s.append((f"pol_{nm}", 1, fac(k=1)))
     s.append(("pol_skater_k2", 2, skater(k=2)))
     s.append(("pol_kahneman_k2", 2, kahneman(k=2)))

--- a/parity/scenarios.mjs
+++ b/parity/scenarios.mjs
@@ -10,7 +10,7 @@ import {
   holtLinear, garch, seasonalDifference, powerTransform, ar, groupedAr, yeoJohnson,
 } from "../docs/js/skaters/transform.mjs";
 import {
-  skater, holt, hosking, laplace, wald, samuelson, kahneman, dantzig, dirac,
+  skater, holt, hosking, laplace, wald, samuelson, kahneman, dantzig, dirac, doob,
 } from "../docs/js/skaters/api.mjs";
 import { sticky } from "../docs/js/skaters/sticky.mjs";
 import { search } from "../docs/js/skaters/search.mjs";
@@ -47,7 +47,7 @@ export function buildScenarios() {
   }
 
   // Named policies
-  const pols = { skater, holt, hosking, laplace, wald, samuelson, kahneman };
+  const pols = { skater, holt, hosking, laplace, wald, samuelson, kahneman, doob };
   for (const [nm, fac] of Object.entries(pols)) s.push([`pol_${nm}`, 1, fac(1)]);
   s.push(["pol_skater_k2", 2, skater(2)]);
   s.push(["pol_kahneman_k2", 2, kahneman(2)]);

--- a/src/skaters/__init__.py
+++ b/src/skaters/__init__.py
@@ -20,7 +20,7 @@ from skaters.transform import (
 )
 from skaters.search import search
 from skaters.periodicity import period_detector, top_periods
-from skaters.api import skater, holt, hosking, laplace, samuelson, wald, dantzig, kahneman, dirac
+from skaters.api import skater, holt, hosking, laplace, samuelson, wald, dantzig, kahneman, dirac, doob
 from skaters.sticky import sticky
 from skaters.spec import (
     build, name as spec_name, to_json, from_json,
@@ -42,6 +42,7 @@ __all__ = [
     "dantzig",
     "kahneman",
     "dirac",
+    "doob",
     "sticky",
     "period_detector",
     "top_periods",

--- a/src/skaters/api.py
+++ b/src/skaters/api.py
@@ -16,8 +16,9 @@ different models.
 
 from __future__ import annotations
 import math
-from skaters.leaf import leaf
+from skaters.leaf import leaf, scale_mixture_leaf
 from skaters.conjugate import conjugate
+from skaters.bayesian import bayesian_ensemble
 from skaters.transform import (
     difference, fractional_difference, standardize, ema_transform,
     garch, power_transform, drift, holt_linear, ar, theta,
@@ -473,4 +474,39 @@ def dirac(k: int = 1, spike_frac: float = 0.003):
     """
     f = sticky(skater(k=k), k=k, spike_frac=spike_frac)   # mean-preserving projection
     f.__name__ = f"dirac(k={k})"
+    return f
+
+
+def doob(k: int = 1):
+    """Doob's policy: a driftless martingale with a stochastic volatility clock.
+
+    After Joseph Doob (martingale theory). A committed **level-domain** model:
+    the mean is pinned to the last value — a martingale, no drift and no mean
+    reversion — and the only thing learned is how the volatility *breathes*. By
+    the Dambis-Dubins-Schwarz theorem any continuous martingale is a
+    time-changed Brownian motion, so the bet is exactly "BM on a stochastic
+    clock".
+
+    It is a Bayesian average over several martingale predictives that differ
+    only in their volatility model (constant, GARCH, slowly-varying, and
+    heavy-tailed). Because every candidate shares the *same* mean, the average
+    does **not** wash out kurtosis (the usual BMA failure mode) — instead it
+    blends the volatility clocks into one scale mixture and lets likelihood pick.
+
+    Feed it the **level** series (prices, indices, rates), not pre-differenced
+    changes. When the martingale prior holds — near-martingale levels — it beats
+    the diffuse ``laplace`` ensemble by committing the mean and spending its
+    capacity on the clock; on genuinely mean-reverting series (e.g. the VIX) the
+    prior is wrong and it gives ground. A deliberately sharp instrument.
+    """
+    cands = [
+        conjugate(leaf(k=k), difference(), k=k),                                       # constant vol
+        conjugate(conjugate(leaf(k=k), garch(), k=k), difference(), k=k),              # GARCH clock
+        conjugate(conjugate(leaf(k=k), standardize(0.02), k=k), difference(), k=k),    # slow clock
+        conjugate(conjugate(scale_mixture_leaf(k=k), garch(), k=k), difference(), k=k),  # GARCH + heavy
+        conjugate(scale_mixture_leaf(k=k), difference(), k=k),                         # EWMA + heavy
+    ]
+    f = bayesian_ensemble(cands, k=k, learning_rate=0.5, depths=[1, 2, 2, 2, 1],
+                          max_components=30)
+    f.__name__ = f"doob(k={k})"
     return f

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,12 +2,12 @@
 
 import math
 import random
-from skaters.api import skater, holt, hosking, laplace, samuelson, wald, dantzig, kahneman, dirac
+from skaters.api import skater, holt, hosking, laplace, samuelson, wald, dantzig, kahneman, dirac, doob
 from skaters.conventions import Skater
 from skaters.dist import Dist
 
 
-ALL_POLICIES = [holt, hosking, laplace, samuelson, wald, dantzig, kahneman, dirac]
+ALL_POLICIES = [holt, hosking, laplace, samuelson, wald, dantzig, kahneman, dirac, doob]
 
 
 def test_all_policies_return_skaters():

--- a/tests/test_doob.py
+++ b/tests/test_doob.py
@@ -1,0 +1,57 @@
+"""Tests for the doob policy — a committed martingale with a learned vol clock."""
+
+import math
+import random
+
+from skaters.api import doob, laplace
+from skaters.conventions import Skater
+
+
+def _run_logpdf(make, series, burn=200):
+    f = make()
+    state, pend, lp, n = None, None, 0.0, 0
+    for i, y in enumerate(series):
+        if pend is not None and i > burn:
+            v = pend[0].logpdf(y)
+            lp += v if math.isfinite(v) else -20.0
+            n += 1
+        d, state = f(y, state)
+        pend = d
+    return lp / n if n else float("nan")
+
+
+def test_doob_is_skater_and_valid():
+    f = doob(1)
+    assert isinstance(f, Skater)
+    state = None
+    random.seed(0)
+    lvl = 0.0
+    out = None
+    for _ in range(120):
+        lvl += random.gauss(0, 1.0)
+        out, state = f(lvl, state)
+    assert out[0].std > 0 and math.isfinite(out[0].mean)
+
+
+def test_doob_mean_is_a_martingale():
+    # the committed mean must track the last value (random walk), within the
+    # blend's tolerance — not drift off or mean-revert.
+    f = doob(1)
+    state = None
+    series = [5.0, 7.0, 6.0, 9.0, 9.0, 4.0, 8.0, 8.0, 8.0, 3.0]
+    out = None
+    for y in series:
+        out, state = f(y, state)
+    assert abs(out[0].mean - series[-1]) < 1.5      # anchored near the last level
+
+
+def test_doob_beats_laplace_on_a_vol_clustered_martingale():
+    # on a driftless level with volatility clustering (its design regime), the
+    # committed martingale + vol clock should beat the diffuse laplace ensemble.
+    random.seed(3)
+    lvl, vol, series = 0.0, 1.0, []
+    for _ in range(700):
+        vol = 0.95 * vol + 0.05 + 0.1 * abs(random.gauss(0, vol))
+        lvl += random.gauss(0, vol)
+        series.append(lvl)
+    assert _run_logpdf(doob, series) > _run_logpdf(lambda: laplace(1), series)


### PR DESCRIPTION
**Stacked on #14** (it needs the variance-stability fix — a martingale at a large level is exactly the catastrophic-cancellation case). Retargets to main once #14 merges.

After Joseph Doob. The one **committed** policy: it pins the mean to a **martingale** (last value — no drift, no mean reversion) and learns only how **volatility breathes**, Bayesian-averaging several martingale predictives that differ in their volatility clock (constant, GARCH, slowly-varying, heavy-tailed).

**Why plain BMA is the right tool here:** averaging usually washes out kurtosis when candidate *means* disagree — but every candidate here shares the *same* (martingale) mean, so the average becomes a **scale mixture** (same mean, different vols) that *preserves* kurtosis and just blends the clocks. The committed mean is what makes BMA correct. By Dambis–Dubins–Schwarz a continuous martingale is a time-changed Brownian motion — "BM on a stochastic clock."

**Result (fed levels, its real domain):** beats `laplace` on **9/10** near-martingale financial series. The lone loss is `VIXCLS`, which genuinely mean-reverts — the prior is *correctly* wrong there. This is the case you flagged where a strong prior really does pay: when the martingale holds, committing the mean and spending capacity on the clock beats the diffuse ensemble.

⚠️ Feed it **levels** (prices/indices/rates), not pre-differenced changes — it's a level model; on changes it differences again and predicts spurious momentum.

Python + JS (parity 100,758 values), README + docs policy table, exported, `doob` behavioral tests. 710 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)