### PR TITLE
Complete the OU work: JS twin, laplace(k>1) pool integration, multi-step demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ prior matches your series; `laplace` if you're unsure.
 
 A likelihood-weighted Bayesian ensemble over a large candidate population (EMA,
 differencing, drift, Holt, AR, fractional differencing, seasonal, a Yeo-Johnson
-**coordinate** grid, a fast/slow two-systems block, …). Three things are on by
-default, each a free or near-free win:
+**coordinate** grid, a fast/slow two-systems block, and — at multi-step horizons
+(`k>1`) — an **Ornstein–Uhlenbeck mean-reversion** group; see `mean_revert`). The
+one-step pool is unchanged. Three things are on by default, each a free or
+near-free win:
 
 - **model first, conform last** — the trunk is weighted by **likelihood** (honest
   modelling); the terminal leaf is fit by **CRPS** (`objective="crps"`). On a

--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -44,6 +44,7 @@
             <option value="trend">trend + noise</option>
             <option value="seasonal">seasonal (period 7)</option>
             <option value="rw">random walk</option>
+            <option value="meanrevert">weak mean reversion</option>
             <option value="hetero">slowly-varying noise</option>
             <option value="jumps">level jumps</option>
           </select>
@@ -115,6 +116,14 @@
         if (regime === "trend") s.push(0.06 * t + 2 * gauss(r));
         else if (regime === "seasonal") s.push(5 * Math.sin((2 * Math.PI * t) / 7) + gauss(r));
         else if (regime === "rw") { lvl += gauss(r); s.push(lvl); }
+        else if (regime === "meanrevert") {
+          // Weakly mean-reverting (Ornstein-Uhlenbeck): wanders like a random
+          // walk but is slowly pulled back to 0 — where doob's martingale prior
+          // is wrong. Small kappa = weak reversion.
+          const kappa = 0.04;
+          lvl += kappa * (0 - lvl) + 1.2 * gauss(r);
+          s.push(lvl);
+        }
         else if (regime === "hetero") {
           const sigma = Math.exp(Math.log(0.3) + (Math.log(3) - Math.log(0.3)) * (0.5 + 0.5 * Math.sin((2 * Math.PI * t) / 120)));
           s.push(gauss(r) * sigma);

--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -36,7 +36,12 @@
           <select id="policy">
             <option value="laplace">laplace (default)</option>
             <option value="doob">doob (martingale)</option>
+            <option value="mean_revert">mean_revert (reversion)</option>
           </select>
+        </div>
+        <div class="control">
+          <label for="horizon">Horizon <span class="val" id="horizonVal">6</span></label>
+          <input type="range" id="horizon" min="1" max="12" value="6" />
         </div>
         <div class="control">
           <label for="regime">Data</label>
@@ -60,16 +65,21 @@
       <canvas class="plot" id="plot" width="940" height="420"></canvas>
       <div class="legend">
         <span><span class="swatch" style="background:#1a1a1a"></span>observation</span>
-        <span><span class="swatch" style="background:#4a3aff"></span>forecast mean</span>
-        <span><span class="swatch" style="background:#cdc7ff"></span>95% interval</span>
+        <span><span class="swatch" style="background:#4a3aff"></span>1-step mean</span>
+        <span><span class="swatch" style="background:#cdc7ff"></span>1-step 95%</span>
+        <span><span class="swatch" style="background:#ff8a3a"></span>k-step forecast fan</span>
       </div>
       <p class="status" id="status">—</p>
     </div>
 
     <p>
-      The model sees one observation at a time. At each step it emits a full
-      predictive distribution for the next step; we score it against what actually
-      happens. <span class="metric" id="metrics"></span>
+      The model sees one observation at a time and emits a full predictive
+      distribution for each of the next <em>k</em> steps. The dashed orange
+      <strong>fan</strong> is that k-step forecast projecting from the latest point
+      — on the <em>weak mean reversion</em> regime, watch <code>laplace</code> (at
+      <em>k&gt;1</em>) and <code>mean_revert</code> curve the fan back toward the
+      mean while <code>doob</code>'s martingale fan stays flat.
+      <span class="metric" id="metrics"></span>
     </p>
     <p>
       Open the console and <code>import</code> from
@@ -85,12 +95,14 @@
   </footer>
 
   <script type="module">
-    import { laplace, doob } from "../js/skaters/index.mjs";
+    import { laplace, doob, meanRevert } from "../js/skaters/index.mjs";
 
     const POLICIES = {
-      laplace: () => laplace(1),
-      doob: () => doob(1),
+      laplace: (k) => laplace(k),
+      doob: (k) => doob(k),
+      mean_revert: (k) => meanRevert(k),
     };
+    let K = 6;   // forecast horizon (set from the slider in compute)
 
     // Reproducible-but-varied RNG (mulberry32). Seed bumps each regenerate.
     function rng(seed) {
@@ -142,7 +154,8 @@
     let rows = [], cursor = 0, timer = null, seed = 1, paused = false;
 
     function compute() {
-      const policy = POLICIES[document.getElementById("policy").value]();
+      K = parseInt(document.getElementById("horizon").value, 10);
+      const policy = POLICIES[document.getElementById("policy").value](K);
       const regime = document.getElementById("regime").value;
       const series = makeSeries(regime, seed);
       let state = null, pending = null;
@@ -154,9 +167,11 @@
           const d = pending[0];
           mean = d.mean; lo = d.quantile(0.025); hi = d.quantile(0.975); lp = d.logpdf(y);
         }
-        rows.push({ y, mean, lo, hi, lp });
         const [dists, st] = policy(y, state);
         state = st; pending = dists;
+        // Store the full k-step forecast fan made AFTER seeing y (predicts t+1..t+K).
+        const fan = dists.map((d) => ({ mean: d.mean, lo: d.quantile(0.025), hi: d.quantile(0.975) }));
+        rows.push({ y, mean, lo, hi, lp, fan, distK: dists[dists.length - 1] });
       }
       cursor = 1;
     }
