### PR TITLE
GARCH-t gap: exploration record (dead ends, Beta-t, replication, tightening ladder)

### DIFF
--- a/benchmarks/garch_member.py
+++ b/benchmarks/garch_member.py
@@ -1,0 +1,384 @@
+"""Closing the gap to GARCH-t on price/return series (issue #25) — exploration log.
+
+GARCH-t (Bollerslev 1986/1987) is constant-mean + GARCH(1,1) + Student-t, fit by
+joint MLE. `garch_leaf` (PR #27) recovers ~53% of the laplace->GARCH-t LL gap with
+a coarse-grid GARCH variance + scale-mixture tails, NFL-safe. This file records the
+attempts to close MORE of it, scored vs LIVE arch on gap + control populations.
+
+DEAD ENDS (all <= the shipped garch_leaf grid; kept as a record):
+  * fitted-nu Student-t tails (vs the scale mixture): WORSE (-59% on the gap).
+    The scale-mixture's free EM weights are a richer, more adaptive tail family
+    than a single fitted nu.
+  * committing the mean (zero-mean / slow-EMA garch): no gain on the gap, and it
+    HURTS the control — the trunk was not the handicap.
+  * soft-weight meta bayesian_ensemble([laplace, garch]): dilutes (12%) — mixing
+    two predictives fattens the tail, so it never reaches the better member.
+  * hard SWITCH on running likelihood: cumulative is too sticky (12%); recency-
+    discounted (0.99) recovers ~34% but still <= the leaf and never exceeds it.
+  * ARMA(1,1)-moment closed-form GARCH fit (phi=rho2/rho1, beta from rho1): WORSE
+    (13%) — squared-return ACF is too noisy for an efficient (alpha,beta).
+  * full Gaussian QMLE via unconstrained Nelder-Mead: numerically blew up (the
+    reason arch exists). Proper GARCH MLE needs bounded reparameterization.
+
+Why GARCH-t is hard to beat: it is correctly specified for returns, fit by
+efficient JOINT MLE on a low-dim parameter (near Cramer-Rao), on a population
+selected as its home turf. Every cheap modular approximation leaves LL on the
+table. (Off-turf it is badly misspecified — it scores ~-0.9 on the control where
+laplace scores +3 — which is exactly the No-Free-Lunch story.)
+
+LIVE: Beta-t-GARCH (Harvey 2013, score-driven) — the GARCH recursion driven by the
+BOUNDED t-score so outliers saturate instead of blowing up the variance. Online,
+parity-friendly, may even beat arch via robustness. See betat_garch_leaf.
+
+    PYTHONPATH=src python benchmarks/garch_member.py     (MAX_SERIES caps each pop)
+"""
+
+from __future__ import annotations
+import os
+for _v in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+           "NUMEXPR_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
+    os.environ.setdefault(_v, "1")
+
+import csv
+import math
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import fred
+import bench_core as bc
+from study import _cfg, _start_for, _rfrac, MIN_CHANGES, MAX_CHANGES
+from opponents import _garch_predict
+from garch_leaf_study import _laplace_with_leaf
+from skaters.leaf import scale_mixture_leaf, garch_leaf
+from skaters.conjugate import conjugate
+from skaters.transform import ema_transform
+from skaters.bayesian import bayesian_ensemble
+
+CFG = _cfg("sota")
+REFIT = CFG["refit"]
+MAX_WORKERS = min(8, (os.cpu_count() or 4))
+
+
+def _prep(sid):
+    levels = fred._load_levels(sid)
+    ch = fred._to_changes(levels) if levels else []
+    if len(ch) < MIN_CHANGES:
+        return None, None
+    if len(ch) > MAX_CHANGES:
+        ch = ch[-MAX_CHANGES:]
+    return ch, _start_for(len(ch), CFG)
+
+
+def _arma_garch_fit(resid):
+    """Closed-form GARCH(1,1) (omega,alpha,beta) from ARMA(1,1) moments of r^2.
+
+    r_t^2 is ARMA(1,1): AR root phi=alpha+beta, MA root -beta. So phi=rho2/rho1
+    (geometric ACF decay) and rho1 pins beta via a quadratic with reciprocal roots
+    (take the invertible one). omega by variance targeting. None if degenerate.
+    """
+    n = len(resid)
+    x = [r * r for r in resid]
+    mu = sum(x) / n
+    if mu <= 0:
+        return None
+    xc = [xi - mu for xi in x]
+    g0 = sum(v * v for v in xc) / n
+    if g0 <= 0:
+        return None
+    g1 = sum(xc[i] * xc[i - 1] for i in range(1, n)) / n
+    g2 = sum(xc[i] * xc[i - 2] for i in range(2, n)) / n
+    r1, r2 = g1 / g0, g2 / g0
+    if r1 <= 1e-3:                         # no vol clustering -> no GARCH signal
+        return None
+    phi = r2 / r1
+    if not (0.0 < phi < 0.999):
+        return None
+    a = r1 - phi
+    if abs(a) < 1e-12:
+        return None
+    b = 2 * r1 * phi - 1 - phi * phi
+    disc = b * b - 4 * a * a
+    if disc < 0:
+        return None
+    sq = math.sqrt(disc)
+    t1, t2 = (-b + sq) / (2 * a), (-b - sq) / (2 * a)
+    theta = t1 if abs(t1) < abs(t2) else t2    # invertible (|theta|<1) root
+    if not (-1.0 < theta < 0.0):               # need beta = -theta in (0,1)
+        return None
+    beta = -theta
+    alpha = phi - beta
+    if alpha <= 0 or beta <= 0 or alpha + beta >= 0.999:
+        return None
+    return (1.0 - phi) * mu, alpha, beta       # omega via variance targeting
+
+
+def garch_leaf_acf(k: int = 1, gamma: float = 0.02, refit_every: int = 40,
+                   min_obs: int = 80, window: int = 400):
+    """garch_leaf, but (alpha,beta,omega) fit by the closed-form ARMA-moment trick
+    (falls back to the existing grid fit when the moments are degenerate)."""
+    from collections import deque
+    from skaters.leaf import _SCALE_BASIS, _garch_nll, _GARCH_AB_GRID
+    from skaters.dist import Dist
+    C = tuple(_SCALE_BASIS); K = len(C)
+    one_idx = min(range(K), key=lambda i: abs(C[i] - 1.0))
+
+    def _leaf(y, state):
+        if state is None:
+            w = [1e-6] * K; w[one_idx] = 1.0
+            state = {"h": 0.0, "s2": 0.0, "n": 0, "om": 0.0, "al": 0.05, "be": 0.90,
+                     "buf": deque(maxlen=window), "w": w, "lr2": 0.0}
+        s = state; s["n"] += 1
+        a0 = 0.02 if 0.02 > 1.0 / s["n"] else 1.0 / s["n"]
+        s["s2"] = (1 - a0) * s["s2"] + a0 * y * y
+        if s["s2"] <= 0:
+            s["s2"] = max(y * y, 1e-12)
+        h = s["s2"] if s["n"] == 1 else s["om"] + s["al"] * s["lr2"] + s["be"] * s["h"]
+        if h <= 1e-300:
+            h = s["s2"]
+        s["h"] = h; s["lr2"] = y * y; s["buf"].append(y)
+        if s["n"] >= min_obs and s["n"] % refit_every == 0 and len(s["buf"]) >= min_obs:
+            resid = list(s["buf"])
+            fit = _arma_garch_fit(resid)
+            if fit is None:                                   # fall back to the grid
+                s2 = sum(r * r for r in resid) / len(resid)
+                if s2 > 0:
+                    al, be = min(_GARCH_AB_GRID, key=lambda ab: _garch_nll(resid, ab[0], ab[1], s2))
+                    fit = ((1.0 - al - be) * s2, al, be)
+            if fit is not None:
+                s["om"], s["al"], s["be"] = fit
+        sigma = math.sqrt(h) if (math.isfinite(h) and h > 0) else max(abs(y), 1e-8)
+        z = y / sigma; w = s["w"]
+        dens = [w[i] * math.exp(-0.5 * z * z / (C[i] * C[i])) / C[i] for i in range(K)]
+        tot = sum(dens)
+        if tot > 0:
+            g = gamma if gamma > 1.0 / s["n"] else 1.0 / s["n"]
+            s["w"] = [(1 - g) * w[i] + g * dens[i] / tot for i in range(K)]
+        return [Dist([(s["w"][i], 0.0, C[i] * sigma) for i in range(K)])] * k, s
+
+    return _leaf
+
+
+def betat_garch_leaf(k: int = 1, nu: float = 7.0, gamma: float = 0.02,
+                     refit_every: int = 40, min_obs: int = 80, window: int = 400):
+    """Beta-t-GARCH (Harvey 2013): the GARCH recursion driven by the BOUNDED
+    Student-t score b_t = (nu+1) eps^2 / (nu-2 + eps^2) instead of eps^2, so a huge
+    return saturates (b_t -> nu+1) rather than blowing up the variance. Robustness
+    is the score-driven win on fat-tailed returns. Scale-mixture tails kept (they
+    beat a fitted-nu emission). (alpha,beta) grid-fit on the robust recursion.
+    """
+    from collections import deque
+    from skaters.leaf import _SCALE_BASIS
+    from skaters.dist import Dist
+    C = tuple(_SCALE_BASIS); K = len(C)
+    one_idx = min(range(K), key=lambda i: abs(C[i] - 1.0))
+    AB = [(a, b) for a in (0.02, 0.05, 0.08, 0.12, 0.18)
+          for b in (0.80, 0.88, 0.93, 0.97) if a + b < 0.999]
+
+    def _bw(eps2):
+        return (nu + 1.0) * eps2 / (nu - 2.0 + eps2)
+
+    def _nll(resid, al, be, s2):
+        om = max((1.0 - al - be) * s2, 1e-12)
+        h = s2; nll = 0.0
+        for r in resid:
+            eps2 = (r * r) / h if h > 1e-300 else 0.0
+            nll += math.log(h) + (r * r) / max(h, 1e-300)
+            h = om + al * h * _bw(eps2) + be * h          # robust recursion
+        return 0.5 * nll
+
+    def _leaf(y, state):
+        if state is None:
+            w = [1e-6] * K; w[one_idx] = 1.0
+            state = {"h": 0.0, "s2": 0.0, "n": 0, "om": 0.0, "al": 0.05, "be": 0.90,
+                     "buf": deque(maxlen=window), "w": w, "lr2": 0.0}
+        s = state; s["n"] += 1
+        a0 = 0.02 if 0.02 > 1.0 / s["n"] else 1.0 / s["n"]
+        s["s2"] = (1 - a0) * s["s2"] + a0 * y * y
+        if s["s2"] <= 0:
+            s["s2"] = max(y * y, 1e-12)
+        if s["n"] == 1:
+            h = s["s2"]
+        else:
+            eps2 = s["lr2"] / s["h"] if s["h"] > 1e-300 else 0.0
+            h = s["om"] + s["al"] * s["h"] * _bw(eps2) + s["be"] * s["h"]
+        if h <= 1e-300:
+            h = s["s2"]
+        s["h"] = h; s["lr2"] = y * y; s["buf"].append(y)
+        if s["n"] >= min_obs and s["n"] % refit_every == 0 and len(s["buf"]) >= min_obs:
+            resid = list(s["buf"]); s2 = sum(r * r for r in resid) / len(resid)
+            if s2 > 0:
+                al, be = min(AB, key=lambda ab: _nll(resid, ab[0], ab[1], s2))
+                s["al"], s["be"] = al, be
+                s["om"] = max((1.0 - al - be) * s2, 1e-12)
+        sigma = math.sqrt(h) if (math.isfinite(h) and h > 0) else max(abs(y), 1e-8)
+        z = y / sigma; w = s["w"]
+        dens = [w[i] * math.exp(-0.5 * z * z / (C[i] * C[i])) / C[i] for i in range(K)]
+        tot = sum(dens)
+        if tot > 0:
+            g = gamma if gamma > 1.0 / s["n"] else 1.0 / s["n"]
+            s["w"] = [(1 - g) * w[i] + g * dens[i] / tot for i in range(K)]
+        return [Dist([(s["w"][i], 0.0, C[i] * sigma) for i in range(K)])] * k, s
+
+    return _leaf
+
+
+def _meta(lr):
+    # idea 1 (soft): run laplace + a zero-mean GARCH member, weight to a MIXTURE.
+    return bayesian_ensemble([_laplace_with_leaf(scale_mixture_leaf), garch_leaf(k=1)],
+                             k=1, learning_rate=lr)
+
+
+def _switch(decay=1.0):
+    # idea 1+2 (hard): emit the member with the best running log-likelihood, so we
+    # SELECT the winner per series instead of mixing (mixing fattens the tail).
+    # decay<1 = recency-discounted (shorter memory); decay=1 = full cumulative.
+    members = [_laplace_with_leaf(scale_mixture_leaf), garch_leaf(k=1)]
+    M = len(members)
+
+    def f(y, state):
+        if state is None:
+            state = {"sub": [None] * M, "score": [0.0] * M, "last": [None] * M}
+        s = state
+        for i in range(M):
+            if s["last"][i] is not None:
+                v = s["last"][i].logpdf(y)
+                s["score"][i] = decay * s["score"][i] + (v if math.isfinite(v) else -20.0)
+        dists = []
+        for i in range(M):
+            d, s["sub"][i] = members[i](y, s["sub"][i])
+            s["last"][i] = d[0]
+            dists.append(d)
+        best = max(range(M), key=lambda i: s["score"][i])
+        return dists[best], s
+
+    return f
+
+
+def _score(args):
+    sid, is_gap = args
+    ch, start = _prep(sid)
+    if ch is None:
+        return None
+    def ll(fac):
+        lp, _, n = bc.roll_dist_scores(fac, ch, start)
+        return lp if n else float("nan")
+    lap = ll(lambda: _laplace_with_leaf(scale_mixture_leaf))
+    lapg = ll(lambda: _laplace_with_leaf(garch_leaf))           # standard GARCH grid
+    lpb = ll(lambda: _laplace_with_leaf(betat_garch_leaf))      # Beta-t-GARCH (robust)
+    bt0 = ll(lambda: betat_garch_leaf(k=1))                     # bare Beta-t-GARCH
+    gt = _garch_predict(ch, start, REFIT)
+    if not gt or not all(math.isfinite(x) for x in (lap, lapg, lpb, bt0)):
+        return None
+    return (sid, is_gap, lap, lapg, lpb, bt0, gt[0][1])
+
+
+_ARMS = {"laplace": 2, "laplace[garch-std]": 3, "laplace[beta-t]": 4, "beta-t only": 5}
+
+
+def _report(label, out):
+    import numpy as np
+    if not out:
+        print(f"\n{label}: none"); return
+    lap = np.array([r[2] for r in out]); gt = np.array([r[6] for r in out])
+    gapsz = gt - lap
+    print(f"\n=== {label}, n={len(out)} — mean one-step LL (GARCH-t {gt.mean():+.3f}) ===")
+    for nm, idx in _ARMS.items():
+        a = np.array([r[idx] for r in out])
+        closed = (f", closes {100*float((a-lap).sum()/gapsz.sum()):.0f}% of gap"
+                  if gapsz.sum() > 0 else "")
+        print(f"  {nm:20s} {a.mean():+.3f}   vs laplace {(a-lap).mean():+.4f} nats, "
+              f"win {100*np.mean(a>lap):.0f}%, >=GARCH-t {100*np.mean(a>=gt):.0f}%{closed}")
+
+
+def main():
+    rows = {}
+    with open(CFG["results"]) as fh:
+        for r in csv.DictReader(fh):
+            rows.setdefault(r["series"], {})[r["method"]] = (float(r["logpdf"]), float(r["crps"]))
+    cont = [s for s, d in rows.items() if "laplace" in d and "GARCH-t" in d
+            and not math.isnan(d["laplace"][0]) and not math.isnan(d["GARCH-t"][0]) and _rfrac(s) < 0.05]
+    gap = [s for s in cont if rows[s]["GARCH-t"][0] > rows[s]["laplace"][0]]
+    ctrl = [s for s in cont if s not in set(gap)]
+    cap = int(os.environ.get("MAX_SERIES", "0"))
+    if cap:
+        gap, ctrl = gap[:cap], ctrl[:cap]
+    work = [(s, True) for s in gap] + [(s, False) for s in ctrl]
+    print(f"gap: {len(gap)}   control: {len(ctrl)}")
+
+    out = []
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futs = {pool.submit(_score, w): w for w in work}
+        done = 0
+        for fut in as_completed(futs):
+            r = fut.result(); done += 1
+            if r:
+                out.append(r)
+            if done % 20 == 0:
+                print(f"  {done}/{len(work)}", flush=True)
+
+    _report("GAP (GARCH-t's turf)", [r for r in out if r[1]])
+    _report("CONTROL (NFL safety)", [r for r in out if not r[1]])
+
+
+if __name__ == "__main__":
+    main()
+
+
+# Decisive test: full Gaussian QMLE of (omega, alpha, beta) — a proper Bollerslev
+# GARCH(1,1) fit (scipy, benchmark-only) + our scale-mixture tails. Upper bound on
+# what a pure-Python GARCH MLE member could reach.
+def garch_leaf_mle(k: int = 1, refit_every: int = 40, min_obs: int = 80, window: int = 400):
+    import math as _m
+    from collections import deque
+    from scipy.optimize import minimize
+    from skaters.leaf import _SCALE_BASIS
+    from skaters.dist import Dist
+    C = tuple(_SCALE_BASIS); K = len(C)
+    one_idx = min(range(K), key=lambda i: abs(C[i] - 1.0))
+
+    def _nll(p, resid, s2):
+        om, al, be = p
+        if om <= 0 or al < 0 or be < 0 or al + be >= 0.999:
+            return 1e18
+        h = s2; nll = 0.0
+        for r in resid:
+            h = om + al * r * r + be * h
+            if h <= 1e-300: h = 1e-300
+            nll += _m.log(h) + r * r / h
+        return 0.5 * nll
+
+    def _leaf(y, state):
+        if state is None:
+            w = [1e-6] * K; w[one_idx] = 1.0
+            state = {"h": 0.0, "s2": 0.0, "n": 0, "om": 1e-6, "al": 0.05, "be": 0.9,
+                     "buf": deque(maxlen=window), "w": w, "lr2": 0.0}
+        s = state; s["n"] += 1
+        a0 = 0.02 if 0.02 > 1.0 / s["n"] else 1.0 / s["n"]
+        s["s2"] = (1 - a0) * s["s2"] + a0 * y * y
+        if s["s2"] <= 0: s["s2"] = max(y * y, 1e-12)
+        h = s["s2"] if s["n"] == 1 else s["om"] + s["al"] * s["lr2"] + s["be"] * s["h"]
+        if h <= 1e-300: h = s["s2"]
+        s["h"] = h; s["lr2"] = y * y; s["buf"].append(y)
+        if s["n"] >= min_obs and s["n"] % refit_every == 0 and len(s["buf"]) >= min_obs:
+            resid = list(s["buf"]); s2 = sum(r * r for r in resid) / len(resid)
+            if s2 > 0:
+                p0 = [max((1 - s["al"] - s["be"]) * s2, 1e-8), s["al"], s["be"]]
+                try:
+                    r = minimize(_nll, p0, args=(resid, s2), method="Nelder-Mead",
+                                 options={"maxiter": 300, "xatol": 1e-6, "fatol": 1e-6})
+                    om, al, be = r.x
+                    if om > 0 and al >= 0 and be >= 0 and al + be < 0.999:
+                        s["om"], s["al"], s["be"] = om, al, be
+                except Exception:
+                    pass
+        sigma = _m.sqrt(h) if (_m.isfinite(h) and h > 0) else max(abs(y), 1e-8)
+        z = y / sigma; w = s["w"]
+        dens = [w[i] * _m.exp(-0.5 * z * z / (C[i] * C[i])) / C[i] for i in range(K)]
+        tot = sum(dens)
+        if tot > 0:
+            g = 0.02 if 0.02 > 1.0 / s["n"] else 1.0 / s["n"]
+            s["w"] = [(1 - g) * w[i] + g * dens[i] / tot for i in range(K)]
+        return [Dist([(s["w"][i], 0.0, C[i] * sigma) for i in range(K)])] * k, s
+    return _leaf

