### PR TITLE
Demo: show the model's live search (ensemble weight by candidate family)

### DIFF
--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -5,6 +5,17 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>skaters — forecasting playground</title>
   <link rel="stylesheet" href="../academic.css" />
+  <style>
+    .weights-panel { margin-top: 14px; }
+    .weights-title { font-size: 0.82rem; font-weight: 600; color: #333; margin-bottom: 6px; }
+    .weights-sub { font-weight: 400; color: #888; }
+    .weights { display: flex; flex-direction: column; gap: 3px; }
+    .wrow { display: flex; align-items: center; gap: 8px; font-size: 0.78rem; }
+    .wlabel { flex: 0 0 96px; text-align: right; color: #444; }
+    .wtrack { flex: 1 1 auto; height: 11px; background: #f0f0f3; border-radius: 3px; overflow: hidden; }
+    .wbar { display: block; height: 100%; background: #4a3aff; border-radius: 3px; transition: width 0.12s linear; }
+    .wval { flex: 0 0 34px; text-align: right; color: #666; font-variant-numeric: tabular-nums; }
+  </style>
 </head>
 <body>
   <header class="site-header">
@@ -62,6 +73,11 @@
         <span><span class="swatch" style="background:#ff8a3a"></span>k-step forecast fan</span>
       </div>
       <p class="status" id="status">—</p>
+      <div class="weights-panel">
+        <div class="weights-title">What the model is betting on
+          <span class="weights-sub">— live ensemble weight by candidate family</span></div>
+        <div class="weights" id="weights"></div>
+      </div>
     </div>
 
     <p>
@@ -72,6 +88,14 @@
       <code>laplace</code> (at <em>k&gt;1</em>, via its Ornstein–Uhlenbeck pool
       group) curve the fan back toward the mean.
       <span class="metric" id="metrics"></span>
+    </p>
+    <p>
+      The bars above are <strong>live</strong>: <code>laplace</code> is a Bayesian
+      average over ~50 candidate models, and the panel shows how much weight it
+      currently places on each <em>family</em> (random walk, drift, AR, Holt trend,
+      seasonal, mean reversion, …). Watch it <em>search</em> — switch the data
+      regime and the model re-weights toward the family that fits, abandoning a
+      wrong prior as fast as the evidence accumulates.
     </p>
     <p>
       Open the console and <code>import</code> from
@@ -87,8 +111,30 @@
   </footer>
 
   <script type="module">
-    import { laplace } from "../js/skaters/index.mjs";
+    import { buildCandidates, terminalLeafEnsemble, crpsLeaf } from "../js/skaters/index.mjs";
     let K = 6;   // forecast horizon (set from the slider in compute)
+
+    // Build laplace's candidate pool + terminal ensemble directly, so we can read
+    // the live per-candidate weights and show which families the model is betting
+    // on. (This is laplace minus the lattice projection — a no-op on the demo's
+    // continuous regimes.) families[i] is the human family label of candidate i.
+    let FAMILIES = [];
+    function buildLaplace(k) {
+      const [cands, depths, , families] = buildCandidates(k);
+      FAMILIES = families;
+      return terminalLeafEnsemble(cands, {
+        k, leafFn: crpsLeaf, learningRate: 0.8, complexityPenalty: 0.005,
+        depths, maxComponents: 20, forget: 0.99,
+      });
+    }
+    // Aggregate the ensemble's normalized candidate weights by family.
+    function familyWeights(state) {
+      const lw = state.log_w; const mx = Math.max(...lw);
+      let tot = 0; const w = lw.map((x) => { const e = Math.exp(x - mx); tot += e; return e; });
+      const fam = {};
+      for (let i = 0; i < w.length; i++) fam[FAMILIES[i]] = (fam[FAMILIES[i]] || 0) + w[i] / tot;
+      return fam;
+    }
 
     // Reproducible-but-varied RNG (mulberry32). Seed bumps each regenerate.
     function rng(seed) {
@@ -141,7 +187,7 @@
 
     function compute() {
       K = parseInt(document.getElementById("horizon").value, 10);
-      const policy = laplace(K);
+      const policy = buildLaplace(K);
       const regime = document.getElementById("regime").value;
       const series = makeSeries(regime, seed);
       let state = null, pending = null;
@@ -157,7 +203,7 @@
         state = st; pending = dists;
         // Store the full k-step forecast fan made AFTER seeing y (predicts t+1..t+K).
         const fan = dists.map((d) => ({ mean: d.mean, lo: d.quantile(0.025), hi: d.quantile(0.975) }));
-        rows.push({ y, mean, lo, hi, lp, fan, distK: dists[dists.length - 1] });
+        rows.push({ y, mean, lo, hi, lp, fan, distK: dists[dists.length - 1], fam: familyWeights(st) });
       }
       cursor = 1;
     }
@@ -263,12 +309,29 @@
       document.getElementById("status").textContent = `step ${upto} / ${rows.length}`;
     }
 
+    // Live "what the model is betting on": the ensemble's family weights at the
+    // current step, as a ranked bar list. Watch it shift as the regime changes.
+    function renderWeights(upto) {
+      const row = upto >= 1 ? rows[upto - 1] : null;
+      const fam = row && row.fam;
+      const el = document.getElementById("weights");
+      if (!fam) { el.innerHTML = ""; return; }
+      const ranked = Object.entries(fam).filter(([, w]) => w > 0.004)
+        .sort((a, b) => b[1] - a[1]).slice(0, 8);
+      const max = ranked.length ? ranked[0][1] : 1;
+      el.innerHTML = ranked.map(([name, w]) =>
+        `<div class="wrow"><span class="wlabel">${name}</span>` +
+        `<span class="wtrack"><span class="wbar" style="width:${(100 * w / max).toFixed(1)}%"></span></span>` +
+        `<span class="wval">${(100 * w).toFixed(0)}%</span></div>`).join("");
+    }
+
     function tick() {
       if (paused) return;
       const step = parseInt(document.getElementById("speed").value, 10);
       cursor = Math.min(rows.length, cursor + step);
       draw(cursor);
       updateMetrics(cursor);
+      renderWeights(cursor);
       if (cursor < rows.length) timer = requestAnimationFrame(tick);
     }
 

--- a/docs/js/skaters/api.mjs
+++ b/docs/js/skaters/api.mjs
@@ -20,86 +20,88 @@ export function buildCandidates(k) {
   const candidates = [];
   const depths = [];
   const groups = {};
-  const push = (c, d) => {
+  const families = [];                 // human family label per candidate (for introspection)
+  const push = (c, d, fam) => {
     candidates.push(c);
     depths.push(d);
+    families.push(fam);
     return candidates.length - 1;
   };
 
   // Depth 0: baseline noise
-  push(leaf(k), 0);
+  push(leaf(k), 0, "baseline");
 
   // Depth 1: single EMA at various speeds
-  for (const alpha of [0.01, 0.05, 0.1, 0.3]) push(conjugate(leaf(k), emaTransform(alpha), k), 1);
+  for (const alpha of [0.01, 0.05, 0.1, 0.3]) push(conjugate(leaf(k), emaTransform(alpha), k), 1, "EMA");
 
   // Depth 1: differencing (pure random walk)
   groups.diff = [];
-  groups.diff.push(push(conjugate(leaf(k), difference(), k), 1));
+  groups.diff.push(push(conjugate(leaf(k), difference(), k), 1, "random walk"));
 
   // Depth 1: drift (random walk with adaptive drift)
   groups.drift = [];
   for (const [a, s] of [[0.05, 0.01], [0.01, 0.002], [0.002, 0.001], [0.0005, 0.0002]]) {
-    groups.drift.push(push(conjugate(leaf(k), drift(a, s), k), 1));
+    groups.drift.push(push(conjugate(leaf(k), drift(a, s), k), 1, "drift"));
   }
 
   // Depth 1: Theta
-  for (const a of [0.05, 0.1, 0.3]) push(conjugate(leaf(k), theta(a), k), 1);
+  for (const a of [0.05, 0.1, 0.3]) push(conjugate(leaf(k), theta(a), k), 1, "Theta");
 
   // Depth 1: AR
-  push(conjugate(leaf(k), ar(1), k), 1);
-  push(conjugate(leaf(k), ar(2, 0.99, 1.0, 1), k), 1);
+  push(conjugate(leaf(k), ar(1), k), 1, "AR");
+  push(conjugate(leaf(k), ar(2, 0.99, 1.0, 1), k), 1, "AR");
 
   // Depth 1: Holt linear
   groups.holt = [];
   for (const [a, b] of [[0.1, 0.02], [0.1, 0.05], [0.3, 0.1]]) {
-    groups.holt.push(push(conjugate(leaf(k), holtLinear(a, b), k), 1));
+    groups.holt.push(push(conjugate(leaf(k), holtLinear(a, b), k), 1, "Holt trend"));
   }
 
   // Depth 1: Seasonal differencing
-  for (const period of [7, 12, 24]) push(conjugate(leaf(k), seasonalDifference(period), k), 1);
+  for (const period of [7, 12, 24]) push(conjugate(leaf(k), seasonalDifference(period), k), 1, "seasonal");
 
   // Depth 2: Seasonal differencing + EMA
   for (const period of [7, 12, 24]) {
     for (const alpha of [0.05, 0.1]) {
-      push(conjugate(conjugate(leaf(k), emaTransform(alpha), k), seasonalDifference(period), k), 2);
+      push(conjugate(conjugate(leaf(k), emaTransform(alpha), k), seasonalDifference(period), k), 2, "seasonal");
     }
   }
 
   // Depth 2: differencing + EMA
   for (const alpha of [0.05, 0.1, 0.3]) {
-    groups.diff.push(push(conjugate(conjugate(leaf(k), emaTransform(alpha), k), difference(), k), 2));
+    groups.diff.push(push(conjugate(conjugate(leaf(k), emaTransform(alpha), k), difference(), k), 2, "random walk"));
   }
 
   // Depth 2: standardize + EMA
   for (const alpha of [0.05, 0.1]) {
-    push(conjugate(conjugate(leaf(k), emaTransform(alpha), k), standardize(), k), 2);
+    push(conjugate(conjugate(leaf(k), emaTransform(alpha), k), standardize(), k), 2, "EMA");
   }
 
   // Depth 2: fractional diff + EMA
   groups.frac = [];
   for (const d of [0.2, 0.4]) {
-    groups.frac.push(push(conjugate(conjugate(leaf(k), emaTransform(0.1), k), fractionalDifference(d, 30), k), 2));
+    groups.frac.push(push(conjugate(conjugate(leaf(k), emaTransform(0.1), k), fractionalDifference(d, 30), k), 2, "frac diff"));
   }
 
   // Depth 2: drift + EMA
   for (const [aDrift, sDrift] of [[0.002, 0.001], [0.0005, 0.0002]]) {
     for (const aEma of [0.05, 0.1]) {
-      groups.drift.push(push(conjugate(conjugate(leaf(k), emaTransform(aEma), k), drift(aDrift, sDrift), k), 2));
+      groups.drift.push(push(conjugate(conjugate(leaf(k), emaTransform(aEma), k), drift(aDrift, sDrift), k), 2, "drift"));
     }
   }
 
   // Depth 2: drift + Holt linear
   {
-    const idx = push(conjugate(conjugate(leaf(k), holtLinear(0.1, 0.05), k), drift(0.001, 0.0005), k), 2);
+    const idx = push(conjugate(conjugate(leaf(k), holtLinear(0.1, 0.05), k), drift(0.001, 0.0005), k), 2, "Holt trend");
     groups.drift.push(idx);
     groups.holt.push(idx);
   }
 
   // Depth 2: GARCH + EMA
-  push(conjugate(conjugate(leaf(k), emaTransform(0.1), k), garch(), k), 2);
+  push(conjugate(conjugate(leaf(k), emaTransform(0.1), k), garch(), k), 2, "GARCH vol");
 
   // Depth 2: power transform + EMA
-  push(conjugate(conjugate(leaf(k), emaTransform(0.1), k), powerTransform(0.5), k), 2);
+  push(conjugate(conjugate(leaf(k), emaTransform(0.1), k), powerTransform(0.5), k), 2, "power coord");
 
   // Depth 2: thinking fast and slow (fast tracker outside, slow scale inside)
   const fastTrackers = () => [
@@ -108,7 +110,7 @@ export function buildCandidates(k) {
   groups.fast_slow = [];
   for (const scaleAlpha of [0.02, 0.05]) {
     for (const tracker of fastTrackers()) {
-      groups.fast_slow.push(push(conjugate(conjugate(leaf(k), standardize(scaleAlpha), k), tracker, k), 2));
+      groups.fast_slow.push(push(conjugate(conjugate(leaf(k), standardize(scaleAlpha), k), tracker, k), 2, "fast/slow"));
     }
   }
 
@@ -116,7 +118,7 @@ export function buildCandidates(k) {
   groups.coordinate = [];
   for (const L of [0.0, 0.5]) {
     for (const innerTx of [difference(), emaTransform(0.1)]) {
-      groups.coordinate.push(push(conjugate(conjugate(leaf(k), innerTx, k), yeoJohnson(L), k), 2));
+      groups.coordinate.push(push(conjugate(conjugate(leaf(k), innerTx, k), yeoJohnson(L), k), 2, "coordinate"));
     }
   }
 
@@ -127,12 +129,12 @@ export function buildCandidates(k) {
     for (const L of [0.0, 0.5]) {
       for (const kappa of [0.03, 0.1, 0.3]) {
         groups.mean_revert.push(push(
-          conjugate(conjugate(leaf(k), ouTransform(kappa, 0.02), k), yeoJohnson(L), k), 2));
+          conjugate(conjugate(leaf(k), ouTransform(kappa, 0.02), k), yeoJohnson(L), k), 2, "mean reversion"));
       }
     }
   }
 
-  return [candidates, depths, groups];
+  return [candidates, depths, groups, families];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Per the request — the [playground](https://skaters.microprediction.org/demos/playground.html) now lets you **see the choices the model makes as it searches the space**.

`laplace` is a Bayesian average over ~50 candidate models; the demo now shows a **live ranked bar panel** of the ensemble's normalized weight, aggregated by candidate **family** (random walk, drift, AR, Holt trend, seasonal, mean reversion, coordinate, fast/slow, GARCH vol, …). As the stream plays — and especially when you switch the data regime — the bars re-search toward the family that fits, and the `forget=0.99` factor abandons a wrong prior as the evidence accumulates.

Verified the bets genuinely differ by regime: **drift** on a random walk, **seasonal** on period-7 data, **AR** on mean reversion.

## How
- `buildCandidates` (JS) returns a 4th element, `families[]` — a human label per candidate. JS destructuring ignores the extra, so `laplace`/`search` are unaffected, and **parity is untouched** (it scores forecast output, not this metadata).
- The playground builds the pool + terminal ensemble inline (faithful to `laplace`, minus the lattice projection which is a no-op on the continuous demo regimes) so it can read `state.log_w` each step and render the top families as bars.

JS validated; **Python↔JS parity still 1e-6**; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)