### PR TITLE
Site: non-price framing + current numbers (from the multi-agent site audit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img src="docs/assets/frontier.png" alt="Accuracy vs. speed on 500 FRED series: laplace has both the highest held-out log-likelihood and the highest forecasts-per-second, alone in the top-right, while AutoARIMA, AutoETS, SARIMAX, GARCH-t, conformal, NeuralForecast and Prophet trade accuracy for far more compute." width="680">
+  <img src="docs/assets/frontier.png" alt="Accuracy vs. speed on 894 non-price FRED series: laplace has both the highest held-out log-likelihood and the highest forecasts-per-second, alone in the top-right, while AutoARIMA, AutoETS, SARIMAX, GARCH-t, conformal and NeuralForecast trade accuracy for far more compute." width="680">
 </p>
 
 

--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -192,7 +192,10 @@
       const pad = (ymax - ymin) * 0.08 + 1e-9;
       ymin -= pad; ymax += pad;
       const n = rows.length;
-      const X = (i) => PAD + (i / (n - 1)) * (W - 2 * PAD);
+      // Reserve room on the right for the K-step forecast fan so it never runs off
+      // the plot: map the index domain over [0, n-1+K] rather than [0, n-1].
+      const span = (n - 1) + (fan ? fan.length : 0);
+      const X = (i) => PAD + (i / span) * (W - 2 * PAD);
       const Y = (v) => H - PAD - ((v - ymin) / (ymax - ymin)) * (H - 2 * PAD);
 
       // axes

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,9 +32,11 @@
       time-series prediction.</p>
 
     <p class="lead">One call, zero dependencies, every prediction a full probability
-      <em>distribution</em> computed online in O(1) — in pure Python and JavaScript alike. On
-      held-out likelihood <code>laplace</code> beats AutoARIMA, AutoETS, GARCH-t, conformal, and
-      even zero-shot foundation models like Chronos and TimesFM — all of them heavier and slower.</p>
+      <em>distribution</em> computed online in O(1) — in pure Python and JavaScript alike. A
+      general-purpose forecaster for <strong>non-price economic series</strong>: on held-out
+      likelihood <code>laplace</code> beats AutoARIMA, AutoETS, SARIMAX, conformal, zero-shot
+      foundation models like Chronos and TimesFM, <em>and</em> GARCH-t — all heavier and slower.
+      (No free lunch on price/returns: there GARCH-t wins, and you should use it.)</p>
 
     <div class="tag-row">
       <span class="tag">distributional</span>
@@ -47,8 +49,8 @@
     <figure class="hero-figure">
       <img src="./assets/frontier.svg" alt="Accuracy vs speed frontier: laplace dominates the
         baselines, with higher held-out likelihood at a fraction of the runtime." />
-      <figcaption>Held-out accuracy vs. runtime on 500 FRED series. <code>laplace</code> sits alone
-        in the top-left — best likelihood, lowest cost — while the classical, neural, and
+      <figcaption>Held-out accuracy vs. runtime on 894 non-price FRED series. <code>laplace</code>
+        sits alone in the top-right — best likelihood, fastest — while the classical, neural, and
         foundation-model baselines trade accuracy for orders of magnitude more compute.
         <a href="/papers.html">The benchmarks →</a></figcaption>
     </figure>
@@ -62,13 +64,14 @@
     </div>
 
     <div class="callout">
-      <strong>It wins the likelihood race against eight distributional baselines.</strong> On 500
-      FRED series (rolling one-step-ahead, per series), <code>laplace</code> beats
-      <strong>AutoARIMA</strong>, <strong>AutoETS</strong>, statsmodels <strong>SARIMAX/ETS</strong>,
-      <strong>GARCH-t</strong>, <strong>NeuralForecast-StudentT</strong>, and AutoARIMA-with-<em>conformal</em>
-      on held-out <strong>log-likelihood</strong> — the decision-relevant metric — including on the
-      continuous series. The real test is <strong>GARCH-t</strong>, the heavy-tail SOTA: laplace
-      still edges it (mean continuous logpdf 2.86 vs 2.72).
+      <strong>It wins the likelihood race against every baseline on non-price series.</strong> On
+      894 continuous non-price FRED series (rolling one-step-ahead, per series), <code>laplace</code>
+      has the highest mean held-out <strong>log-likelihood</strong> (3.20) and the best win-rate
+      against <strong>AutoARIMA</strong> (82%), <strong>AutoETS</strong> (97%), statsmodels
+      <strong>SARIMAX</strong> (87%), <em>conformal</em>, and — the real test — the heavy-tail SOTA
+      <strong>GARCH-t</strong> (68% raw / 65% family-weighted; mean LL 3.20 vs 3.03). On CRPS it
+      loses only to the CRPS-specialists (conformal, GARCH-t). <strong>No free lunch on
+      price/returns</strong> — there GARCH-t wins, and we recommend it.
       <a href="/papers.html">The benchmarks →</a>
     </div>
 
@@ -121,7 +124,7 @@ f = mean_revert(k=10)  # committed mean reversion — multi-step (spreads, vol, 
       <thead><tr><th>Forecaster</th><th>What it is</th><th>Best for</th></tr></thead>
       <tbody>
         <tr><td><code>laplace</code></td><td>Likelihood-weighted ensemble over the full candidate pool; <em>model first, conform last</em> + lattice projection on by default</td><td><strong>General purpose (default)</strong></td></tr>
-        <tr><td><code>doob</code></td><td>Committed martingale + learned volatility clock (time-changed Brownian motion)</td><td>Near-martingale <strong>levels</strong> (prices, indices)</td></tr>
+        <tr><td><code>doob</code></td><td>Committed martingale + learned volatility clock (time-changed Brownian motion)</td><td>Series where the <strong>martingale prior holds</strong> (random-walk levels). Not a price-volatility specialist — use GARCH-t for returns.</td></tr>
         <tr><td><code>mean_revert</code></td><td>Committed Ornstein–Uhlenbeck reversion to a running mean; learns the speed</td><td>Multi-step <strong>mean reversion</strong> (spreads, vol, rates)</td></tr>
       </tbody>
     </table>

--- a/docs/papers.html
+++ b/docs/papers.html
@@ -49,30 +49,37 @@
       <a href="https://github.com/microprediction/skaters/blob/main/papers/skaters.md">Markdown draft</a>
     </p>
 
-    <h2>Benchmark 1 — eight distributional baselines</h2>
+    <h2>Benchmark 1 — the non-price universe</h2>
     <p>
-      A fair rolling one-step-ahead comparison on 500 FRED change-series (309 continuous). Every
-      method — ours and theirs — is turned into the same <code>Dist</code> and scored on held-out
-      log-likelihood <em>and</em> CRPS. Per-series win-rate of <code>laplace</code> (all / continuous):
+      A fair rolling one-step-ahead comparison on the <strong>non-price</strong> FRED universe —
+      894 continuous daily change-series (57 correlated families); equity/fx/commodity returns are
+      excluded and treated separately in the price caveat below. Every method — ours and theirs — is
+      turned into the same <code>Dist</code> and scored on held-out log-likelihood <em>and</em> CRPS.
+      Per-series win-rate of <code>laplace</code>, reported <em>raw</em> and <em>family-weighted</em>
+      (one vote per correlated family):
     </p>
     <table>
-      <thead><tr><th>Baseline</th><th>LL (all / cont)</th><th>CRPS (all / cont)</th><th>mean LL (cont)</th></tr></thead>
+      <thead><tr><th>Baseline</th><th>LL (raw / fam)</th><th>CRPS (raw / fam)</th><th>mean LL</th></tr></thead>
       <tbody>
-        <tr><td>AutoARIMA</td><td>78 / 64%</td><td>51 / 47%</td><td>2.09</td></tr>
-        <tr><td>AutoETS</td><td>92 / 88%</td><td>68 / 67%</td><td>2.20</td></tr>
-        <tr><td>SARIMAX (statsmodels)</td><td>82 / 72%</td><td>53 / 49%</td><td>2.13</td></tr>
-        <tr><td>ETS (statsmodels)</td><td>93 / 89%</td><td>69 / 68%</td><td>2.12</td></tr>
-        <tr><td>GARCH(1,1)-t (<code>arch</code>)</td><td>79 / 67%</td><td>76 / 66%</td><td>2.72</td></tr>
+        <tr><td>AutoARIMA</td><td>82 / 90%</td><td>53 / 65%</td><td>2.80</td></tr>
+        <tr><td>AutoETS</td><td>97 / 99%</td><td>83 / 92%</td><td>2.79</td></tr>
+        <tr><td>SARIMAX (statsmodels)</td><td>87 / 86%</td><td>53 / 64%</td><td>2.92</td></tr>
+        <tr><td>ETS (statsmodels)</td><td>96 / 98%</td><td>81 / 90%</td><td>2.89</td></tr>
+        <tr><td>GARCH(1,1)-t (<code>arch</code>)</td><td>68 / 65%</td><td>54 / 45%</td><td>3.03</td></tr>
+        <tr><td>AutoARIMA + conformal</td><td>86 / 88%</td><td>31 / 31%</td><td>2.27</td></tr>
+        <tr><td>AutoARIMA + ACI</td><td>88 / 88%</td><td>29 / 29%</td><td>2.51</td></tr>
+        <tr><td>naive conformal</td><td>— (CDF)</td><td>92 / 93%</td><td>—</td></tr>
         <tr><td>NF-StudentT (NeuralForecast)</td><td>100 / 100%</td><td>78 / 76%</td><td>0.82</td></tr>
-        <tr><td>AutoARIMA + conformal</td><td>84 / 75%</td><td>37 / 29%</td><td>1.47</td></tr>
-        <tr><td>AutoARIMA + ACI</td><td>87 / 80%</td><td>36 / 28%</td><td>1.89</td></tr>
       </tbody>
     </table>
     <p>
-      <code>laplace</code> (mean continuous logpdf <strong>2.855</strong>) wins the likelihood race
-      against all eight. The real test is <strong>GARCH-t</strong>, the heavy-tail SOTA: it still
-      edges it (2.86 vs 2.72). On CRPS it beats the smoothing/GARCH/neural baselines, ties the ARIMA
-      family, and loses to the CRPS-optimised conformal variants.
+      <code>laplace</code> (mean log-likelihood <strong>3.20</strong>) wins the likelihood race
+      against every baseline on non-price series — including <strong>GARCH-t</strong>, the heavy-tail
+      SOTA (68% raw / 65% family-weighted; mean LL 3.20 vs 3.03). On CRPS it beats the mean-model
+      baselines and loses only to the CRPS-specialists (fitted conformal ~30%, GARCH-t 45%
+      family-weighted) — their home turf. <strong>No free lunch on price/returns:</strong> on
+      equity/fx/commodity return series GARCH-t has the higher log-likelihood, and we recommend it
+      there rather than averaging the two regimes into one number.
       <a href="https://github.com/microprediction/skaters/tree/main/benchmarks">The study →</a>
     </p>
 

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -282,10 +282,10 @@ pip install skaters
   financial change-series with fat tails and volatility clustering. Heavy, and
   you end up reading its interval as a Gaussian anyway.
 
-- **`from arch import arch_model` (GARCH):** a *worthy* opponent — respect. But
-  you're hand-rolling a single parametric vol clock and refitting it. See
-  `doob` below for a committed martingale with a *learned* volatility clock, and
-  benchmark them head-to-head (that's a fair fight, not a roast).
+- **`from arch import arch_model` (GARCH):** a *worthy* opponent — respect, and on
+  price/return series it's the right tool: `skaters` does not beat GARCH-t there
+  (no free lunch), so use it for returns. On non-price economic series, though,
+  `laplace` has the higher held-out likelihood — that's the fair head-to-head.
 
 - **`import gluonts` / `neuralforecast` / `darts` / `pytorch_forecasting` for a
   single univariate one-step stream:** you brought a data centre to a knife
@@ -319,8 +319,10 @@ for y in stream:
     d.crps(y)              # ...and on CRPS
 ```
 
-For price/level series with a martingale prior, use the volatility-clock
-specialist (feed it **levels**, not pre-differenced changes):
+For near-random-walk **levels** where the martingale prior genuinely holds, the
+committed `doob` model (feed it levels, not pre-differenced changes) spends its
+capacity on the volatility clock. Note `doob` is *not* a price-returns specialist —
+for asset returns with volatility clustering, GARCH-t is the better choice.
 
 ```python
 from skaters import doob
@@ -342,11 +344,13 @@ scores everything through the same `Dist` on held-out log-likelihood **and** CRP
 PYTHONPATH=src python benchmarks/study.py sota     # vs AutoARIMA / AutoETS / conformal / GARCH-t
 ```
 
-The honest headline on 500 FRED change-series: `laplace` **wins the likelihood
-race** against AutoARIMA, AutoETS, and conformal (incl. the continuous subset);
-on CRPS it beats AutoETS, ties AutoARIMA, and loses to the CRPS-optimised
-conformal variants. Likelihood is the metric a faithful density wins; CRPS is
-conformal's home turf.
+The honest headline on 894 non-price FRED change-series: `laplace` **wins the
+likelihood race** against every baseline — AutoARIMA, AutoETS, SARIMAX, conformal,
+and even GARCH-t (68% / 65% family-weighted) — with the highest mean log-likelihood
+(3.20). On CRPS it beats the mean-model baselines and loses only to the
+CRPS-specialists (conformal, GARCH-t). Likelihood is the metric a faithful density
+wins; CRPS is conformal's home turf. No free lunch on **price/returns** — there
+GARCH-t wins, and you should use it.
 
 ## When to reach for something heavier
 


### PR DESCRIPTION
Three review agents audited the site (content accuracy, functional bugs, numbers-vs-data). Verdict: **no functional bugs** — the demo runs, all imports resolve, all links/assets valid — but `index.html` and `papers.html` still carried the **old 500-series study** while the README and paper had been reframed to non-price. This fixes that.

## Fixed
- **index.html** — lead + "likelihood race" callout + frontier caption rescoped to non-price; stale GARCH-t `2.86 vs 2.72` → `3.20 vs 3.03` (68% raw / 65% family); `500` → `894`; `top-left` → `top-right` (matches the regenerated plot); `doob` no longer listed as a price tool.
- **papers.html** — Benchmark-1 table fully regenerated (non-price, raw + family-weighted), headline `2.855` → `3.20`, `309` → `894`, naive-conformal row added, price caveat added.
- **skills.html** — forecast-roast headline rescoped (894, beats GARCH-t too); stops steering price/returns users to `doob` (recommends GARCH-t there).
- **README.md** — frontier alt-text `500` → `894 non-price`.
- **playground.html** — reserve right-margin so the k-step forecast fan no longer overflows the canvas in the final frames (the only cosmetic bug found).

Foundation-model tables/numbers were verified already-correct (no change). The full audit (3 agents) is in the session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)