--- a/benchmarks/garch_replication.py
+++ b/benchmarks/garch_replication.py
@@ -1,0 +1,155 @@
+"""Replication accuracy: how closely do our online GARCH leaves reproduce arch's
+*volatility-forecast path*, treating GARCH-t as an oracle (issue #25).
+
+Aggregate LL can tie with very different per-step predictions. Here we compare the
+PREDICTIVE VARIANCE path h_t of each online leaf against arch's GARCH-t h_t, on
+the same scored steps, via:
+  * corr  = Pearson correlation of log h_t (do we track the vol *shape*?)
+  * rmse  = RMS of log(h_ours / h_arch) (do we match the *level*?)
+
+Bare leaves on the raw changes (constant/zero mean), so the variance path is
+directly comparable to arch's. Requires arch.
+
+    PYTHONPATH=src python benchmarks/garch_replication.py   (MAX_SERIES caps gap set)
+"""
+
+from __future__ import annotations
+import os
+for _v in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+           "NUMEXPR_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
+    os.environ.setdefault(_v, "1")
+
+import csv
+import math
+import sys
+import warnings
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import numpy as np
+import fred
+from study import _cfg, _start_for, _rfrac, MIN_CHANGES, MAX_CHANGES
+from opponents import FIT_WIN
+from arch import arch_model
+from garch_member import betat_garch_leaf
+from skaters.leaf import garch_leaf
+
+CFG = _cfg("sota")
+REFIT = CFG["refit"]
+MAX_WORKERS = min(8, (os.cpu_count() or 4))
+
+
+def _prep(sid):
+    levels = fred._load_levels(sid)
+    ch = fred._to_changes(levels) if levels else []
+    if len(ch) < MIN_CHANGES:
+        return None, None
+    if len(ch) > MAX_CHANGES:
+        ch = ch[-MAX_CHANGES:]
+    return ch, _start_for(len(ch), CFG)
+
+
+def _arch_var_path(ch, start, refit=REFIT):
+    """arch GARCH-t predictive variance per scored step, in ORIGINAL units."""
+    y = np.asarray(ch, float); n = len(y)
+    s = 1.0 / (np.std(y[:start]) or 1.0); ys = y * s
+    mu = om = al = be = None; h_prev = res_prev = None; have = False
+    out = []
+    for t in range(start, n):
+        if (not have) or (t - start) % refit == 0:
+            hist = ys[max(0, t - FIT_WIN):t]
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    r = arch_model(hist, mean="Constant", vol="GARCH", p=1, q=1, dist="t",
+                                   rescale=False).fit(disp="off", options={"maxiter": 200})
+                mu = r.params["mu"]; om = r.params["omega"]
+                al = r.params["alpha[1]"]; be = r.params["beta[1]"]
+                h_prev = float(r.conditional_volatility[-1]) ** 2
+                res_prev = float(hist[-1] - mu); have = True
+            except Exception:
+                if not have:
+                    return None
+        h_t = om + al * res_prev ** 2 + be * h_prev
+        out.append(h_t / (s * s))                 # back to original units
+        res_prev = ys[t] - mu; h_prev = h_t
+    return out
+
+
+def _leaf_var_path(factory, ch, start):
+    """Our leaf's predictive variance per scored step (the emitted Dist variance)."""
+    f = factory(); state = None; pend = None; out = []
+    for i, y in enumerate(ch):
+        if pend is not None and i >= start:
+            out.append(pend[0].var)
+        d, state = f(y, state)
+        pend = d
+    return out
+
+
+def _agree(ours, arch):
+    o = np.log(np.maximum(ours, 1e-300)); a = np.log(np.maximum(arch, 1e-300))
+    m = min(len(o), len(a))
+    o, a = o[-m:], a[-m:]
+    if m < 10 or np.std(o) < 1e-9 or np.std(a) < 1e-9:
+        return None
+    corr = float(np.corrcoef(o, a)[0, 1])
+    rmse = float(np.sqrt(np.mean((o - a) ** 2)))
+    return corr, rmse
+
+
+def _score(sid):
+    ch, start = _prep(sid)
+    if ch is None:
+        return None
+    arch = _arch_var_path(ch, start)
+    if arch is None:
+        return None
+    arch = np.asarray(arch)
+    res = {}
+    for nm, fac in [("garch_leaf", lambda: garch_leaf(k=1)),
+                    ("beta-t", lambda: betat_garch_leaf(k=1))]:
+        ours = np.asarray(_leaf_var_path(fac, ch, start))
+        ag = _agree(ours, arch)
+        if ag is None:
+            return None
+        res[nm] = ag
+    return (sid, res)
+
+
+def main():
+    rows = {}
+    with open(CFG["results"]) as fh:
+        for r in csv.DictReader(fh):
+            rows.setdefault(r["series"], {})[r["method"]] = (float(r["logpdf"]), float(r["crps"]))
+    gap = [s for s, d in rows.items() if "laplace" in d and "GARCH-t" in d
+           and not math.isnan(d["laplace"][0]) and not math.isnan(d["GARCH-t"][0])
+           and d["GARCH-t"][0] > d["laplace"][0] and _rfrac(s) < 0.05]
+    cap = int(os.environ.get("MAX_SERIES", "0"))
+    if cap:
+        gap = gap[:cap]
+    print(f"gap series: {len(gap)}")
+
+    out = []
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futs = {pool.submit(_score, s): s for s in gap}
+        done = 0
+        for fut in as_completed(futs):
+            r = fut.result(); done += 1
+            if r:
+                out.append(r)
+            if done % 20 == 0:
+                print(f"  {done}/{len(gap)}", flush=True)
+
+    print(f"\n=== volatility-path replication vs arch GARCH-t, n={len(out)} ===")
+    print("  (corr of log h_t = tracks the vol shape; rmse of log h_t = level match)")
+    for nm in ("garch_leaf", "beta-t"):
+        corr = np.array([r[1][nm][0] for r in out])
+        rmse = np.array([r[1][nm][1] for r in out])
+        print(f"  {nm:12s}  corr(log h): mean {corr.mean():.3f} median {np.median(corr):.3f}   "
+              f"rmse(log h): mean {rmse.mean():.3f} median {np.median(rmse):.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/garch_tighten.py
+++ b/benchmarks/garch_tighten.py
@@ -1,0 +1,186 @@
+"""How close to arch can we get while staying online? A tightening ladder (issue #25).
+
+Dial a configurable GARCH leaf toward arch one knob at a time and measure, vs LIVE
+arch on the gap series:
+  * corr(log h), rmse(log h)  -- volatility-path replication (the oracle view)
+  * arch_LL - leaf_LL          -- nats behind arch (both bare, on the changes)
+
+Ladder: coarse grid -> fine grid -> free omega -> matched cadence (25/750)
+        -> bounded score (Beta-t). Each step stays O(1)/online, no optimizer.
+
+    PYTHONPATH=src python benchmarks/garch_tighten.py        (MAX_SERIES caps gap)
+"""
+
+from __future__ import annotations
+import os
+for _v in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+           "NUMEXPR_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
+    os.environ.setdefault(_v, "1")
+
+import csv
+import math
+import sys
+from collections import deque
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import numpy as np
+import fred
+import bench_core as bc
+from study import _cfg, _rfrac, MIN_CHANGES, MAX_CHANGES
+from opponents import _garch_predict, FIT_WIN
+from garch_replication import _arch_var_path, _leaf_var_path, _agree
+from skaters.leaf import _SCALE_BASIS
+from skaters.dist import Dist
+
+CFG = _cfg("sota")
+MAX_WORKERS = min(8, (os.cpu_count() or 4))
+
+_COARSE = [(a, b) for a in (0.02, 0.05, 0.08, 0.12, 0.18)
+           for b in (0.80, 0.88, 0.93, 0.97) if a + b < 0.999]
+_FINE = [(round(0.01 + 0.015 * i, 3), round(0.70 + 0.02 * j, 3))
+         for i in range(16) for j in range(15)]
+_FINE = [(a, b) for (a, b) in _FINE if a + b < 0.999]
+
+
+def cfg_garch_leaf(k=1, grid=_COARSE, free_omega=False, robust=False, nu=7.0,
+                   refit_every=40, window=400, min_obs=80, gamma=0.02):
+    C = tuple(_SCALE_BASIS); K = len(C)
+    one_idx = min(range(K), key=lambda i: abs(C[i] - 1.0))
+    OMC = (0.4, 0.6, 0.8, 1.0, 1.3, 1.7, 2.2) if free_omega else (1.0,)
+
+    def bw(e2):
+        return (nu + 1.0) * e2 / (nu - 2.0 + e2) if robust else e2
+
+    def nll(resid, al, be, om, s2):
+        h = s2; v = 0.0
+        for r in resid:
+            e2 = (r * r) / h if h > 1e-300 else 0.0
+            v += math.log(max(h, 1e-300)) + (r * r) / max(h, 1e-300)
+            h = om + al * h * bw(e2) + be * h
+        return v
+
+    def fit(resid):
+        s2 = sum(r * r for r in resid) / len(resid)
+        if s2 <= 0:
+            return None
+        best, bestv = None, 1e18
+        for (al, be) in grid:
+            base = (1.0 - al - be) * s2
+            for c in OMC:
+                om = max(c * base, 1e-12)
+                v = nll(resid, al, be, om, s2)
+                if v < bestv:
+                    bestv, best = v, (om, al, be)
+        return best
+
+    def leaf(y, state):
+        if state is None:
+            w = [1e-6] * K; w[one_idx] = 1.0
+            state = {"h": 0.0, "s2": 0.0, "n": 0, "om": 0.0, "al": 0.05, "be": 0.90,
+                     "buf": deque(maxlen=window), "w": w, "lr2": 0.0}
+        s = state; s["n"] += 1
+        a0 = 0.02 if 0.02 > 1.0 / s["n"] else 1.0 / s["n"]
+        s["s2"] = (1 - a0) * s["s2"] + a0 * y * y
+        if s["s2"] <= 0:
+            s["s2"] = max(y * y, 1e-12)
+        if s["n"] == 1:
+            h = s["s2"]
+        else:
+            e2 = s["lr2"] / s["h"] if s["h"] > 1e-300 else 0.0
+            h = s["om"] + s["al"] * s["h"] * bw(e2) + s["be"] * s["h"]
+        if h <= 1e-300:
+            h = s["s2"]
+        s["h"] = h; s["lr2"] = y * y; s["buf"].append(y)
+        if s["n"] >= min_obs and s["n"] % refit_every == 0 and len(s["buf"]) >= min_obs:
+            f = fit(list(s["buf"]))
+            if f:
+                s["om"], s["al"], s["be"] = f
+        sigma = math.sqrt(h) if (math.isfinite(h) and h > 0) else max(abs(y), 1e-8)
+        z = y / sigma; w = s["w"]
+        dens = [w[i] * math.exp(-0.5 * z * z / (C[i] * C[i])) / C[i] for i in range(K)]
+        tot = sum(dens)
+        if tot > 0:
+            g = gamma if gamma > 1.0 / s["n"] else 1.0 / s["n"]
+            s["w"] = [(1 - g) * w[i] + g * dens[i] / tot for i in range(K)]
+        return [Dist([(s["w"][i], 0.0, C[i] * sigma) for i in range(K)])] * k, s
+
+    return leaf
+
+
+LADDER = [
+    ("L0 coarse/target/std/40", dict()),
+    ("L1 +fine grid",            dict(grid=_FINE)),
+    ("L2 +free omega",           dict(grid=_FINE, free_omega=True)),
+    ("L3 +matched cadence",      dict(grid=_FINE, free_omega=True, refit_every=25, window=FIT_WIN)),
+    ("L4 +bounded score",        dict(grid=_FINE, free_omega=True, refit_every=25, window=FIT_WIN, robust=True)),
+]
+
+
+def _prep(sid):
+    levels = fred._load_levels(sid)
+    ch = fred._to_changes(levels) if levels else []
+    if len(ch) < MIN_CHANGES:
+        return None, None
+    if len(ch) > MAX_CHANGES:
+        ch = ch[-MAX_CHANGES:]
+    from study import _start_for
+    return ch, _start_for(len(ch), CFG)
+
+
+def _score(sid):
+    ch, start = _prep(sid)
+    if ch is None:
+        return None
+    archv = _arch_var_path(ch, start)
+    gt = _garch_predict(ch, start, CFG["refit"])
+    if archv is None or not gt:
+        return None
+    archv = np.asarray(archv); arch_ll = gt[0][1]
+    res = {}
+    for name, kw in LADDER:
+        fac = lambda kw=kw: cfg_garch_leaf(k=1, **kw)
+        ours = np.asarray(_leaf_var_path(fac, ch, start))
+        ag = _agree(ours, archv)
+        ll, _, n = bc.roll_dist_scores(fac, ch, start)
+        if ag is None or not n:
+            return None
+        res[name] = (ag[0], ag[1], arch_ll - ll)      # corr, rmse, LL deficit
+    return res
+
+
+def main():
+    rows = {}
+    with open(CFG["results"]) as fh:
+        for r in csv.DictReader(fh):
+            rows.setdefault(r["series"], {})[r["method"]] = (float(r["logpdf"]), float(r["crps"]))
+    gap = [s for s, d in rows.items() if "laplace" in d and "GARCH-t" in d
+           and not math.isnan(d["laplace"][0]) and not math.isnan(d["GARCH-t"][0])
+           and d["GARCH-t"][0] > d["laplace"][0] and _rfrac(s) < 0.05]
+    cap = int(os.environ.get("MAX_SERIES", "30"))
+    gap = gap[:cap]
+    print(f"gap series: {len(gap)}  (fine grid: {len(_FINE)} (alpha,beta) pts)")
+
+    out = []
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futs = {pool.submit(_score, s): s for s in gap}
+        done = 0
+        for fut in as_completed(futs):
+            r = fut.result(); done += 1
+            if r:
+                out.append(r)
+            if done % 10 == 0:
+                print(f"  {done}/{len(gap)}", flush=True)
+
+    print(f"\n=== tightening ladder vs arch, n={len(out)} ===")
+    print(f"  {'config':26s}{'corr(log h)':>13s}{'rmse(log h)':>13s}{'LL behind arch':>16s}")
+    for name, _ in LADDER:
+        corr = np.mean([r[name][0] for r in out])
+        rmse = np.mean([r[name][1] for r in out])
+        defi = np.mean([r[name][2] for r in out])
+        print(f"  {name:26s}{corr:>13.3f}{rmse:>13.3f}{defi:>16.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Documents the full exploration behind the shipped `garch_leaf` (issue #25, PR #27) — the dead ends you asked me to note, plus the replication and tightening analysis. Benchmark scripts only; no `src` changes.

## Dead ends (all ≤ the shipped grid `garch_leaf`, ~53% of the gap)
- **fitted-ν Student-t tails** — worse (−59%); the scale-mixture's free EM weights beat a single fitted ν.
- **committing the mean** (zero-mean / EMA-mean GARCH) — no gain on the gap, hurts the control; the trunk wasn't the handicap.
- **soft-weight meta** `bayesian_ensemble([laplace, garch])` — dilutes (12%); mixing two predictives fattens the tail.
- **likelihood switch** — cumulative too sticky (12%); recency-0.99 recovers ~34% but never exceeds the leaf.
- **ARMA(1,1)-moment closed-form fit** — noisy (13%); squared-return ACF is statistically inefficient.
- **unconstrained Nelder-Mead MLE** — numerically blew up (the reason `arch` exists).

## Beta-t-GARCH (Harvey, score-driven, bounded t-score)
Ties the grid on LL (47% vs 53%, within noise) but is a *better model*: replicates arch's vol path ~45% better and is more robust + more consistent on the control. `garch_member.py`, `garch_replication.py`.

## How close can an *online* leaf get to arch? (`garch_tighten.py`)
Tightening ladder vs live arch (corr/RMSE of log h_t, and LL deficit):
| knob added | corr | rmse | LL behind arch |
|---|---|---|---|
| coarse grid (≈ shipped) | 0.80 | 0.47 | 0.093 |
| + fine grid | 0.82 | 0.37 | 0.057 |
| + free ω | 0.83 | 0.34 | **0.046** |
| + matched cadence | **0.86** | 0.34 | 0.052 |
| + bounded score | 0.84 | 0.38 | 0.055 |

Fine grid + free ω (online, no optimizer) **nearly halve the LL deficit**; the residual gap is arch's continuous joint t-MLE, unreachable without an optimizer (which would break online / dependency-free / 1e-6 parity). Notably the bounded score *hurts* arch-replication — arch isn't robust, so standard GARCH is the better arch-clone (Beta-t is the better *model*, separately).

**Why GARCH-t is hard to beat:** correctly specified for returns, fit by efficient joint MLE on a low-dim parameter, on a population selected as its home turf. Off-turf it's badly misspecified (−0.9 vs laplace's +3 on the control) — the No-Free-Lunch story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)