@@ -169,6 +184,10 @@
         ymin = Math.min(ymin, r.y, isFinite(r.lo) ? r.lo : r.y);
         ymax = Math.max(ymax, r.y, isFinite(r.hi) ? r.hi : r.y);
       }
+      // The forward fan: the k-step forecast made at the last revealed point.
+      const fanRow = upto >= 1 ? rows[upto - 1] : null;
+      const fan = fanRow && fanRow.fan ? fanRow.fan : null;
+      if (fan) for (const f of fan) { ymin = Math.min(ymin, f.lo); ymax = Math.max(ymax, f.hi); }
       if (!isFinite(ymin)) { ymin = -1; ymax = 1; }
       const pad = (ymax - ymin) * 0.08 + 1e-9;
       ymin -= pad; ymax += pad;
@@ -210,6 +229,26 @@
       for (let i = 0; i < view.length; i++) {
         ctx.beginPath(); ctx.arc(X(i), Y(view[i].y), 1.7, 0, 2 * Math.PI); ctx.fill();
       }
+
+      // forward k-step forecast fan, projecting from the last revealed point.
+      // On a mean-reverting series the fan curves back toward the mean; a
+      // martingale (doob) fan stays flat. The band widens with the horizon.
+      if (fan) {
+        const anchorX = X(upto - 1), anchorY = Y(fanRow.y);
+        const fx = (h) => X(upto - 1 + h);   // h = 1..K maps to future x positions
+        // band
+        ctx.fillStyle = "rgba(255,138,58,0.18)";
+        ctx.beginPath();
+        ctx.moveTo(anchorX, anchorY);
+        for (let h = 1; h <= fan.length; h++) ctx.lineTo(fx(h), Y(fan[h - 1].hi));
+        for (let h = fan.length; h >= 1; h--) ctx.lineTo(fx(h), Y(fan[h - 1].lo));
+        ctx.closePath(); ctx.fill();
+        // mean trajectory (dashed)
+        ctx.strokeStyle = "#ff8a3a"; ctx.lineWidth = 1.8; ctx.setLineDash([4, 3]);
+        ctx.beginPath(); ctx.moveTo(anchorX, anchorY);
+        for (let h = 1; h <= fan.length; h++) ctx.lineTo(fx(h), Y(fan[h - 1].mean));
+        ctx.stroke(); ctx.setLineDash([]);
+      }
     }
 
     function updateMetrics(upto) {
@@ -219,11 +258,19 @@
         if (isFinite(r.lp)) { sumLp += r.lp; nLp++; se += (r.mean - r.y) ** 2; if (r.y >= r.lo && r.y <= r.hi) cov++; }
       }
       if (nLp === 0) { document.getElementById("metrics").textContent = ""; return; }
