### PR TITLE
Benchmarks: real R forecast stack, CSP opponent, refit sweeps, comparison folders

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -57,6 +57,36 @@ pip install statsforecast # AutoARIMA/ETS mean models to pair conformal with
 The script prints which it found. These need network + heavy deps, so they are
 intentionally absent from the package's `pyproject.toml`.
 
+### The R stack (`forecast`, `smooth`) — the real thing, not a port
+
+`statsforecast`'s AutoARIMA is a Python *reimplementation* of Hyndman's
+`auto.arima`. To benchmark against the **actual** R packages, install R and:
+
+```r
+install.packages(c("forecast", "smooth"))   # forecast = auto.arima/ETS/thetaf; smooth = ADAM
+```
+
+Gated on `Rscript` being on `PATH` (and each method gated inside R on its
+package). One `Rscript` per series runs the rolling one-step CV in R and prints
+`mean, sd` per step; we rebuild a Gaussian `Dist` (sd from the 90 % band) and
+score it through the *same* one scorer as everything else. It adds three
+opponents Python has no clean equivalent for: **auto.arima-R** (the real
+Hyndman), **Theta-R** (`thetaf`, the M3 winner), and **ADAM-R** (Svetunkov's
+state-space auto-ETS/ARIMA). Because auto.arima and ADAM reuse the fitted model
+between refits, each is registered at several **refit cadences**
+(`BENCH_R_REFITS`, default `5,25,100`) so the frontier plot shows each model's
+own accuracy-vs-speed curve rather than one point.
+
+### CSP — Conformal Seasonal Pools (arXiv:2605.03789)
+
+A training-free seasonal-pool sampler: mixes same-season empirical draws with
+signed residual draws around a seasonal-naive forecast. Pure numpy (zero deps),
+so it always loads. Like the fitted conformal foil we KDE-smooth its sample pool
+into a `Dist` and score it on **both** log-likelihood and CRPS — a CRPS-tuned
+method doesn't get to duck the density test here. `CSP-adaptive` rescales the
+pool by recent 90 % hit-rate (the paper's adaptive variant). Season period is
+weekly by default on daily FRED (`BENCH_CSP_M=7`).
+
 ## Headline: vs eight distributional baselines (`study.py sota`)
 
 The honest head-to-head against everything we could find that claims a

--- a/benchmarks/bench_core.py
+++ b/benchmarks/bench_core.py
@@ -96,6 +96,26 @@ def conformal_dist(point, resid_window, scale=1.0, nq=41):
     return Dist([(1.0 / nq, point + scale * q, h) for q in qs])
 
 
+def grid_dist(taus, qs):
+    """Dist from predictive quantile *values* `qs` at probability levels `taus`
+    (0<tau<1) — for a baseline whose predictive is genuinely non-Gaussian (ADAM,
+    NNETAR, GARCH-t, BSTS). Each node gets mass = its tau-midpoint gap and a
+    Silverman kernel, so the density is scored on its real shape, not a
+    Gaussian-from-band flattening of it. Returns None on too few finite nodes."""
+    taus = np.asarray(taus, float); qs = np.asarray(qs, float)
+    ok = np.isfinite(taus) & np.isfinite(qs)
+    taus, qs = taus[ok], qs[ok]
+    if qs.size < 5:
+        return None
+    o = np.argsort(taus); taus, qs = taus[o], np.sort(qs[o])   # quantiles monotone in tau
+    edges = np.concatenate(([0.0], (taus[:-1] + taus[1:]) / 2.0, [1.0]))
+    w = np.diff(edges); w = w / w.sum()                        # trapezoidal tau mass
+    iqr = np.interp(0.75, taus, qs) - np.interp(0.25, taus, qs)
+    spread = (iqr / 1.349) if iqr > 0 else (qs[-1] - qs[0]) or 1.0
+    h = max(0.9 * spread * qs.size ** (-0.2), 1e-9)            # Silverman bandwidth
+    return Dist([(float(wi), float(v), h) for wi, v in zip(w, qs)])
+
+
 def student_t_dist(mu, var, nu, K=24):
     """Location-scale Student-t as a Gaussian scale mixture Dist (so it scores
     through the same logpdf/crps). Matches the analytic t logpdf to ~1e-3 at K=24."""

--- a/benchmarks/comparisons/.gitignore
+++ b/benchmarks/comparisons/.gitignore
@@ -1,0 +1,4 @@
+# transient run outputs — the READMEs are the committed artifact, not the raw CSVs
+_shared*.csv
+*/results.csv
+__pycache__/

--- a/benchmarks/comparisons/.gitignore
+++ b/benchmarks/comparisons/.gitignore
@@ -1,4 +1,5 @@
 # transient run outputs — the READMEs are the committed artifact, not the raw CSVs
 _shared*.csv
 */results.csv
+*.log
 __pycache__/

--- a/benchmarks/comparisons/README.md
+++ b/benchmarks/comparisons/README.md
@@ -35,6 +35,48 @@ if `Rscript` is absent they simply drop out. Budgets (`BENCH_R_MAX`, `BENCH_SF_M
 …) and cadences (`BENCH_R_REFITS`, `BENCH_SF_REFITS`) are the same env vars as the
 main study.
 
+## The long sweep (`overnight_sweep.sh`)
+
+`overnight_sweep.sh` is the auto-resuming volume runner behind the results here. It
+appends to a resumable CSV (`STUDY_RESULTS`, per series+method — a kill never loses
+or re-scores work) and relaunches the study on any non-zero exit. Every knob is an
+env override; defaults are the lean max-N config (`laplace,R@25,statsforecast@25,CSP,GARCH-t`,
+`bsts-R` skipped).
+
+```bash
+# macOS (prevent sleep):  caffeinate keeps it awake; the loop resumes on any kill
+caffeinate -is bash benchmarks/comparisons/overnight_sweep.sh &
+# Linux:
+nohup bash benchmarks/comparisons/overnight_sweep.sh &
+```
+
+## Running on another machine (transfer)
+
+The code travels with the branch; two things don't and must be moved by hand:
+
+1. **The FRED cache** — `benchmarks/data/` (~146 MB, ~2600 CSVs, gitignored). Either
+   rsync it, or set a `FRED_API_KEY` and run with `STUDY_CACHED_ONLY=0` to re-fetch.
+   ```bash
+   rsync -av this-machine:~/github/skaters/benchmarks/data/ ./benchmarks/data/
+   ```
+2. **The in-progress results** — `benchmarks/comparisons/_shared_R25.csv` (gitignored).
+   Copy it over to *continue* the accumulation; omit it to start fresh.
+   ```bash
+   rsync -av this-machine:~/github/skaters/benchmarks/comparisons/_shared_R25.csv \
+             ./benchmarks/comparisons/
+   ```
+
+Then install deps and launch:
+```bash
+Rscript -e 'install.packages(c("forecast","smooth","rugarch","bsts"), repos="https://cloud.r-project.org")'
+pip install statsforecast arch statsmodels    # Python opponents (absent ones drop out)
+caffeinate -is bash benchmarks/comparisons/overnight_sweep.sh &   # or nohup on Linux
+```
+
+**Run on one machine at a time.** Two machines appending to the same-named CSV will
+duplicate rows and skew `summarize`. To split work, give each a distinct
+`STUDY_RESULTS`, then concatenate and de-dup on `(series,method)` before summarizing.
+
 ## The rule (unchanged)
 
 Every method — ours and theirs — is turned into the same predictive `Dist` and

--- a/benchmarks/comparisons/README.md
+++ b/benchmarks/comparisons/README.md
@@ -1,0 +1,43 @@
+# comparisons — laplace vs. one opponent at a time
+
+Head-to-head slices of the *same* `sota` study (one FRED loader, one `Dist`
+scorer, one rolling one-step protocol — see `../README.md`), each isolated to
+**laplace vs. a single opponent** so the story is legible: what is X, why does it
+matter, and does `laplace` beat it on held-out **log-likelihood** and **CRPS**.
+
+Each subfolder is one matchup:
+
+| folder | opponent(s) | what it tests |
+|---|---|---|
+| `laplace-vs-autoarima/` | `auto.arima-R@*`, `AutoARIMA@*` (statsforecast) | the real Hyndman R auto.arima *and* its Python port, across refit cadences |
+| `laplace-vs-adam/` | `ADAM-R@*` | Svetunkov's ADAM — the strongest classical *distributional* forecaster |
+| `laplace-vs-theta/` | `Theta-R@*` | the M3 winner; cheap, hard to beat |
+| `laplace-vs-nnetar/` | `nnetar-R@*` | a nonlinear (neural AR) opponent with no clean Python twin |
+| `laplace-vs-garch/` | `GARCH-t`, `GARCH-t-R@*` | heavy-tail volatility SOTA (its home turf is price/returns) |
+| `laplace-vs-csp/` | `CSP`, `CSP-adaptive` | training-free Conformal Seasonal Pools (arXiv:2605.03789) |
+
+## Reproduce a matchup
+
+```bash
+# laplace vs the real R auto.arima at three refit cadences
+PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
+    laplace-vs-autoarima R@5 R@25 R@100
+```
+
+`run_comparison.py` restricts the `sota` opponent set to laplace + the names you
+pass (`STUDY_ONLY`) and writes to `comparisons/<slug>/results.csv`
+(`STUDY_RESULTS`). It scores nothing new — it's the one harness, one slice. Paste
+the printed summary into that folder's `README.md` under **Result**.
+
+R opponents need R installed (`install.packages(c("forecast","smooth","rugarch","bsts"))`);
+if `Rscript` is absent they simply drop out. Budgets (`BENCH_R_MAX`, `BENCH_SF_MAX`,
+…) and cadences (`BENCH_R_REFITS`, `BENCH_SF_REFITS`) are the same env vars as the
+main study.
+
+## The rule (unchanged)
+
+Every method — ours and theirs — is turned into the same predictive `Dist` and
+scored by the same code on the same held-out points. Gaussian predictives
+(auto.arima, Theta) are scored exactly; genuinely non-Gaussian ones (ADAM,
+nnetar, GARCH-t, BSTS, CSP) are scored on their **real quantiles**, not a
+Gaussian-from-band flattening. CDF-only methods report CRPS and say so.

--- a/benchmarks/comparisons/README.md
+++ b/benchmarks/comparisons/README.md
@@ -14,6 +14,7 @@ Each subfolder is one matchup:
 | `laplace-vs-theta/` | `Theta-R@*` | the M3 winner; cheap, hard to beat |
 | `laplace-vs-nnetar/` | `nnetar-R@*` | a nonlinear (neural AR) opponent with no clean Python twin |
 | `laplace-vs-garch/` | `GARCH-t`, `GARCH-t-R@*` | heavy-tail volatility SOTA (its home turf is price/returns) |
+| `laplace-vs-bsts/` | `bsts-R@*` | Bayesian structural time series — full posterior predictive |
 | `laplace-vs-csp/` | `CSP`, `CSP-adaptive` | training-free Conformal Seasonal Pools (arXiv:2605.03789) |
 
 ## Reproduce a matchup

--- a/benchmarks/comparisons/laplace-vs-adam/README.md
+++ b/benchmarks/comparisons/laplace-vs-adam/README.md
@@ -19,14 +19,14 @@ PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
 # (R@* runs the whole R stack; ADAM-R@* is the row that matters here)
 ```
 
-**Result** _(provisional — N=44, 39 continuous; first-scored cached slice; R@25)._
+**Result** _(N=120 R-covered, 167 continuous; still growing overnight. R@25.)_
 
 laplace **win-rate**:
 
 | method | CRPS all/cont | LL all/cont | N |
 |---|---|---|---|
-| ADAM-R@25 | 82/82% | **98/97%** | 44 |
+| ADAM-R@25 | 82/81% | **96/95%** | 120 |
 
-Scored on ADAM's **real predictive quantiles**, not a Gaussian band. laplace wins ~98%
+Scored on ADAM's **real predictive quantiles**, not a Gaussian band. laplace wins ~96%
 on log-likelihood and ~82% on CRPS. ADAM is the strongest classical distributional
 forecaster in the field, so this is the most meaningful of the R matchups.

--- a/benchmarks/comparisons/laplace-vs-adam/README.md
+++ b/benchmarks/comparisons/laplace-vs-adam/README.md
@@ -1,0 +1,32 @@
+# laplace vs. ADAM
+
+**Opponent.** `smooth::adam` (Svetunkov) — Augmented Dynamic Adaptive Model, a
+unified state-space engine (ETS + ARIMA + regression) estimated by **maximum
+likelihood under an explicitly assumed distribution** (Normal, Laplace, S,
+Generalised Normal, …). `ADAM-R@{5,25,100}`, scored on its **real predictive
+quantiles**, not a Gaussian band.
+
+**Why it matters.** ADAM is the strongest classical *distributional* forecaster
+in R and the closest philosophical cousin to `laplace` — likelihood-native,
+possibly heavy-tailed. This is the most informative single matchup: two
+principled distributional forecasters, one online and dependency-free, one a full
+state-space MLE. If `laplace` wins here on log-likelihood, that's the headline.
+
+**Reproduce.**
+```bash
+PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
+    laplace-vs-adam R@5 R@25 R@100
+# (R@* runs the whole R stack; ADAM-R@* is the row that matters here)
+```
+
+**Result** _(provisional — N=44, 39 continuous; first-scored cached slice; R@25)._
+
+laplace **win-rate**:
+
+| method | CRPS all/cont | LL all/cont | N |
+|---|---|---|---|
+| ADAM-R@25 | 82/82% | **98/97%** | 44 |
+
+Scored on ADAM's **real predictive quantiles**, not a Gaussian band. laplace wins ~98%
+on log-likelihood and ~82% on CRPS. ADAM is the strongest classical distributional
+forecaster in the field, so this is the most meaningful of the R matchups.

--- a/benchmarks/comparisons/laplace-vs-autoarima/README.md
+++ b/benchmarks/comparisons/laplace-vs-autoarima/README.md
@@ -17,16 +17,16 @@ PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
     laplace-vs-autoarima R@5 R@25 R@100 statsforecast@5 statsforecast@25 statsforecast@100
 ```
 
-**Result** _(provisional — N=44, 39 continuous; the first-scored cached slice, which
-is rates/FX/credit-heavy and not yet representative; R@25 cadence)._
+**Result** _(N=120 R-covered, 167 continuous; still growing overnight toward the full
+universe. R@25 cadence.)_
 
 laplace **win-rate** (fraction of series where laplace scores better):
 
 | method | CRPS all/cont | LL all/cont | N |
 |---|---|---|---|
-| auto.arima-R@25 | 55/51% | **82/79%** | 44 |
+| auto.arima-R@25 | 51/50% | **79/78%** | 120 |
 
-laplace beats the *real R* auto.arima on **log-likelihood** (82%) while it's a near-tie
-on **CRPS** (55%) — the CRPS-vs-likelihood distinction in a single row: a method can
-match the density's spread yet lose on the density itself. Full-universe run and the
-Python `AutoARIMA@*` port (same refit axis) still pending.
+laplace beats the *real R* auto.arima on **log-likelihood** (~79%) while it's a coin-flip
+on **CRPS** (~51%) — the CRPS-vs-likelihood distinction in a single row: a method can
+match the density's spread yet lose on the density itself. The Python `AutoARIMA@*` port
+(same refit axis) is scoring overnight for a like-for-like port-vs-real comparison.

--- a/benchmarks/comparisons/laplace-vs-autoarima/README.md
+++ b/benchmarks/comparisons/laplace-vs-autoarima/README.md
@@ -1,0 +1,32 @@
+# laplace vs. AutoARIMA
+
+**Opponent.** Hyndman's `auto.arima` — the default automatic ARIMA. Two forms:
+the **real R** `forecast::auto.arima` (`auto.arima-R@{5,25,100}`) and Nixtla's
+**Python port** `statsforecast.AutoARIMA` (`AutoARIMA@{5,25,100}`). Both emit an
+exactly-Gaussian one-step predictive, so both are scored on log-likelihood.
+
+**Why it matters.** ARIMA is *the* classical baseline and the thing most papers
+compare against. If `laplace` doesn't beat auto.arima on held-out likelihood, it
+has no story. The `@cadence` sweep also shows the accuracy/speed tradeoff:
+auto.arima reuses the fitted orders between refits, so `@100` is far cheaper than
+`@5` — plot both against `laplace`'s online O(1)/step.
+
+**Reproduce.**
+```bash
+PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
+    laplace-vs-autoarima R@5 R@25 R@100 statsforecast@5 statsforecast@25 statsforecast@100
+```
+
+**Result** _(provisional — N=44, 39 continuous; the first-scored cached slice, which
+is rates/FX/credit-heavy and not yet representative; R@25 cadence)._
+
+laplace **win-rate** (fraction of series where laplace scores better):
+
+| method | CRPS all/cont | LL all/cont | N |
+|---|---|---|---|
+| auto.arima-R@25 | 55/51% | **82/79%** | 44 |
+
+laplace beats the *real R* auto.arima on **log-likelihood** (82%) while it's a near-tie
+on **CRPS** (55%) — the CRPS-vs-likelihood distinction in a single row: a method can
+match the density's spread yet lose on the density itself. Full-universe run and the
+Python `AutoARIMA@*` port (same refit axis) still pending.

--- a/benchmarks/comparisons/laplace-vs-bsts/README.md
+++ b/benchmarks/comparisons/laplace-vs-bsts/README.md
@@ -1,0 +1,33 @@
+# laplace vs. BSTS
+
+**Opponent.** `bsts` (Scott / Google) — Bayesian structural time series. A
+local-level state-space model fit by MCMC each step; the one-step **posterior
+predictive draws** become sample quantiles, scored on their real (non-Gaussian)
+shape (`bsts-R@25`). No online update — a fresh short MCMC per step — so it's the
+most expensive opponent per series and runs at a tiny budget.
+
+**Why it matters.** The Bayesian gold standard for *honest* uncertainty: the
+predictive is a genuine posterior, not a plug-in Gaussian. If laplace beats a full
+posterior-predictive on held-out log-likelihood, that's a strong statement about
+calibration, not just point accuracy.
+
+**Result** _(N=119 R-covered, 167 continuous; R@25; scored before `bsts-R` was
+skipped for the throughput sweep)._
+
+laplace **win-rate**:
+
+| method | CRPS all/cont | LL all/cont | N |
+|---|---|---|---|
+| bsts-R@25 | 80/79% | **97/97%** | 119 |
+
+laplace wins ~97% on log-likelihood against the full Bayesian posterior-predictive —
+at O(1)/step and zero dependencies versus per-step MCMC.
+
+**Reproduce.** bsts is slow (fresh MCMC every step). Run it at a small budget and do
+*not* skip it:
+```bash
+BENCH_R_MAX=30 BENCH_BSTS_NITER=300 PYTHONPATH=src \
+    python benchmarks/comparisons/run_comparison.py laplace-vs-bsts R@25
+```
+(The overnight throughput sweep sets `BENCH_R_SKIP=bsts-R`, so bsts only accrues in
+dedicated small-N runs like this one.)

--- a/benchmarks/comparisons/laplace-vs-csp/README.md
+++ b/benchmarks/comparisons/laplace-vs-csp/README.md
@@ -19,14 +19,14 @@ PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
     laplace-vs-csp CSP
 ```
 
-**Result** _(provisional — N=44, 39 continuous; first-scored cached slice; weekly season)._
+**Result** _(N=194, 167 continuous; still growing overnight; weekly season.)_
 
 laplace **win-rate**:
 
 | method | CRPS all/cont | LL all/cont | N |
 |---|---|---|---|
-| CSP | 100/100% | 100/100% | 44 |
-| CSP-adaptive | 100/100% | 100/100% | 44 |
+| CSP | 100/100% | 99/99% | 194 |
+| CSP-adaptive | 100/100% | 99/99% | 194 |
 
 A clean sweep on both metrics — but read it fairly: daily FRED *change*-series has only a
 weak weekly signal, so CSP is off the strongly-seasonal turf (electricity/traffic) it was

--- a/benchmarks/comparisons/laplace-vs-csp/README.md
+++ b/benchmarks/comparisons/laplace-vs-csp/README.md
@@ -1,0 +1,35 @@
+# laplace vs. CSP (Conformal Seasonal Pools)
+
+**Opponent.** CSP — Conformal Seasonal Pools (Manokhin, arXiv:2605.03789), a
+training-free sampler that mixes same-season empirical draws with signed residual
+draws around a seasonal-naive forecast. `CSP` and `CSP-adaptive`. Pure numpy, zero
+deps. We KDE-smooth its sample pool into a `Dist` and score it on **both**
+log-likelihood and CRPS — a CRPS-tuned method doesn't get to duck the density
+test here.
+
+**Why it matters.** CSP is pitched on strongly-seasonal multi-series data
+(electricity, traffic) and on **CRPS**. On daily FRED *change*-series the weekly
+seasonal signal is weak, so this is partly off CSP's home turf — frame it fairly:
+report where it's competitive on CRPS and where the empirical/thin tails cost it
+on log-likelihood. Season period defaults to weekly (`BENCH_CSP_M=7`).
+
+**Reproduce.**
+```bash
+PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
+    laplace-vs-csp CSP
+```
+
+**Result** _(provisional — N=44, 39 continuous; first-scored cached slice; weekly season)._
+
+laplace **win-rate**:
+
+| method | CRPS all/cont | LL all/cont | N |
+|---|---|---|---|
+| CSP | 100/100% | 100/100% | 44 |
+| CSP-adaptive | 100/100% | 100/100% | 44 |
+
+A clean sweep on both metrics — but read it fairly: daily FRED *change*-series has only a
+weak weekly signal, so CSP is off the strongly-seasonal turf (electricity/traffic) it was
+built for. The honest claim is narrow: **on non-seasonal economic change-series, seasonal
+pooling has nothing to add**, and its empirical/thin tails cost it badly on log-likelihood.
+A seasonal-heavy universe would be the fair home-turf rematch.

--- a/benchmarks/comparisons/laplace-vs-garch/README.md
+++ b/benchmarks/comparisons/laplace-vs-garch/README.md
@@ -1,0 +1,27 @@
+# laplace vs. GARCH-t
+
+**Opponent.** GARCH(1,1) with Student-t innovations — the classical heavy-tail /
+volatility-clustering SOTA. Two forms: Python `arch` (`GARCH-t`) and R `rugarch`
+(`GARCH-t-R@{5,25,100}`, quantiles straight from the fitted Student-t). rugarch
+needs `install.packages("rugarch")`.
+
+**Why it matters.** This is the **honest caveat** in the README: on price/returns
+GARCH-t wins, and you should use it. This matchup is where we *expect* to lose on
+its home turf (and on CRPS especially), and the point is to say so plainly rather
+than hide it. Run it split by universe:
+
+```bash
+# non-price economic series (laplace's turf)
+STUDY_EXCLUDE_PRICE=1 PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
+    laplace-vs-garch GARCH-t R@25
+# price/returns (GARCH-t's turf)
+STUDY_ONLY_PRICE=1 PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
+    laplace-vs-garch GARCH-t R@25
+```
+
+**Result.** _Pending the price/non-price split run._ `GARCH-t-R` (rugarch) is installed and
+verified working (Student-t quantile predictive), but the only series scored so far are the
+first cached ones — rates/FX/VIX, i.e. GARCH's *home turf* — where it beats laplace on CRPS
+on a tiny N=4. Publishing that would be dishonestly cherry-picked in GARCH's favour; the
+matchup only means something split by universe (`STUDY_EXCLUDE_PRICE=1` vs `STUDY_ONLY_PRICE=1`),
+so it's deliberately left blank until that run.

--- a/benchmarks/comparisons/laplace-vs-garch/README.md
+++ b/benchmarks/comparisons/laplace-vs-garch/README.md
@@ -19,9 +19,25 @@ STUDY_ONLY_PRICE=1 PYTHONPATH=src python benchmarks/comparisons/run_comparison.p
     laplace-vs-garch GARCH-t R@25
 ```
 
-**Result.** _Pending the price/non-price split run._ `GARCH-t-R` (rugarch) is installed and
-verified working (Student-t quantile predictive), but the only series scored so far are the
-first cached ones — rates/FX/VIX, i.e. GARCH's *home turf* — where it beats laplace on CRPS
-on a tiny N=4. Publishing that would be dishonestly cherry-picked in GARCH's favour; the
-matchup only means something split by universe (`STUDY_EXCLUDE_PRICE=1` vs `STUDY_ONLY_PRICE=1`),
-so it's deliberately left blank until that run.
+**Result** _(N=119 R-covered across the mixed universe, 167 continuous; still growing
+overnight. The price/non-price split below is the honest full story and is still pending.)_
+
+laplace **win-rate**:
+
+| method | CRPS all/cont | LL all/cont | N |
+|---|---|---|---|
+| GARCH-t-R@25 | 53/50% | **82/81%** | 119 |
+
+A cautionary tale about small N: on the *first* 4 scored series (all rates/FX/VIX — GARCH's
+home turf) GARCH-t-R was beating laplace on CRPS. Across the fuller mixed universe (N=119)
+that reverses — laplace wins ~82% on log-likelihood and is a coin-flip on CRPS, because most
+of the universe is *not* price/returns. That's exactly why this matchup must be read split by
+universe, not pooled:
+
+```bash
+STUDY_EXCLUDE_PRICE=1 ...   # non-price economic series — laplace's turf
+STUDY_ONLY_PRICE=1   ...   # price/returns — GARCH-t's turf (expect to lose here, and say so)
+```
+
+The split run is still pending; the pooled number above already makes the honest point that
+GARCH-t only wins on the price minority.

--- a/benchmarks/comparisons/laplace-vs-nnetar/README.md
+++ b/benchmarks/comparisons/laplace-vs-nnetar/README.md
@@ -1,0 +1,28 @@
+# laplace vs. NNETAR
+
+**Opponent.** `forecast::nnetar` — a feed-forward neural-network autoregression
+with **simulated** prediction intervals, so its one-step predictive is genuinely
+non-Gaussian; scored on its real quantiles (`nnetar-R@{5,25,100}`).
+
+**Why it matters.** A nonlinear, "small neural net" opponent with no clean Python
+equivalent in the existing harness — a different failure mode from the linear
+ARIMA/ETS family. Tests whether `laplace`'s transform-ensemble captures
+nonlinearity that a black-box net would otherwise claim.
+
+**Reproduce.**
+```bash
+PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
+    laplace-vs-nnetar R@5 R@25 R@100
+```
+
+**Result** _(provisional — N=44, 39 continuous; first-scored cached slice; R@25)._
+
+laplace **win-rate**:
+
+| method | CRPS all/cont | LL all/cont | N |
+|---|---|---|---|
+| nnetar-R@25 | 82/82% | **98/97%** | 44 |
+
+Scored on nnetar's **simulated (non-Gaussian) quantiles**. laplace wins ~98% on
+log-likelihood — the transform-ensemble captures the structure the neural AR reaches for,
+at O(1)/step and zero dependencies rather than a per-step 400-path simulation.

--- a/benchmarks/comparisons/laplace-vs-nnetar/README.md
+++ b/benchmarks/comparisons/laplace-vs-nnetar/README.md
@@ -15,14 +15,14 @@ PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
     laplace-vs-nnetar R@5 R@25 R@100
 ```
 
-**Result** _(provisional — N=44, 39 continuous; first-scored cached slice; R@25)._
+**Result** _(N=120 R-covered, 167 continuous; still growing overnight. R@25.)_
 
 laplace **win-rate**:
 
 | method | CRPS all/cont | LL all/cont | N |
 |---|---|---|---|
-| nnetar-R@25 | 82/82% | **98/97%** | 44 |
+| nnetar-R@25 | 76/74% | **96/95%** | 120 |
 
-Scored on nnetar's **simulated (non-Gaussian) quantiles**. laplace wins ~98% on
+Scored on nnetar's **simulated (non-Gaussian) quantiles**. laplace wins ~96% on
 log-likelihood — the transform-ensemble captures the structure the neural AR reaches for,
 at O(1)/step and zero dependencies rather than a per-step 400-path simulation.

--- a/benchmarks/comparisons/laplace-vs-theta/README.md
+++ b/benchmarks/comparisons/laplace-vs-theta/README.md
@@ -1,0 +1,28 @@
+# laplace vs. Theta
+
+**Opponent.** `forecast::thetaf` — the Theta method, winner of the M3
+competition and still a notoriously hard-to-beat, near-free baseline. Gaussian
+one-step predictive (`Theta-R@*`), scored on log-likelihood. (Theta refits every
+step regardless, so its cadence line is near-flat — a single honest point.)
+
+**Why it matters.** The "simple thing that just works." A distributional
+forecaster that can't beat Theta on likelihood is over-engineered. This is the
+sanity check every new method should pass first.
+
+**Reproduce.**
+```bash
+PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
+    laplace-vs-theta R@25
+```
+
+**Result** _(provisional — N=44, 39 continuous; first-scored cached slice; R@25)._
+
+laplace **win-rate**:
+
+| method | CRPS all/cont | LL all/cont | N |
+|---|---|---|---|
+| Theta-R@25 | 68/67% | **91/90%** | 44 |
+
+laplace clears the M3-winner sanity check — 91% on log-likelihood — while Theta stays
+the most CRPS-competitive of the cheap baselines (68%). Passing this is the minimum bar
+for a new distributional forecaster; laplace passes comfortably on the density metric.

--- a/benchmarks/comparisons/laplace-vs-theta/README.md
+++ b/benchmarks/comparisons/laplace-vs-theta/README.md
@@ -15,14 +15,14 @@ PYTHONPATH=src python benchmarks/comparisons/run_comparison.py \
     laplace-vs-theta R@25
 ```
 
-**Result** _(provisional — N=44, 39 continuous; first-scored cached slice; R@25)._
+**Result** _(N=120 R-covered, 167 continuous; still growing overnight. R@25.)_
 
 laplace **win-rate**:
 
 | method | CRPS all/cont | LL all/cont | N |
 |---|---|---|---|
-| Theta-R@25 | 68/67% | **91/90%** | 44 |
+| Theta-R@25 | 63/61% | **87/87%** | 120 |
 
-laplace clears the M3-winner sanity check — 91% on log-likelihood — while Theta stays
-the most CRPS-competitive of the cheap baselines (68%). Passing this is the minimum bar
+laplace clears the M3-winner sanity check — ~87% on log-likelihood — while Theta stays
+the most CRPS-competitive of the cheap baselines (~63%). Passing this is the minimum bar
 for a new distributional forecaster; laplace passes comfortably on the density metric.

--- a/benchmarks/comparisons/overnight_sweep.sh
+++ b/benchmarks/comparisons/overnight_sweep.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Long-running benchmark sweep with auto-resume. Appends to STUDY_RESULTS, which
+# is resumable (per series+method), so a kill/restart never loses or re-scores
+# work. Every knob below is overridable via the environment before launching.
+#
+# Requires the FRED cache in benchmarks/data/ (rsync it between machines) OR a
+# FRED_API_KEY to fetch (drop STUDY_CACHED_ONLY then). R opponents need
+# install.packages(c("forecast","smooth","rugarch","bsts")); absent ones drop out.
+#
+# Launch (macOS, prevent sleep):
+#   caffeinate -is bash benchmarks/comparisons/overnight_sweep.sh &
+# Launch (Linux):
+#   nohup bash benchmarks/comparisons/overnight_sweep.sh &
+set -u
+cd "$(dirname "$0")/../.." || exit 1              # repo root
+
+: "${STUDY_CACHED_ONLY:=1}"                        # 0 + FRED_API_KEY to fetch instead
+: "${STUDY_MAX_QUALIFY:=2600}"
+: "${BENCH_R_REFITS:=25}"                          # single cadence: nnetar/adam per-step cost doesn't amortize
+: "${BENCH_SF_REFITS:=25}"
+: "${BENCH_R_MAX:=2600}"; : "${BENCH_SF_MAX:=2600}"; : "${BENCH_GARCH_MAX:=2600}"
+: "${BENCH_R_SKIP:=bsts-R}"                        # bsts refits MCMC every step — too slow for volume
+: "${STUDY_ONLY:=laplace,R@25,statsforecast@25,CSP,GARCH-t}"
+: "${STUDY_RESULTS:=benchmarks/comparisons/_shared_R25.csv}"
+: "${OVERNIGHT_LOG:=benchmarks/comparisons/_overnight.log}"
+: "${MAX_RESUMES:=200}"
+export STUDY_CACHED_ONLY STUDY_MAX_QUALIFY BENCH_R_REFITS BENCH_SF_REFITS \
+       BENCH_R_MAX BENCH_SF_MAX BENCH_GARCH_MAX BENCH_R_SKIP STUDY_ONLY STUDY_RESULTS
+
+echo "[sweep] start $(date) -> $STUDY_RESULTS  opponents=$STUDY_ONLY" | tee -a "$OVERNIGHT_LOG"
+n=0
+until PYTHONPATH=src python benchmarks/study.py sota >>"$OVERNIGHT_LOG" 2>&1; do
+  n=$((n + 1)); echo "[sweep] non-zero exit; resume $n at $(date)" | tee -a "$OVERNIGHT_LOG"
+  [ "$n" -ge "$MAX_RESUMES" ] && { echo "[sweep] giving up after $n" | tee -a "$OVERNIGHT_LOG"; break; }
+  sleep 15
+done
+echo "[sweep] finished $(date) after $n resumes" | tee -a "$OVERNIGHT_LOG"

--- a/benchmarks/comparisons/run_comparison.py
+++ b/benchmarks/comparisons/run_comparison.py
@@ -1,0 +1,39 @@
+"""Run laplace vs. a single opponent set, into that comparison's own folder.
+
+    PYTHONPATH=src python benchmarks/comparisons/run_comparison.py <slug> <opp> [<opp> ...]
+
+`<slug>` is the folder under comparisons/ (e.g. laplace-vs-adam); the remaining
+args are opponent *names* from the registry (e.g. R@25, statsforecast@25, CSP,
+GARCH-t). laplace is always included. Results go to comparisons/<slug>/results.csv
+and the same one-harness summary is printed (paste it into that folder's README).
+
+Nothing new is scored: it's the `sota` study with STUDY_ONLY restricting the
+opponent set and STUDY_RESULTS pointing at the folder — the one honest harness,
+one slice at a time.
+"""
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_BENCH = os.path.dirname(_HERE)
+sys.path.insert(0, _BENCH)
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__)
+        return 1
+    slug, opps = argv[0], argv[1:]
+    folder = os.path.join(_HERE, slug)
+    os.makedirs(folder, exist_ok=True)
+    os.environ["STUDY_ONLY"] = ",".join(["laplace"] + opps)
+    os.environ["STUDY_RESULTS"] = os.path.join(folder, "results.csv")
+    print(f"[comparison] {slug}: laplace vs {opps}")
+    print(f"[comparison] results -> {os.environ['STUDY_RESULTS']}\n")
+    import study
+    study.run("sota")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/benchmarks/opponents.py
+++ b/benchmarks/opponents.py
@@ -372,6 +372,11 @@ qgrid <- function(point, lower, upper, levels) {
   out
 }
 
+# BENCH_R_SKIP=name1,name2 drops those methods (e.g. skip the slow bsts-R for a
+# high-throughput sweep). Empty by default -> run everything available.
+SKIP <- strsplit(Sys.getenv("BENCH_R_SKIP", ""), ",")[[1]]
+skip <- function(nm) nm %in% SKIP
+
 have_forecast <- requireNamespace("forecast", quietly = TRUE)
 have_smooth   <- requireNamespace("smooth",   quietly = TRUE)
 have_rugarch  <- requireNamespace("rugarch",  quietly = TRUE)
@@ -385,6 +390,7 @@ if (have_bsts)     suppressMessages(library(bsts))
 # history; the realized value python-y[t] is scored on the Python side. fc_fn(m)
 # returns list(mu,sd) -> emitG, or list(q=<TAUS-ordered values>) -> emitQ.
 run_reuse <- function(name, refit_fn, reuse_fn, fc_fn) {
+  if (skip(name)) return(invisible())
   fit <- NULL
   for (t in start:(n - 1)) {
     win <- y[max(1L, t - fitwin + 1L):t]
@@ -413,7 +419,7 @@ if (have_forecast) {
                        sd = sdband(as.numeric(f$lower)[1], as.numeric(f$upper)[1])) })
 
   # Theta (M3 winner): Gaussian predictive; cheap, refit every step.
-  for (t in start:(n - 1)) {
+  if (!skip("Theta-R")) for (t in start:(n - 1)) {
     win <- y[max(1L, t - fitwin + 1L):t]
     if (length(win) < 20) next
     f <- tryCatch(thetaf(win, h = 1, level = 90), error = function(e) NULL)
@@ -442,7 +448,7 @@ if (have_smooth) {
                                  as.numeric(f$lower[1, ]), as.numeric(f$upper[1, ]), LEVELS)) })
 }
 
-if (have_rugarch) {
+if (have_rugarch && !skip("GARCH-t-R")) {
   # GARCH(1,1)-t: heavy-tail conditional predictive; quantiles straight from the
   # fitted Student-t (mu + sigma * t_nu quantile). The R counterpart to arch's GARCH-t.
   spec <- ugarchspec(variance.model = list(model = "sGARCH", garchOrder = c(1, 1)),
@@ -465,7 +471,7 @@ if (have_rugarch) {
   }
 }
 
-if (have_bsts) {
+if (have_bsts && !skip("bsts-R")) {
   # BSTS (Bayesian local level): posterior-predictive draws => sample quantiles.
   # No online update — a fresh short MCMC each step, so keep its max_series tiny.
   niter <- as.integer(Sys.getenv("BENCH_BSTS_NITER", "300"))

--- a/benchmarks/opponents.py
+++ b/benchmarks/opponents.py
@@ -78,10 +78,12 @@ except Exception:                              # noqa: BLE001
     _HAVE_SF = False
 
 
-def _statsforecast_predict(ch, start, refit):
+def _statsforecast_predict(ch, start, refit, suffix=""):
     """One rolling-1-step CV yields AutoARIMA & AutoETS (Gaussian from the 90%
     band) AND the AutoARIMA-mean conformal + ACI variants (split-conformal over
-    AutoARIMA residuals). The fitted-mean counterpart to the naive crepes."""
+    AutoARIMA residuals). The fitted-mean counterpart to the naive crepes.
+    `refit` is the CV refit cadence (the accuracy/speed knob); `suffix` tags the
+    emitted method names when the same models are swept across cadences."""
     y = np.asarray(ch, float); n = len(y)
     nw = n - start
     if nw < 30:
@@ -117,14 +119,29 @@ def _statsforecast_predict(ch, start, refit):
             aci *= 1.0 + 0.02 * ((0.0 if lo2 <= yt <= hi2 else 1.0) - 0.10)
             aci = min(max(aci, 0.2), 5.0)
         resid.append(yt - pt)
-    return [(m, lp / k, cr / k, k) for m, (lp, cr, k) in out.items() if k]
+    return [(m + suffix, lp / k, cr / k, k) for m, (lp, cr, k) in out.items() if k]
 
 
-STATSFORECAST = ([Opponent("statsforecast", _statsforecast_predict,
-                           max_series=int(os.environ.get("BENCH_SF_MAX", 800)),
-                           methods=["AutoARIMA", "AutoETS",
-                                    "AutoARIMA+conformal", "AutoARIMA+ACI"])]
-                 if _HAVE_SF else [])
+# Same accuracy/speed sweep as the R stack: AutoARIMA refits are the cost, so
+# register the CV at a few cadences (`BENCH_SF_REFITS`, shares the `5,25,100`
+# default) — AutoARIMA-py@5/@25/@100 then sit on the *same* refit-cadence axis as
+# auto.arima-R, port vs. real thing at matched cost. (AutoETS is cheap, its curve
+# is near-flat.)
+_SF_METHODS = ("AutoARIMA", "AutoETS", "AutoARIMA+conformal", "AutoARIMA+ACI")
+_SF_REFITS = [int(x) for x in os.environ.get("BENCH_SF_REFITS", "5,25,100").split(",")]
+
+
+def _make_sf(refit_val):
+    suffix = f"@{refit_val}"
+
+    def predict(ch, start, refit=None):        # ignore the preset refit; bake our own
+        return _statsforecast_predict(ch, start, refit_val, suffix=suffix)
+    return Opponent(f"statsforecast{suffix}", predict,
+                    max_series=int(os.environ.get("BENCH_SF_MAX", 800)),
+                    methods=[m + suffix for m in _SF_METHODS])
+
+
+STATSFORECAST = [_make_sf(r) for r in _SF_REFITS] if _HAVE_SF else []
 
 
 # ---- GARCH(1,1)-t (arch) ------------------------------------------------------
@@ -298,16 +315,335 @@ PROPHET = ([Opponent("Prophet", _prophet_predict, int(os.environ.get("BENCH_PROP
            if _HAVE_PROPHET else [])
 
 
+# ---- R (compound): the *actual* R forecast stack, not a Python port -----------
+# One Rscript per series runs the rolling one-step CV in R and prints one line per
+# scored step: `method,t,G,mu;sd` (a Gaussian predictive) or `method,t,Q,q1;q2;…`
+# (a quantile grid at the shared TAUS levels, for a genuinely non-Gaussian
+# predictive). Python rebuilds the matching Dist — Dist.gaussian or bc.grid_dist —
+# and scores it through the one scorer. Gated on `Rscript` on PATH; each method is
+# gated inside R on its package, so a missing package just drops that method:
+#   forecast -> auto.arima-R, Theta-R (Gaussian), nnetar-R (simulated => quantiles)
+#   smooth   -> ADAM-R (assumed-distribution predictive => quantiles)
+#   rugarch  -> GARCH-t-R (Student-t conditional predictive => quantiles)
+#   bsts     -> bsts-R (posterior-predictive draws => quantiles)
+# Install: R, then `install.packages(c("forecast","smooth","rugarch","bsts"))`
+# (forecast+smooth are the core; rugarch/bsts are optional heavier opponents).
+import shutil
+import subprocess
+import tempfile
+
+_RSCRIPT = shutil.which("Rscript")
+
+# Canonical predictive-quantile grid, shared with the R side (must match exactly).
+_R_TAUS = [0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5,
+           0.6, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.975, 0.99]
+
+_R_SRC = r'''
+suppressWarnings(suppressMessages({
+args <- commandArgs(trailingOnly = TRUE)
+datafile <- args[1]
+start  <- as.integer(args[2])   # 0-based python index of the first scored step
+refit  <- as.integer(args[3])
+fitwin <- as.integer(args[4])
+y <- scan(datafile, quiet = TRUE)
+n <- length(y)
+z90 <- 1.6448536269514722
+
+# Shared quantile grid; LEVELS = the two-sided central-interval %s it needs.
+TAUS <- c(0.01,0.025,0.05,0.1,0.15,0.2,0.25,0.3,0.4,0.5,
+          0.6,0.7,0.75,0.8,0.85,0.9,0.95,0.975,0.99)
+LEVELS <- sort(unique(round(abs(1 - 2 * TAUS[TAUS != 0.5]) * 100, 6)))
+
+emitG <- function(method, t, mu, sd)
+  cat(sprintf("%s,%d,G,%.10g;%.10g\n", method, t, mu, sd))
+emitQ <- function(method, t, qs)
+  cat(sprintf("%s,%d,Q,%s\n", method, t, paste(sprintf("%.10g", qs), collapse = ";")))
+sdband <- function(lo, hi) max((hi - lo) / (2 * z90), 1e-9)
+
+# Assemble a TAUS-ordered quantile vector from a fan of central intervals + point.
+qgrid <- function(point, lower, upper, levels) {
+  out <- numeric(length(TAUS))
+  for (i in seq_along(TAUS)) {
+    tau <- TAUS[i]
+    if (isTRUE(all.equal(tau, 0.5))) { out[i] <- point; next }
+    L <- round(abs(1 - 2 * tau) * 100, 6); j <- which(levels == L)[1]
+    out[i] <- if (tau < 0.5) lower[j] else upper[j]
+  }
+  out
+}
+
+have_forecast <- requireNamespace("forecast", quietly = TRUE)
+have_smooth   <- requireNamespace("smooth",   quietly = TRUE)
+have_rugarch  <- requireNamespace("rugarch",  quietly = TRUE)
+have_bsts     <- requireNamespace("bsts",     quietly = TRUE)
+if (have_forecast) suppressMessages(library(forecast))
+if (have_smooth)   suppressMessages(library(smooth))
+if (have_rugarch)  suppressMessages(library(rugarch))
+if (have_bsts)     suppressMessages(library(bsts))
+
+# t iterates python 0-based indices start..n-1. The first t obs (R y[1:t]) are the
+# history; the realized value python-y[t] is scored on the Python side. fc_fn(m)
+# returns list(mu,sd) -> emitG, or list(q=<TAUS-ordered values>) -> emitQ.
+run_reuse <- function(name, refit_fn, reuse_fn, fc_fn) {
+  fit <- NULL
+  for (t in start:(n - 1)) {
+    win <- y[max(1L, t - fitwin + 1L):t]
+    if (length(win) < 20) next
+    if (is.null(fit) || ((t - start) %% refit == 0L)) {
+      fit <- tryCatch(refit_fn(win), error = function(e) NULL); m <- fit
+    } else {
+      m <- tryCatch(reuse_fn(win, fit), error = function(e)
+             tryCatch(refit_fn(win), error = function(e2) NULL))
+    }
+    if (is.null(m)) next
+    r <- tryCatch(fc_fn(m), error = function(e) NULL)
+    if (is.null(r)) next
+    if (!is.null(r$q)) emitQ(name, t, r$q) else emitG(name, t, r$mu, r$sd)
+  }
+}
+
+if (have_forecast) {
+  # auto.arima: exactly-Gaussian predictive -> emit mean+sd (the band is exact).
+  # Reuse fitted orders between refits via Arima(model=) (refilter, no re-estimate).
+  run_reuse("auto.arima-R",
+    function(win) auto.arima(win),
+    function(win, fit) Arima(win, model = fit),
+    function(m) { f <- forecast(m, h = 1, level = 90)
+                  list(mu = as.numeric(f$mean)[1],
+                       sd = sdband(as.numeric(f$lower)[1], as.numeric(f$upper)[1])) })
+
+  # Theta (M3 winner): Gaussian predictive; cheap, refit every step.
+  for (t in start:(n - 1)) {
+    win <- y[max(1L, t - fitwin + 1L):t]
+    if (length(win) < 20) next
+    f <- tryCatch(thetaf(win, h = 1, level = 90), error = function(e) NULL)
+    if (!is.null(f)) emitG("Theta-R", t, as.numeric(f$mean)[1],
+                           sdband(as.numeric(f$lower)[1], as.numeric(f$upper)[1]))
+  }
+
+  # NNETAR (nonlinear autoregression): simulated predictive => real non-Gaussian
+  # quantiles. Reuse the trained net between refits via nnetar(model=).
+  run_reuse("nnetar-R",
+    function(win) nnetar(win),
+    function(win, fit) nnetar(win, model = fit),
+    function(m) { f <- forecast(m, h = 1, PI = TRUE, level = LEVELS, npaths = 400)
+                  list(q = qgrid(as.numeric(f$mean)[1],
+                                 as.numeric(f$lower[1, ]), as.numeric(f$upper[1, ]), LEVELS)) })
+}
+
+if (have_smooth) {
+  # ADAM (Svetunkov): state-space auto ETS/ARIMA with an assumed (possibly
+  # non-Gaussian) distribution — score its real quantiles, not a Gaussian band.
+  run_reuse("ADAM-R",
+    function(win) adam(win, model = "ZZZ"),
+    function(win, fit) adam(win, model = fit),
+    function(m) { f <- forecast(m, h = 1, interval = "prediction", level = LEVELS / 100)
+                  list(q = qgrid(as.numeric(f$mean)[1],
+                                 as.numeric(f$lower[1, ]), as.numeric(f$upper[1, ]), LEVELS)) })
+}
+
+if (have_rugarch) {
+  # GARCH(1,1)-t: heavy-tail conditional predictive; quantiles straight from the
+  # fitted Student-t (mu + sigma * t_nu quantile). The R counterpart to arch's GARCH-t.
+  spec <- ugarchspec(variance.model = list(model = "sGARCH", garchOrder = c(1, 1)),
+                     mean.model = list(armaOrder = c(0, 0), include.mean = TRUE),
+                     distribution.model = "std")
+  gfit <- NULL
+  for (t in start:(n - 1)) {
+    win <- y[max(1L, t - fitwin + 1L):t]
+    if (length(win) < 60) next
+    if (is.null(gfit) || ((t - start) %% refit == 0L))
+      gfit <- tryCatch(ugarchfit(spec, win, solver = "hybrid"), error = function(e) NULL)
+    if (is.null(gfit)) next
+    r <- tryCatch({
+      fc <- ugarchforecast(gfit, n.ahead = 1)
+      mu <- as.numeric(fitted(fc))[1]; sg <- as.numeric(sigma(fc))[1]
+      nu <- coef(gfit)[["shape"]]
+      mu + sg * qdist("std", p = TAUS, mu = 0, sigma = 1, shape = nu)
+    }, error = function(e) NULL)
+    if (!is.null(r)) emitQ("GARCH-t-R", t, r)
+  }
+}
+
+if (have_bsts) {
+  # BSTS (Bayesian local level): posterior-predictive draws => sample quantiles.
+  # No online update — a fresh short MCMC each step, so keep its max_series tiny.
+  niter <- as.integer(Sys.getenv("BENCH_BSTS_NITER", "300"))
+  for (t in start:(n - 1)) {
+    win <- y[max(1L, t - fitwin + 1L):t]
+    if (length(win) < 40) next
+    r <- tryCatch({
+      md <- bsts(win, state.specification = AddLocalLevel(list(), win),
+                 niter = niter, ping = 0, seed = 1)
+      pr <- predict(md, horizon = 1, burn = as.integer(niter / 3))
+      as.numeric(quantile(as.numeric(pr$distribution), probs = TAUS))
+    }, error = function(e) NULL)
+    if (!is.null(r)) emitQ("bsts-R", t, r)
+  }
+}
+}))
+'''
+
+_R_PATH = None
+if _RSCRIPT:
+    try:
+        _fd, _R_PATH = tempfile.mkstemp(suffix=".R", prefix="skaters_rbench_")
+        with os.fdopen(_fd, "w") as _f:
+            _f.write(_R_SRC)
+    except Exception:                          # noqa: BLE001
+        _R_PATH = None
+
+
+_R_METHODS = ("auto.arima-R", "Theta-R", "nnetar-R", "ADAM-R", "GARCH-t-R", "bsts-R")
+
+
+def _r_line_dist(kind, payload):
+    """Parse one R output line's predictive into a Dist: `G`->Gaussian(mu,sd),
+    `Q`->grid_dist over the shared _R_TAUS. Returns None if unusable."""
+    if kind == "G":
+        mu_s, sd_s = payload.split(";")
+        mu = float(mu_s); sd = max(float(sd_s), 1e-9)
+        return Dist.gaussian(mu, sd) if np.isfinite(mu) and np.isfinite(sd) else None
+    if kind == "Q":
+        qs = [float(x) for x in payload.split(";")]
+        if len(qs) != len(_R_TAUS):
+            return None
+        return bc.grid_dist(_R_TAUS, qs)
+    return None
+
+
+def _r_predict(ch, start, refit, suffix=""):
+    if not (_RSCRIPT and _R_PATH):
+        return []
+    y = np.asarray(ch, float); n = len(y)
+    if n - start < 30:
+        return []
+    tf = tempfile.NamedTemporaryFile("w", suffix=".dat", delete=False)
+    try:
+        tf.write("\n".join("%.12g" % float(v) for v in y)); tf.close()
+        proc = subprocess.run(
+            [_RSCRIPT, "--vanilla", _R_PATH, tf.name, str(start), str(refit), str(FIT_WIN)],
+            capture_output=True, text=True,
+            timeout=int(os.environ.get("BENCH_R_TIMEOUT", 1800)))
+    except Exception:                          # noqa: BLE001
+        return []
+    finally:
+        try:
+            os.unlink(tf.name)
+        except OSError:
+            pass
+    out = {}
+    for line in proc.stdout.splitlines():
+        parts = line.split(",")
+        if len(parts) != 4:
+            continue
+        method, t_s, kind, payload = parts
+        try:
+            t = int(t_s)
+        except ValueError:
+            continue
+        if not (0 <= t < n):
+            continue
+        try:
+            d = _r_line_dist(kind, payload)
+        except ValueError:
+            continue
+        if d is None:
+            continue
+        a, b = bc.score_dist(d, y[t])
+        acc = out.setdefault(method + suffix, [0.0, 0.0, 0])
+        acc[0] += a; acc[1] += b; acc[2] += 1
+    return [(m, lp / k, cr / k, k) for m, (lp, cr, k) in out.items() if k]
+
+
+# Refit cadence is the key accuracy/speed meta-variable: auto.arima and ADAM
+# reuse the fitted model between refits, so a coarse cadence is far cheaper and
+# (usually) a little less accurate. Register the R stack at a few cadences so the
+# frontier plot shows each model's own accuracy-vs-speed curve, not one point.
+# (Theta refits every step regardless, so its cadence knob is a near-flat line.)
+_R_REFITS = [int(x) for x in os.environ.get("BENCH_R_REFITS", "5,25,100").split(",")]
+
+
+def _make_r(refit_val):
+    suffix = f"@{refit_val}"
+
+    def predict(ch, start, refit=None):        # ignore the preset refit; bake our own
+        return _r_predict(ch, start, refit_val, suffix=suffix)
+    return Opponent(f"R{suffix}", predict,
+                    max_series=int(os.environ.get("BENCH_R_MAX", 120)),
+                    methods=[m + suffix for m in _R_METHODS])
+
+
+R = [_make_r(r) for r in _R_REFITS] if _RSCRIPT else []
+
+
+# ---- CSP: Conformal Seasonal Pools (Manokhin, arXiv:2605.03789) ----------------
+# Training-free: the predictive pool mixes same-season empirical draws with signed
+# residual draws around a seasonal-naive forecast. It's a predictive-distribution
+# *sampler*, not just an interval builder, so — like the fitted conformal_dist — we
+# KDE-smooth the pool into a Dist (Silverman bandwidth) and score BOTH logpdf and
+# CRPS. The tails are empirical/thin (the same caveat as any conformal foil). Pure
+# numpy, zero deps, so it always loads. `CSP-adaptive` widens/narrows the pool by
+# recent 90% hit-rate (ACI-style), the paper's adaptive variant.
+CSP_M   = int(os.environ.get("BENCH_CSP_M", 7))       # season period (weekly on daily FRED)
+CSP_WIN = int(os.environ.get("BENCH_CSP_WIN", 750))   # capped look-back per step
+
+
+def _csp_dist(s, m, nq=41, scale=1.0):
+    """Predictive Dist for the step right after the contiguous window `s`."""
+    s = np.asarray(s, float); L = len(s)
+    if L <= m + 5:
+        return None
+    i = np.arange(L)
+    same = s[i[i % m == L % m]]                        # same-season past draws
+    snaive = s[L - m]                                  # seasonal-naive point
+    resid = s[m:] - s[:-m]                             # seasonal-naive residuals
+    pool = np.concatenate([same, snaive + scale * resid, snaive - scale * resid])
+    if pool.size < 5:
+        return None
+    qs = np.quantile(pool, np.linspace(0.02, 0.98, nq))
+    iqr = np.quantile(pool, 0.75) - np.quantile(pool, 0.25)
+    spread = (iqr / 1.349) if iqr > 0 else (pool.max() - pool.min()) or 1.0
+    h = max(0.9 * spread * pool.size ** (-0.2), 1e-9)  # Silverman
+    return Dist([(1.0 / nq, float(q), h) for q in qs])
+
+
+def _csp_predict(ch, start, refit=None):
+    y = np.asarray(ch, float); n = len(y)
+    lp = cr = 0.0; m = 0
+    lpa = cra = 0.0; ma = 0; scale = 1.0
+    for t in range(start, n):
+        win = y[max(0, t - CSP_WIN):t]
+        d = _csp_dist(win, CSP_M)
+        if d is not None:
+            a, b = bc.score_dist(d, y[t]); lp += a; cr += b; m += 1
+        da = _csp_dist(win, CSP_M, scale=scale)
+        if da is not None:
+            aa, bb = bc.score_dist(da, y[t]); lpa += aa; cra += bb; ma += 1
+            lo, hi = da.quantile(0.05), da.quantile(0.95)
+            scale *= 1.0 + 0.02 * ((0.0 if lo <= y[t] <= hi else 1.0) - 0.10)
+            scale = min(max(scale, 0.2), 5.0)
+    out = []
+    if m:
+        out.append(("CSP", lp / m, cr / m, m))
+    if ma:
+        out.append(("CSP-adaptive", lpa / ma, cra / ma, ma))
+    return out
+
+
+CSP = [Opponent("CSP", _csp_predict, methods=["CSP", "CSP-adaptive"])]
+
+
 # ---- registry & named opponent sets -------------------------------------------
-ALL = OURS + CONFORMAL_NAIVE + STATSFORECAST + GARCH + STATSMODELS + NF + PROPHET
+ALL = OURS + CONFORMAL_NAIVE + STATSFORECAST + GARCH + STATSMODELS + NF + PROPHET + R + CSP
 REGISTRY = {op.name: op for op in ALL}
 
 SETS = {
     # cheap, scales to the whole daily universe
-    "conformal-scale": [op.name for op in OURS] + [op.name for op in CONFORMAL_NAIVE],
+    "conformal-scale": [op.name for op in OURS] + [op.name for op in CONFORMAL_NAIVE + CSP],
     # the heavy SOTA opponents (small universe); ours + everything installed
     "sota": [op.name for op in OURS] + [op.name for op in
-             (CONFORMAL_NAIVE + STATSFORECAST + GARCH + STATSMODELS + NF + PROPHET)],
+             (CONFORMAL_NAIVE + STATSFORECAST + GARCH + STATSMODELS + NF + PROPHET + R + CSP)],
 }
 
 

--- a/benchmarks/study.py
+++ b/benchmarks/study.py
@@ -145,6 +145,10 @@ def _done_methods(results):
 def run(preset):
     cfg = _cfg(preset)
     opps = opp.resolve(opp.SETS[cfg["opponents"]])
+    only = os.environ.get("STUDY_ONLY")            # restrict to these opponent names
+    if only:                                       # (comparison folders use this)
+        keep = {s.strip() for s in only.split(",") if s.strip()}
+        opps = [o for o in opps if o.name in keep]
     results = cfg["results"]
     print(f"[{preset}] opponents: {[o.name for o in opps]}", flush=True)
     print(f"[{preset}] {WORKERS} workers, window={cfg['window']}"
@@ -277,8 +281,9 @@ def summarize(preset, titles=None):
             return min(vs) if vs else float("nan")
         wins = [1.0 if by[s]["laplace"][1] < best_crepes(by[s]) else 0.0
                 for s in by if "laplace" in by[s] and not math.isnan(best_crepes(by[s]))]
-        print(f"\n  laplace beats best-of-crepes (its best window per series): "
-              f"{100*sum(wins)/len(wins):.1f}% of {len(wins)} series")
+        if wins:                               # crepes may be listed but uninstalled (N=0)
+            print(f"\n  laplace beats best-of-crepes (its best window per series): "
+                  f"{100*sum(wins)/len(wins):.1f}% of {len(wins)} series")
 
     print("\n  mean logpdf (ours; crepes emits no density):")
     for m in OURS:


### PR DESCRIPTION
## What

Extends the dev-only benchmark harness with new opponents and structure. Package stays zero-dependency — everything here is gated and dev-only.

### New opponents
- **Real R forecast stack** (gated on `Rscript` + each package), one `Rscript` per series doing the rolling one-step CV:
  - `auto.arima-R`, `Theta-R` — exactly-Gaussian predictive (mean+sd, band is exact)
  - `nnetar-R`, `ADAM-R`, `GARCH-t-R`, `bsts-R` — genuinely non-Gaussian, scored on their **real quantiles** via a new quantile-grid output path (`bc.grid_dist`)
  - Value over the existing `statsforecast` Python port: the actual Hyndman `auto.arima`, plus Theta (M3 winner), ADAM (Svetunkov, the strongest classical *distributional* forecaster), NNETAR, rugarch GARCH-t, and BSTS — several with no clean Python twin.
- **CSP** — Conformal Seasonal Pools (Manokhin, arXiv:2605.03789). Pure numpy; KDE-smoothed into a `Dist` so it's scored on **log-likelihood as well as CRPS** — a CRPS-tuned method doesn't get to duck the density test.

### Refit-cadence sweep
Refit frequency is the key accuracy/speed knob (auto.arima and ADAM reuse the fit between refits). Both the R stack and `statsforecast` now register at `@5/@25/@100`, so each model draws its own accuracy-vs-speed curve on the frontier instead of one point.

### Comparison folders
`benchmarks/comparisons/` — one folder per matchup with a brief writeup, plus `run_comparison.py` that restricts the `sota` study to laplace + one opponent (`STUDY_ONLY`). Provisional results (N=44, first-scored cached slice) are written into the READMEs.

### Bug fix
`ZeroDivisionError` in `study.summarize` when a listed method has N=0 (e.g. an uninstalled opponent).

## Provisional results (N=44, rates/FX-heavy first slice — laplace win-rate)

| opponent | CRPS all/cont | LL all/cont |
|---|---|---|
| auto.arima-R@25 | 55/51% | **82/79%** |
| Theta-R@25 | 68/67% | **91/90%** |
| nnetar-R@25 | 82/82% | **98/97%** |
| ADAM-R@25 | 82/82% | **98/97%** |
| CSP / CSP-adaptive | 100/100% | 100/100% |

The `auto.arima-R` row is the story: near-tie on CRPS, clear laplace win on log-likelihood — the CRPS-vs-likelihood distinction in one line. GARCH left blank pending the price/non-price split (its only scored series so far are its home turf).

## Testing
All six R methods verified emitting and scoring on real FRED series; `grid_dist` round-trips a Gaussian; full comparison flow verified end-to-end; py_compile clean. R stack needs `install.packages(c("forecast","smooth","rugarch","bsts"))`; absent packages drop out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)