### PR TITLE
Fix reproducibility pointer + overstated claims (CRPS, forecaster count)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skaters
 
-**One univariate time-series model to rule them all?** — Nah I think we need two, and they are both here. Their names are *Laplace* and *Doob* and you can watch them [here](https://skaters.microprediction.org/demos/playground.html). Only use the latter if your martingality prior is very strong. 
+**One univariate time-series model to rule them all?** — Nah. There's a general forecaster, *Laplace*, and two committed specialists, *Doob* (martingale) and *Mean-Revert*, and you can watch them [here](https://skaters.microprediction.org/demos/playground.html). Reach for a specialist only when its prior is strong; otherwise *Laplace*. 
 
 
 <p align="center">
@@ -13,7 +13,7 @@
 </p>
 
 
-Fast, dependency-free, **online** univariate *distributional* forecasting in **Python _and_ JavaScript** (identical to 1e-6, browser-ready via [Pyodide](https://skaters.microprediction.org/demos/pyodide.html)). Across thousands of economic series *Laplace* beats the heavier, slower competition — AutoARIMA, AutoETS, GARCH-t, conformal, even zero-shot foundation models — on held-out **log-likelihood**, and ties on CRPS, conformal's home turf and a goal-post that won't grow your wealth. ([Why likelihood is the metric that matters.](https://mechanisms.microprediction.org))
+Fast, dependency-free, **online** univariate *distributional* forecasting in **Python _and_ JavaScript** (identical to 1e-6, browser-ready via [Pyodide](https://skaters.microprediction.org/demos/pyodide.html)). Across thousands of economic series *Laplace* beats the heavier, slower competition — AutoARIMA, AutoETS, GARCH-t, conformal, even zero-shot foundation models — on held-out **log-likelihood**. On CRPS it is competitive but not dominant: it beats the mean-model baselines (ARIMA/ETS) and trades blows with the methods explicitly optimised for that metric (conformal, GARCH-t) — CRPS being conformal's home turf and a goal-post that won't grow your wealth. ([Why likelihood is the metric that matters.](https://mechanisms.microprediction.org))
 
 ## Install
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,21 +106,23 @@ for y in observations:
       facets of the same object.
     </p>
 
-    <h2>The two forecasters</h2>
+    <h2>The named forecasters</h2>
     <p>
-      <code>skaters</code> exposes exactly two named forecasters; everything else is a building
-      block you can compose. ("skater" is the <em>concept</em> — any
+      <code>skaters</code> exposes a general forecaster plus two committed specialists;
+      everything else is a building block you can compose. ("skater" is the <em>concept</em> — any
       <code>(y, state) → ([Dist], state)</code> function — not a function name.)
     </p>
-<pre><code>from skaters import laplace, doob
+<pre><code>from skaters import laplace, doob, mean_revert
 
-f = laplace(k=1)   # general purpose — the default
-f = doob(k=1)      # committed martingale + volatility clock (feed levels)</code></pre>
+f = laplace(k=1)       # general purpose — the default
+f = doob(k=1)          # committed martingale + volatility clock (feed levels)
+f = mean_revert(k=10)  # committed mean reversion — multi-step (spreads, vol, rates)</code></pre>
     <table>
       <thead><tr><th>Forecaster</th><th>What it is</th><th>Best for</th></tr></thead>
       <tbody>
         <tr><td><code>laplace</code></td><td>Likelihood-weighted ensemble over the full candidate pool; <em>model first, conform last</em> + lattice projection on by default</td><td><strong>General purpose (default)</strong></td></tr>
         <tr><td><code>doob</code></td><td>Committed martingale + learned volatility clock (time-changed Brownian motion)</td><td>Near-martingale <strong>levels</strong> (prices, indices)</td></tr>
+        <tr><td><code>mean_revert</code></td><td>Committed Ornstein–Uhlenbeck reversion to a running mean; learns the speed</td><td>Multi-step <strong>mean reversion</strong> (spreads, vol, rates)</td></tr>
       </tbody>
     </table>
 

--- a/papers/skaters-jss.tex
+++ b/papers/skaters-jss.tex
@@ -535,11 +535,13 @@ distributions. The library is implemented twice --- pure \proglang{Python} and
 zero-dependency \proglang{JavaScript} --- and a parity suite checks roughly
 $90{,}000$ probe values to $10^{-6}$ on every run, so results are reproducible
 across both runtimes and in the browser via \pkg{Pyodide} \citep{pyodide2021}.
-The benchmark of Section~\ref{sec:experiments} is a single parallel script
-(\code{benchmarks/sota\_study.py}) that scores every method through the identical
-\code{Dist} interface; given a \proglang{FRED} key and the optional baselines
-(\pkg{statsforecast}, \pkg{arch}, \pkg{statsmodels}, \pkg{neuralforecast}) it
-reproduces Table~\ref{tab:sota} end to end.
+The benchmark of Section~\ref{sec:experiments} is a single parallel harness
+(\code{benchmarks/study.py}, invoked as \code{study.py sota}) that scores every
+method through the identical \code{Dist} interface; given a \proglang{FRED} key
+and the optional baselines (\pkg{statsforecast}, \pkg{arch}, \pkg{statsmodels},
+\pkg{neuralforecast}) it reproduces Table~\ref{tab:sota} end to end, and
+\code{study.py sota summarize} regenerates the reported win-rates from the
+committed result file.
 
 %% -------------------------------------------------------------------------
 \bibliographystyle{plainnat}


### PR DESCRIPTION
Verified-safe honesty/reproducibility fixes from the multi-agent review (the larger Table 1 reconciliation is a separate follow-up — see note).

## Fixes
1. **Dead reproduction script (paper §Heritage).** The paper pointed at `benchmarks/sota_study.py`, which **doesn't exist** — the harness was unified into `study.py` in #22. §Experiments already said `study.py sota`; §Heritage contradicted it. Now points at `study.py sota` / `study.py sota summarize` (the latter regenerates win-rates from the committed result file). *Verified `study.py sota summarize` exists and runs.*
2. **"ties on CRPS" (README) overstated it.** The paper's own table shows `laplace` *loses* CRPS to the CRPS-specialists (conformal, GARCH-t) and *wins* vs the mean-model baselines. Reworded to that accurate version.
3. **"two named forecasters" contradiction.** README ("we need two") and `docs/index.html` ("exactly two named forecasters") contradicted the shipped API and the demo, which expose **three** (`laplace`, `doob`, `mean_revert`). Updated to "a general forecaster plus two specialists," with `mean_revert` added to the site's forecaster table.

Paper recompiles cleanly.

## Follow-up (intentionally not bundled)
I reproduced the benchmark agent's finding: the paper's **Table 1 (389 continuous; GARCH-t 51%/33%) does not match the committed `results_sota.csv`**, which `study.py sota summarize` reads as **309 continuous, GARCH-t 67%/66%** (laplace actually *wins* GARCH-t there). Reconciling Table 1 to the committed artifact — done properly with **family-clustered win-rates** to address pseudo-replication (309 series ≈ ~100 FRED families) — is a substantive, statistically-careful revision and gets its own PR rather than a number-swap here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)