+      // k-step-ahead log-likelihood: score the horizon-K forecast against the
+      // value that actually arrived K steps later (where it has been revealed).
+      let sumLpK = 0, nLpK = 0;
+      for (let i = 10; i + K < upto; i++) {
+        const r = rows[i];
+        if (r.distK) { const v = r.distK.logpdf(rows[i + K].y); if (isFinite(v)) { sumLpK += v; nLpK++; } }
+      }
       const ll = (sumLp / nLp).toFixed(3);
       const rmse = Math.sqrt(se / nLp).toFixed(2);
       const c = ((cov / nLp) * 100).toFixed(0);
+      const llK = nLpK ? (sumLpK / nLpK).toFixed(3) : "—";
       document.getElementById("metrics").innerHTML =
-        `Mean log-likelihood <b>${ll}</b> · RMSE <b>${rmse}</b> · 95% coverage <b>${c}%</b> over ${nLp} steps.`;
+        `1-step LL <b>${ll}</b> · ${K}-step LL <b>${llK}</b> · RMSE <b>${rmse}</b> · 95% coverage <b>${c}%</b> over ${nLp} steps.`;
       document.getElementById("status").textContent = `step ${upto} / ${rows.length}`;
     }
 
@@ -250,6 +297,10 @@
     document.getElementById("speed").addEventListener("input", (e) => {
       document.getElementById("speedVal").textContent = e.target.value;
     });
+    document.getElementById("horizon").addEventListener("input", (e) => {
+      document.getElementById("horizonVal").textContent = e.target.value;
+    });
+    document.getElementById("horizon").addEventListener("change", start);
     document.getElementById("pause").addEventListener("click", (e) => {
       paused = !paused;
       e.target.textContent = paused ? "Resume" : "Pause";

--- a/docs/js/skaters/api.mjs
+++ b/docs/js/skaters/api.mjs
@@ -8,7 +8,7 @@ import { terminalLeafEnsemble } from "./terminal.mjs";
 import { bayesianEnsemble } from "./bayesian.mjs";
 import { sticky as project } from "./sticky.mjs";
 import {
-  difference, fractionalDifference, standardize, emaTransform, drift,
+  difference, fractionalDifference, standardize, emaTransform, ouTransform, drift,
   holtLinear, ar, theta, seasonalDifference, garch, powerTransform, yeoJohnson,
 } from "./transform.mjs";
 
@@ -155,5 +155,29 @@ export function doob(k = 1, objective = "crps") {
   ];
   const f = bayesianEnsemble(cands, { k, learningRate: 0.5, depths: [1, 2, 2, 2, 1], maxComponents: 30 });
   f.skaterName = `doob(k=${k})`;
+  return f;
+}
+
+// The mean-reverting counterpart of doob: an online likelihood-weighted average
+// over Ornstein-Uhlenbeck reversion speeds (JS port of api.mean_revert).
+export function meanRevert(k = 1, kappas = [0.02, 0.05, 0.1, 0.2, 0.4], alpha = 0.02,
+                           coordinate = null, objective = "crps") {
+  const leafFn = objectiveLeaf(objective);
+  const cands = [];
+  const depths = [];
+  for (const kp of kappas) {
+    let c = conjugate(leaf(k), ouTransform(kp, alpha), k);
+    let depth = 1;
+    if (coordinate !== null && coordinate !== undefined) {
+      c = conjugate(c, yeoJohnson(coordinate), k);
+      depth = 2;
+    }
+    cands.push(c);
+    depths.push(depth);
+  }
+  const f = terminalLeafEnsemble(cands, {
+    k, leafFn, learningRate: 0.8, complexityPenalty: 0.005, depths, maxComponents: 20,
+  });
+  f.skaterName = `mean_revert(k=${k})`;
   return f;
 }

--- a/docs/js/skaters/api.mjs
+++ b/docs/js/skaters/api.mjs
@@ -120,6 +120,18 @@ export function buildCandidates(k) {
     }
   }
 
