### PR TITLE
Comprehensive horse-race harness + the full-universe finding (price/non-price split)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,7 @@ benchmarks/results_finetune_*.csv
 # foundation fine-tune artifacts
 checkpoints/
 lightning_logs/
+
+# overnight horse race outputs
+benchmarks/results_overnight.csv
+benchmarks/overnight_horserace.log

--- a/benchmarks/horserace_summary.py
+++ b/benchmarks/horserace_summary.py
@@ -1,0 +1,86 @@
+"""Summarize the overnight horse race with the honest breakdown.
+
+Reads benchmarks/results_overnight.csv and reports, for laplace vs each baseline:
+  * raw and family-clustered win-rates (LL and CRPS) on the continuous subset
+  * the price-vs-non-price split for GARCH-t (the No-Free-Lunch story:
+    laplace wins non-price, GARCH-t wins price/returns)
+  * mean continuous log-likelihood per method
+
+    PYTHONPATH=src python benchmarks/horserace_summary.py
+"""
+from __future__ import annotations
+import os, sys, csv, math
+from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np
+from study import _cfg, _rfrac
+from fred_universe import family
+
+RESULTS = os.environ.get("STUDY_RESULTS", "benchmarks/results_overnight.csv")
+# price-like FRED prefixes (equity / fx / commodity / crypto / rate-level proxies)
+PRICE = ("DEX", "DCOIL", "DHOIL", "DDFUEL", "DHHNG", "CB", "NASDAQ", "SP", "DJIA",
+         "VIX", "RVX", "EVZ", "GVZ", "OVX", "WILL", "GOLD", "DTWEX", "BAML",
+         "DGS", "DPRIME", "DAAA", "DBAA", "DTB", "DCP", "T10", "T5", "DSWP")
+isprice = lambda s: any(s.startswith(p) for p in PRICE)
+
+
+def winrate(rows, series, method, idx, lower):
+    """laplace vs `method` on metric idx over `series`: (raw%, family%, n)."""
+    per, byfam = [], defaultdict(list)
+    for s in series:
+        if method not in rows[s] or "laplace" not in rows[s]:
+            continue
+        lv, mv = rows[s]["laplace"][idx], rows[s][method][idx]
+        if math.isnan(lv) or math.isnan(mv):
+            continue
+        win = 1.0 if ((lv < mv) if lower else (lv > mv)) else 0.0
+        per.append(win); byfam[family(s)].append(win)
+    if not per:
+        return float("nan"), float("nan"), 0
+    raw = 100 * np.mean(per)
+    fam = 100 * np.mean([np.mean(v) for v in byfam.values()])
+    return raw, fam, len(per)
+
+
+def main():
+    rows = {}
+    with open(RESULTS) as fh:
+        for r in csv.DictReader(fh):
+            lp = float(r["logpdf"]) if r["logpdf"] not in ("", "nan") else float("nan")
+            rows.setdefault(r["series"], {})[r["method"]] = (lp, float(r["crps"]))
+    cont = [s for s in rows if "laplace" in rows[s] and _rfrac(s) < 0.05]
+    fams = {family(s) for s in cont}
+    print(f"results: {RESULTS}")
+    print(f"continuous series: {len(cont)}  ->  {len(fams)} families  "
+          f"(total series scored: {len(rows)})\n")
+
+    methods = sorted({m for s in cont for m in rows[s] if m != "laplace"})
+    print(f"laplace win-rate vs each baseline (continuous):")
+    print(f"  {'method':22s}{'LL raw/fam':>14s}{'CRPS raw/fam':>15s}{'meanLL':>9s}{'N':>7s}")
+    for m in methods:
+        lr, lf, n = winrate(rows, cont, m, 0, False)
+        cr, cf, _ = winrate(rows, cont, m, 1, True)
+        vals = [rows[s][m][0] for s in cont if m in rows[s] and not math.isnan(rows[s][m][0])]
+        has_ll = bool(vals)
+        ll = f"{lr:.0f}/{lf:.0f}%" if has_ll else "— (CDF)"
+        mll = f"{np.mean(vals):+.2f}" if has_ll else "—"
+        print(f"  {m:22s}{ll:>14s}{f'{cr:.0f}/{cf:.0f}%':>15s}{mll:>9s}{n:>7d}")
+    lapvals = [rows[s]["laplace"][0] for s in cont]
+    print(f"  {'laplace (mean LL)':22s}{'':>14s}{'':>15s}{np.mean(lapvals):+9.2f}{len(lapvals):>7d}")
+
+    if any("GARCH-t" in rows[s] for s in cont):
+        print("\nGARCH-t — the No-Free-Lunch split (laplace vs GARCH-t):")
+        price = [s for s in cont if isprice(s) and "GARCH-t" in rows[s]]
+        nonp = [s for s in cont if not isprice(s) and "GARCH-t" in rows[s]]
+        for label, sub in [("NON-PRICE (rates/macro)", nonp), ("PRICE/returns", price)]:
+            lr, lf, n = winrate(rows, sub, "GARCH-t", 0, False)
+            lap = np.mean([rows[s]["laplace"][0] for s in sub]) if sub else float("nan")
+            gt = np.mean([rows[s]["GARCH-t"][0] for s in sub]) if sub else float("nan")
+            nf = len({family(s) for s in sub})
+            print(f"  {label:24s} n={n:4d} ({nf} fam)  laplace LL-win raw {lr:.0f}% / family {lf:.0f}%"
+                  f"   mean LL  laplace {lap:+.2f} vs GARCH {gt:+.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/overnight_horserace.sh
+++ b/benchmarks/overnight_horserace.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Overnight comprehensive horse race: laplace (current main: ema-calibration fix +
+# forget=0.99) vs every baseline, across the FULL cached FRED universe.
+#
+# study.py's run() resumes from the CSV (skips already-scored series/method pairs)
+# and re-seeds per-opponent budgets, but a hard worker crash (arch/statsforecast
+# can segfault -> BrokenProcessPool) poisons the rest of a single run. So we wrap
+# it in a relaunch loop: each pass resumes where the CSV left off; we stop when a
+# pass adds no new rows (converged) or after MAX_PASSES.
+#
+#   bash benchmarks/overnight_horserace.sh
+set -u
+cd "$(dirname "$0")/.."
+
+export PYTHONPATH=src
+export STUDY_CACHED_ONLY=1                 # no network fetches — use the 2600 cached series
+export STUDY_MAX_QUALIFY=3000              # let the whole qualifying cache in
+export STUDY_N_CANDIDATES=3000
+export STUDY_RESULTS=benchmarks/results_overnight.csv   # fresh file — do NOT clobber committed CSV
+export STUDY_WORKERS=8
+# The slow refitting baselines are capped so they don't gate throughput; the
+# scientifically central race (laplace vs GARCH-t) runs wide across the cache.
+export BENCH_SF_MAX=600                    # AutoARIMA / AutoETS (statsforecast)
+export BENCH_SM_MAX=600                    # SARIMAX / ETS-sm (statsmodels)
+export BENCH_GARCH_MAX=3000               # GARCH-t goes wide — the key opponent
+export OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 NUMEXPR_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1
+
+LOG=benchmarks/overnight_horserace.log
+MAX_PASSES=40
+echo "=== overnight horse race started $(date) ===" >> "$LOG"
+
+rows_count() { [ -f "$STUDY_RESULTS" ] && wc -l < "$STUDY_RESULTS" | tr -d ' ' || echo 0; }
+
+for pass in $(seq 1 $MAX_PASSES); do
+  before=$(rows_count)
+  echo "--- pass $pass start $(date) (rows so far: $before) ---" >> "$LOG"
+  python benchmarks/study.py sota >> "$LOG" 2>&1
+  status=$?
+  after=$(rows_count)
+  echo "--- pass $pass end $(date) status=$status rows: $before -> $after ---" >> "$LOG"
+  # converged: a clean finish (status 0) that added no new rows
+  if [ "$status" -eq 0 ] && [ "$after" -le "$before" ]; then
+    echo "=== converged at pass $pass $(date) ===" >> "$LOG"
+    break
+  fi
+  sleep 5
+done
+
+echo "=== horse race done $(date); summary follows ===" >> "$LOG"
+python benchmarks/study.py sota summarize >> "$LOG" 2>&1 || true
+echo "=== run benchmarks/horserace_summary.py for the price/non-price + family split ===" >> "$LOG"


### PR DESCRIPTION
A resumable, crash-safe overnight harness that races `laplace` vs every baseline across the **full ~2,600-series cached FRED universe**, plus a summary with the honest breakdown.

## Harness
- `overnight_horserace.sh`: `study.py sota` across the whole cache, slow refitting baselines (AutoARIMA/SARIMAX) capped at 600 while `laplace`/`GARCH-t` race wide; relaunch loop resumes from the CSV (survives `arch` worker crashes); fresh `results_overnight.csv` (gitignored, committed CSV untouched).
- `horserace_summary.py`: raw + family-clustered win-rates and the price-vs-non-price GARCH-t split.

## First full run — 2,111 continuous series / 106 families
- **laplace dominates the ARIMA/ETS family**: 83–98% family-weighted LL wins.
- **GARCH-t split** (the No-Free-Lunch story):
  - non-price (602): laplace **80% raw**, mean LL **+2.81 vs +2.61**.
  - price/returns (1,509): GARCH-t wins (laplace 15% raw; mean LL tied +3.13 vs +3.14).
- **The aggregate laplace-vs-GARCH-t number is not robust** — the full cache is price-heavy (1,509 price vs 602 non-price, and price is heavily clustered: 39 families for 1,509 series), so a single number swings with universe composition. The price/non-price split is the only honest framing.
- Lattice projection is a big win at scale: `laplace-nostick` loses 83%.

**Implication for the paper:** Table 1's GARCH-t result should be reported as the price/non-price split, not a single aggregate. The paper's 500-popularity-ranked universe is more defensible than the full cache for the headline; this run is the robustness check that motivates the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)