### PR TITLE
Add CI: gate tests + JS parity on push/PR and before PyPI publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: ci
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up Node (for Python<->JS parity)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install test deps
+        run: pip install pytest
+      - name: Run tests (incl. JS parity — node is present so it must not skip)
+        env:
+          PYTHONPATH: src
+        run: python -m pytest -q
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build and check the distribution
+        run: |
+          pip install build twine uv_build
+          python -m build
+          twine check dist/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - name: Install test deps
+      run: pip install pytest
+    - name: Run tests + JS parity before publishing
+      env:
+        PYTHONPATH: src
+      run: python -m pytest -q
+
   deploy:
+    needs: test
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
From the multi-agent review (verified): the repo had **no CI gating tests or the Python↔JS parity harness** — only `deploy.yml` (release → `twine upload`) and `pages.yml`. So a broken build or a runtime divergence could be published to PyPI unnoticed, and the parity test (the project's central correctness claim) only ran if a developer remembered to locally — and silently skipped when Node was absent.

## Changes
- **`ci.yml`** (push & PR): `pytest` on a 3.10–3.13 matrix, plus a build + `twine check` job. **Node 20 is installed so the parity test actually runs** (it self-skips without Node — the silent hole this closes).
- **`deploy.yml`**: a `test` job (pytest + parity, Node present) that the publish step now `needs:`. A release can no longer upload to PyPI unless tests and parity pass.

Verified `PYTHONPATH=src python -m pytest -q` is green (610 passed) on the current tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)