+  // Mean-reversion prior (Ornstein-Uhlenbeck), MULTI-STEP ONLY: redundant with
+  // the ema/random-walk mix at one step, so gated on k > 1 (see api.py).
+  groups.mean_revert = [];
+  if (k > 1) {
+    for (const L of [0.0, 0.5]) {
+      for (const kappa of [0.03, 0.1, 0.3]) {
+        groups.mean_revert.push(push(
+          conjugate(conjugate(leaf(k), ouTransform(kappa, 0.02), k), yeoJohnson(L), k), 2));
+      }
+    }
+  }
+
   return [candidates, depths, groups];
 }
 

--- a/docs/js/skaters/index.mjs
+++ b/docs/js/skaters/index.mjs
@@ -10,7 +10,7 @@ export { leaf, scaleMixtureLeaf, crpsLeaf } from "./leaf.mjs";
 export { ema } from "./ema.mjs";
 export { conjugate } from "./conjugate.mjs";
 export {
-  difference, fractionalDifference, standardize, emaTransform, theta, drift,
+  difference, fractionalDifference, standardize, emaTransform, ouTransform, theta, drift,
   holtLinear, garch, seasonalDifference, powerTransform, ar, groupedAr,
 } from "./transform.mjs";
 export { precisionWeightedEnsemble } from "./ensemble.mjs";
@@ -19,7 +19,7 @@ export { terminalLeafEnsemble } from "./terminal.mjs";
 export { search, TRANSFORMS } from "./search.mjs";
 export { periodDetector, topPeriods, DEFAULT_LAGS } from "./periodicity.mjs";
 export {
-  buildCandidates, laplace, doob,
+  buildCandidates, laplace, doob, meanRevert,
 } from "./api.mjs";
 export { sticky } from "./sticky.mjs";
 export {

--- a/docs/js/skaters/transform.mjs
+++ b/docs/js/skaters/transform.mjs
@@ -146,6 +146,37 @@ export function emaTransform(alpha = 0.05) {
   return { forward, inverseK };
 }
 
+// Ornstein-Uhlenbeck mean-reversion (JS port of transform.ou_transform).
+// Reverts toward a running mean at speed kappa; phi = 1 - kappa. Multi-step
+// inverse uses the exact OU moments (phi^h mean decay, saturating variance).
+export function ouTransform(kappa = 0.1, alpha = 0.02) {
+  const phi = 1.0 - kappa;
+  function forward(y, state) {
+    if (state === null || state === undefined || !Number.isFinite(y)) {
+      const y0 = Number.isFinite(y) ? y : 0.0;
+      return [0.0, { m: y0, fc: y0, y: y0 }];
+    }
+    let resid = y - state.fc;
+    if (!Number.isFinite(resid)) resid = 0.0;
+    const m = state.m + alpha * (y - state.m);
+    const fc = m + phi * (y - m);
+    return [resid, { m, fc, y }];
+  }
+  function inverseK(dists, state) {
+    const m = state.m;
+    const ylast = state.y;
+    return dists.map((d, i) => {
+      const h = i + 1;
+      const center = m + Math.pow(phi, h) * (ylast - m);
+      const g = phi < 1.0 - 1e-9
+        ? Math.sqrt((1.0 - Math.pow(phi, 2 * h)) / (1.0 - phi * phi))
+        : Math.sqrt(h);
+      return d.scale(g).shift(center);
+    });
+  }
+  return { forward, inverseK };
+}
+
 // ---------------------------------------------------------------------------
 // Theta method (Assimakopoulos & Nikolopoulos, 2000)
 // ---------------------------------------------------------------------------

--- a/parity/gen_vectors.py
+++ b/parity/gen_vectors.py
@@ -84,6 +84,8 @@ def build_scenarios():
     # Named policies (the full shared-pool ensembles)
     for nm, fac in [("laplace", laplace), ("doob", doob), ("mean_revert", mean_revert)]:
         s.append((f"pol_{nm}", 1, fac(k=1)))
+    # laplace at k>1 exercises the multi-step mean-reversion group (gated on k>1).
+    s.append(("pol_laplace_k3", 3, laplace(k=3)))
 
     # Adaptive-search engine (still public via skaters.search)
     s.append(("search_default", 1, adaptive_search(k=1, expand_interval=50)))

--- a/parity/gen_vectors.py
+++ b/parity/gen_vectors.py
@@ -22,11 +22,11 @@ from skaters.ema import ema
 from skaters.ensemble import precision_weighted_ensemble
 from skaters.bayesian import bayesian_ensemble
 from skaters.transform import (
-    difference, fractional_difference, standardize, ema_transform, theta,
+    difference, fractional_difference, standardize, ema_transform, ou_transform, theta,
     drift, holt_linear, garch, seasonal_difference, power_transform, ar,
     grouped_ar, yeo_johnson,
 )
-from skaters.api import laplace, doob
+from skaters.api import laplace, doob, mean_revert
 from skaters.sticky import sticky
 from skaters.search import search as adaptive_search
 from skaters import spec as S
@@ -71,6 +71,9 @@ def build_scenarios():
         s.append((f"grouped_ar{suf}", k, conjugate(leaf(k=k), grouped_ar(8), k=k)))
         s.append((f"yeojohnson_log{suf}", k, conjugate(leaf(k=k), yeo_johnson(0.0), k=k)))
         s.append((f"yeojohnson_half{suf}", k, conjugate(leaf(k=k), yeo_johnson(0.5), k=k)))
+        s.append((f"ou{suf}", k, conjugate(leaf(k=k), ou_transform(0.1), k=k)))
+        s.append((f"ou_sqrt{suf}", k,
+                  conjugate(conjugate(leaf(k=k), ou_transform(0.1), k=k), yeo_johnson(0.5), k=k)))
         s.append((f"ema_skater{suf}", k, ema(0.05, k=k)))
         s.append((f"pw_ensemble{suf}", k,
                   precision_weighted_ensemble([ema(0.05, k=k), ema(0.2, k=k)], k=k)))
@@ -79,7 +82,7 @@ def build_scenarios():
             k=k, learning_rate=0.5, complexity_penalty=0.02, depths=[1, 1])))
 
     # Named policies (the full shared-pool ensembles)
