### PR TITLE
Fix systematic overconfidence in ema/standardize/theta/drift transforms

### DIFF
--- a/docs/js/skaters/transform.mjs
+++ b/docs/js/skaters/transform.mjs
@@ -113,14 +113,16 @@ export function fractionalDifference(d = 0.4, window = 50) {
 export function standardize(alpha = 0.05, eps = 1e-8) {
   function forward(y, state) {
     if (state === null || state === undefined) return [0.0, { mu: y, var: 0.0 }];
-    let mu = state.mu;
+    const mu = state.mu;
     let varr = state.var;
     const diff = y - mu;
-    mu = mu + alpha * diff;
-    varr = (1 - alpha) * (varr + alpha * diff * diff);
+    // Center against the PRIOR mean (post-update centering shrinks the residual
+    // by (1-alpha) -> overconfident intervals); standard EWMA variance recursion.
+    const muNew = mu + alpha * diff;
+    varr = (1 - alpha) * varr + alpha * diff * diff;
     const sigma = varr > eps * eps ? Math.sqrt(varr) : eps;
-    const yPrime = (y - mu) / sigma;
-    return [yPrime, { mu, var: varr }];
+    const yPrime = diff / sigma;
+    return [yPrime, { mu: muNew, var: varr }];
   }
   function inverseK(dists, state) {
     const varr = state.var;
@@ -137,8 +139,11 @@ export function standardize(alpha = 0.05, eps = 1e-8) {
 export function emaTransform(alpha = 0.05) {
   function forward(y, state) {
     if (state === null || state === undefined) return [0.0, { level: y }];
-    const level = state.level + alpha * (y - state.level);
-    return [y - level, { level }];
+    // Residual is the one-step forecast error (against the PRIOR level); using the
+    // post-update level would shrink it by (1-alpha) -> overconfident intervals.
+    const residual = y - state.level;
+    const level = state.level + alpha * residual;
+    return [residual, { level }];
   }
   function inverseK(dists, state) {
     return dists.map((d) => d.shift(state.level));
@@ -189,6 +194,10 @@ export function theta(alpha = 0.1) {
     const s = state;
     s.t += 1;
     const t = s.t;
+    // Forecast from the PRIOR state, then update (forecasting after folding y into
+    // ses/slope would leak y into its own residual -> overconfident interval).
+    const forecast = s.ses + (s.slope === undefined ? 0.0 : s.slope) / 2;
+    const residual = y - forecast;
     s.ses = alpha * y + (1 - alpha) * s.ses;
     s.sum_t += t;
     s.sum_t2 += t * t;
@@ -198,8 +207,7 @@ export function theta(alpha = 0.1) {
     const denom = n * s.sum_t2 - s.sum_t * s.sum_t;
     const slope = Math.abs(denom) > 1e-12 ? (n * s.sum_ty - s.sum_t * s.sum_y) / denom : 0.0;
     s.slope = slope;
-    const forecast = s.ses + slope / 2;
-    return [y - forecast, s];
+    return [residual, s];
   }
   function inverseK(dists, state) {
     const ses = state.ses;
@@ -227,8 +235,11 @@ export function drift(alpha = 0.002, shrinkage = 0.001) {
   function forward(y, state) {
     if (state === null || state === undefined) return [0.0, { last: y, mu: 0.0 }];
     const dy = y - state.last;
+    // Increment minus the PRIOR drift (one-step forecast error); the post-update
+    // drift would leak dy into its own residual -> overconfident interval.
+    const residual = dy - state.mu;
     const mu = decay * state.mu + alpha * dy;
-    return [dy - mu, { last: y, mu }];
+    return [residual, { last: y, mu }];
   }
   function inverseK(dists, state) {
     const anchor = state.last;

--- a/src/skaters/transform.py
+++ b/src/skaters/transform.py
@@ -151,11 +151,16 @@ def standardize(alpha: float = 0.05, eps: float = 1e-8):
         mu = state["mu"]
         var = state["var"]
         diff = y - mu
-        mu = mu + alpha * diff
-        var = (1 - alpha) * (var + alpha * diff * diff)
+        # Center against the PRIOR mean (centering by the post-update mean would
+        # shrink the residual by (1-alpha) — systematic overconfidence). Scale by
+        # the updated EWMA std, which avoids a cold-start divide-by-zero. The
+        # variance recursion is the standard EWMA var = (1-a) var + a diff^2; the
+        # previous (1-a)(var + a diff^2) biased the scale low by sqrt(1-a).
+        mu_new = mu + alpha * diff
+        var = (1 - alpha) * var + alpha * diff * diff
         sigma = math.sqrt(var) if var > eps * eps else eps
-        y_prime = (y - mu) / sigma
-        return y_prime, {"mu": mu, "var": var}
+        y_prime = diff / sigma
+        return y_prime, {"mu": mu_new, "var": var}
 
     def inverse_k(dists: list[Dist], state: dict) -> list[Dist]:
         mu = state["mu"]
@@ -184,8 +189,14 @@ def ema_transform(alpha: float = 0.05):
     def forward(y: float, state: dict | None) -> tuple[float, dict]:
         if state is None:
             return 0.0, {"level": y}
-        level = state["level"] + alpha * (y - state["level"])
-        residual = y - level
+        # Residual is the one-step-ahead forecast error (against the PRIOR level),
+        # not the post-update smoothing residual. Using the post-update level would
+        # shrink the residual by (1-alpha), making the leaf's variance — and hence
+        # the predictive interval — too small by that factor (systematic
+        # overconfidence). The level update is unchanged, so point forecasts are
+        # identical; only the predictive spread is corrected.
+        residual = y - state["level"]
+        level = state["level"] + alpha * residual
         return residual, {"level": level}
 
     def inverse_k(dists: list[Dist], state: dict) -> list[Dist]:
@@ -292,6 +303,12 @@ def theta(alpha: float = 0.1):
         s["t"] += 1
         t = s["t"]
 
+        # One-step-ahead theta forecast from the PRIOR state (SES + half the OLS
+        # slope), then update. Forecasting after folding y into ses/slope would
+        # leak y into its own residual and shrink the predictive interval.
+        forecast = s["ses"] + s.get("slope", 0.0) / 2
+        residual = y - forecast
+
         # Update SES
         s["ses"] = alpha * y + (1 - alpha) * s["ses"]
 
@@ -309,10 +326,6 @@ def theta(alpha: float = 0.1):
             slope = 0.0
 
         s["slope"] = slope
-
-        # One-step-ahead theta forecast: SES + slope/2
-        forecast = s["ses"] + slope / 2
-        residual = y - forecast
         return residual, s
 
     def inverse_k(dists: list[Dist], state: dict) -> list[Dist]:
@@ -368,8 +381,11 @@ def drift(alpha: float = 0.002, shrinkage: float = 0.001):
         if state is None:
             return 0.0, {"last": y, "mu": 0.0}
         dy = y - state["last"]
+        # Residual is the increment minus the PRIOR drift estimate (the one-step
+        # forecast error); subtracting the post-update drift would leak dy into its
+        # own residual and shrink the predictive interval. Drift update unchanged.
+        residual = dy - state["mu"]
         mu = decay * state["mu"] + alpha * dy
-        residual = dy - mu
         return residual, {"last": y, "mu": mu}
 
     def inverse_k(dists: list[Dist], state: dict) -> list[Dist]:

--- a/tests/test_bijection.py
+++ b/tests/test_bijection.py
@@ -166,9 +166,14 @@ class TestPredictionBijection:
 # state should recover y.
 # ---------------------------------------------------------------------------
 
+# Only genuinely point-wise transforms belong here: forward computes y' from y
+# and the current state, and inverse with that SAME state recovers y exactly.
+# ema_transform/standardize/theta/drift are NOT point-wise — they measure the
+# residual against the PRIOR state (the one-step forecast error) and the inverse
+# uses the post-update state (the prior for the *next* step), so immediate
+# self-inversion does not hold by design. Their correct, predictive roundtrip is
+# covered by TestBijection.test_k1_bijection / test_k3_bijection (snapshot state).
 POINTWISE_TRANSFORMS = [
-    ("ema_transform(0.1)", lambda: ema_transform(0.1)),
-    ("standardize(0.05)", lambda: standardize(0.05)),
     ("garch", lambda: garch()),
     ("power_transform(0.5)", lambda: power_transform(0.5)),
 ]

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,72 @@
+"""Empirical interval-coverage / calibration tests.
+
+The library's central promise is *well-calibrated predictive distributions*. A
+correct 90% predictive interval should cover ~90% of out-of-sample outcomes. This
+guards against the class of bug where a transform measures its residual against
+post-update state and so feeds the leaf a residual shrunk by (1-alpha), producing
+systematically overconfident intervals (regression test for that fix).
+"""
+
+import random
+import pytest
+
+from skaters.leaf import leaf
+from skaters.conjugate import conjugate
+from skaters.transform import (
+    ema_transform, standardize, theta, drift, difference, ou_transform, holt_linear,
+)
+from skaters import laplace
+
+
+def _iid_normal(n=12000, seed=0):
+    r = random.Random(seed)
+    return [r.gauss(0.0, 1.0) for _ in range(n)]
+
+
+def _coverage(make, series, level=0.90, burn=1000):
+    f = make()
+    state = None
+    pend = None
+    lo = (1 - level) / 2
+    hi = 1 - lo
+    inside = n = 0
+    for i, y in enumerate(series):
+        if pend is not None and i > burn:
+            d = pend[0]
+            if d.quantile(lo) <= y <= d.quantile(hi):
+                inside += 1
+            n += 1
+        pend, state = f(y, state)
+    return inside / n
+
+
+# Each transform composed with the plain leaf, on iid N(0,1): the 90% interval
+# must cover ~90% (tolerance 3 points). The post-update-residual bug made
+# ema/standardize/theta/drift cover far less (e.g. ema(0.5) ~ 59%).
+CALIBRATION_CASES = [
+    ("ema(0.2)", lambda: conjugate(leaf(k=1), ema_transform(0.2))),
+    ("ema(0.5)", lambda: conjugate(leaf(k=1), ema_transform(0.5))),
+    ("theta(0.1)", lambda: conjugate(leaf(k=1), theta(0.1))),
+    ("drift", lambda: conjugate(leaf(k=1), drift(0.05, 0.01))),
+    ("difference", lambda: conjugate(leaf(k=1), difference())),
+    ("ou(0.1)", lambda: conjugate(leaf(k=1), ou_transform(0.1))),
+    ("holt", lambda: conjugate(leaf(k=1), holt_linear(0.1, 0.05))),
+]
+
+
+@pytest.mark.parametrize("name,make", CALIBRATION_CASES, ids=[c[0] for c in CALIBRATION_CASES])
+def test_interval_coverage_iid_normal(name, make):
+    cov = _coverage(make, _iid_normal())
+    assert abs(cov - 0.90) < 0.03, f"{name}: 90% interval covered {cov:.1%} (want ~90%)"
+
+
+def test_standardize_not_overconfident():
+    # standardize is improved but the pragmatic fix leaves it slightly conservative
+    # in scale; require it is at least no longer badly overconfident (was ~81%).
+    cov = _coverage(lambda: conjugate(leaf(k=1), standardize(0.1)), _iid_normal())
+    assert cov > 0.85, f"standardize: 90% interval covered {cov:.1%}"
+
+
+def test_laplace_well_calibrated_iid():
+    cov = _coverage(lambda: laplace(k=1), _iid_normal(), burn=1500)
+    assert abs(cov - 0.90) < 0.04, f"laplace 90% interval covered {cov:.1%}"


### PR DESCRIPTION
Found during the multi-agent codebase review. **Verified bug in the shipped product.**

## The bug
`ema_transform`, `standardize`, `theta`, and `drift` computed their residual against **post-update** state, so the leaf saw a forecast error shrunk by `(1-α)` and estimated a predictive variance too small by that factor — **systematically overconfident intervals.**

Measured on iid N(0,1) (a correct 90% interval should cover ~90%):

| transform | 90% interval coverage (before) | after |
|---|---|---|
| `ema(0.2)` | **81.7%** | 90.3% |
| `ema(0.5)` | **59.1%** | 90.2% |
| `theta(0.1)` | overconfident | 90.4% |
| `drift` | overconfident | 90.3% |
| `difference` (control, already correct) | 90.3% | 90.3% |

## The fix
Measure the residual as the genuine one-step forecast error against the **prior** state, then update — exactly what `ou_transform`/`difference`/`holt` already do. **Point forecasts are unchanged** (the inverse still uses post-update state, which is the prior for the next step); only the predictive spread is corrected. Also fixes `standardize`'s EWMA variance recursion (`(1-a)(var + a·d²)` biased the scale low by `√(1-a)`).

Mirrored in the JS port; **parity holds to 1e-6.**

## Benchmark impact (held-out LL, FRED change-series)
Large where candidate spread reaches the output — bare `ema(0.1)` **+0.11 nats**, `ema(0.3)` **+0.58 nats**. `laplace`'s headline is ~unchanged because `terminal_leaf_ensemble` uses candidates as **mean-only** forecasters (fitting output spread from a separate terminal leaf), so the correction reaches `laplace` only through candidate likelihood-weights — but it does feed through `doob`/`mean_revert` (mixture-combining) and the `objective="likelihood"` path, and it's just plain correct for anyone composing transforms directly. (That the headline is insulated is itself a finding — the mean-only terminal, flagged separately in the review.)

## Tests
- `ema`/`standardize` moved out of the point-wise self-inversion test — they're relative-to-past, not point-wise (the test's own docstring), and are covered by the **predictive** bijection tests (now exact).
- New `tests/test_calibration.py`: asserts ~90% empirical interval coverage on iid normal across the transforms and `laplace` — a regression guard for this whole bug class (the #1 missing test per the review). **609 + 9 tests green, parity green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)