-    for nm, fac in [("laplace", laplace), ("doob", doob)]:
+    for nm, fac in [("laplace", laplace), ("doob", doob), ("mean_revert", mean_revert)]:
         s.append((f"pol_{nm}", 1, fac(k=1)))
 
     # Adaptive-search engine (still public via skaters.search)

--- a/parity/scenarios.mjs
+++ b/parity/scenarios.mjs
@@ -49,6 +49,8 @@ export function buildScenarios() {
   // Named policies
   const pols = { laplace, doob, mean_revert: meanRevert };
   for (const [nm, fac] of Object.entries(pols)) s.push([`pol_${nm}`, 1, fac(1)]);
+  // laplace at k>1 exercises the multi-step mean-reversion group (gated on k>1).
+  s.push(["pol_laplace_k3", 3, laplace(3)]);
 
   // Adaptive-search engine (still public via skaters.search)
   s.push(["search_default", 1, search({ k: 1, expandInterval: 50 })]);

--- a/parity/scenarios.mjs
+++ b/parity/scenarios.mjs
@@ -6,10 +6,10 @@ import { ema } from "../docs/js/skaters/ema.mjs";
 import { precisionWeightedEnsemble } from "../docs/js/skaters/ensemble.mjs";
 import { bayesianEnsemble } from "../docs/js/skaters/bayesian.mjs";
 import {
-  difference, fractionalDifference, standardize, emaTransform, theta, drift,
+  difference, fractionalDifference, standardize, emaTransform, ouTransform, theta, drift,
   holtLinear, garch, seasonalDifference, powerTransform, ar, groupedAr, yeoJohnson,
 } from "../docs/js/skaters/transform.mjs";
-import { laplace, doob } from "../docs/js/skaters/api.mjs";
+import { laplace, doob, meanRevert } from "../docs/js/skaters/api.mjs";
 import { sticky } from "../docs/js/skaters/sticky.mjs";
 import { search } from "../docs/js/skaters/search.mjs";
 import {
@@ -36,6 +36,8 @@ export function buildScenarios() {
     s.push([`grouped_ar${suf}`, k, conjugate(leaf(k), groupedAr(8), k)]);
     s.push([`yeojohnson_log${suf}`, k, conjugate(leaf(k), yeoJohnson(0.0), k)]);
     s.push([`yeojohnson_half${suf}`, k, conjugate(leaf(k), yeoJohnson(0.5), k)]);
+    s.push([`ou${suf}`, k, conjugate(leaf(k), ouTransform(0.1), k)]);
+    s.push([`ou_sqrt${suf}`, k, conjugate(conjugate(leaf(k), ouTransform(0.1), k), yeoJohnson(0.5), k)]);
     s.push([`ema_skater${suf}`, k, ema(0.05, k)]);
     s.push([`pw_ensemble${suf}`, k,
       precisionWeightedEnsemble([ema(0.05, k), ema(0.2, k)], k)]);
@@ -45,7 +47,7 @@ export function buildScenarios() {
   }
 
   // Named policies
-  const pols = { laplace, doob };
+  const pols = { laplace, doob, mean_revert: meanRevert };
   for (const [nm, fac] of Object.entries(pols)) s.push([`pol_${nm}`, 1, fac(1)]);
 
   // Adaptive-search engine (still public via skaters.search)

--- a/src/skaters/api.py
+++ b/src/skaters/api.py
@@ -221,6 +221,23 @@ def _build_candidates(k: int, leaf_fn=leaf):
             depths.append(2)
             groups["coordinate"].append(len(candidates) - 1)
 
+    # Mean-reversion prior (Ornstein-Uhlenbeck), MULTI-STEP ONLY. The reversion
+    # edge over a random walk grows with horizon (1 - phi^h); at one step it is
+    # redundant with the ema/random-walk mix and only adds cost, so it is gated on
+    # k > 1 to leave the one-step pool (and its speed) byte-identical. Composed
+    # under the sqrt (CIR) and log (geometric) coordinates. NFL-safe: a wrong
+    # reversion speed is down-weighted. See benchmarks/cir_ablation.py.
+    groups["mean_revert"] = []
+    if k > 1:
+        for L in (0.0, 0.5):
+            for kappa in (0.03, 0.1, 0.3):
+                candidates.append(
+                    conjugate(conjugate(leaf_fn(k=k), ou_transform(kappa, 0.02), k=k),
+                              yeo_johnson(L), k=k)
+                )
+                depths.append(2)
+                groups["mean_revert"].append(len(candidates) - 1)
+
     return candidates, depths, groups
 
 

--- a/tests/test_ou.py
+++ b/tests/test_ou.py
@@ -102,6 +102,14 @@ class TestMeanRevert:
 
         assert run(lambda: mean_revert(k=k)) > run(rw)
 
+    def test_pool_gated_on_multistep(self):
+        """laplace's pool gains the mean-reversion group only for k > 1."""
+        from skaters.api import _build_candidates
+        _, _, g1 = _build_candidates(1)
+        _, _, g3 = _build_candidates(3)
+        assert g1["mean_revert"] == []          # k=1 pool byte-identical to before
+        assert len(g3["mean_revert"]) == 6      # k>1 adds the OU group
+
     def test_coordinate_option_positive_series(self):
         f = mean_revert(k=2, coordinate=0.5)        # sqrt coordinate for positive data
         state = None


### PR DESCRIPTION
PR #23's squash merged the first three commits (the `ou_transform` primitive, `mean_revert`, and its README doc) but **not** the four that finished the job. This lands them on top of current main (so #24's refresh is preserved):

- **JS twin** — `ouTransform` + `meanRevert` ported to `docs/js/skaters`, with parity scenarios (`ou`, `ou_sqrt` at k=1/k=3). Without this, main has `ou_transform`/`mean_revert` as **Python-only**, breaking the "identical in both runtimes to 1e-6" guarantee.
- **`laplace(k>1)` pool integration** — the OU mean-reversion group, gated on `k>1` (k=1 byte-identical; the multi-step pool gains the prior it was missing). Mirrored in JS; parity covers it via `pol_laplace_k3`.
- **Multi-step demo** — a weak-mean-reversion data regime, a horizon slider, a `mean_revert` policy, a k-step LL metric, and a forward **predictive fan** that visibly curves back toward the mean for `laplace(k>1)`/`mean_revert` while `doob`'s stays flat.

Cherry-picked cleanly onto main (no conflict with #24). **606 tests + JS parity green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)