### PR TITLE
Fix robustness page: top-bar label CSS collision with .mid

### DIFF
--- a/benchmarks/comparisons/make_robustness_page.py
+++ b/benchmarks/comparisons/make_robustness_page.py
@@ -187,7 +187,7 @@ PAGE = r"""<title>Non-price robustness explorer — skaters</title>
     padding:10px 0 18px;font-family:var(--mono);font-size:12px;color:var(--muted)}
   .topbar a{color:var(--accent);text-decoration:none}
   .topbar a:hover{text-decoration:underline}
-  .topbar .mid{color:var(--faint);letter-spacing:.08em;text-transform:uppercase}
+  .topbar .crumb{color:var(--faint);letter-spacing:.08em;text-transform:uppercase;white-space:nowrap}
   header{border-bottom:1px solid var(--line);padding-bottom:20px;margin-bottom:24px}
   .eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;
     color:var(--accent);margin:0 0 8px}
@@ -263,7 +263,7 @@ PAGE = r"""<title>Non-price robustness explorer — skaters</title>
 <div class="wrap">
   <nav class="topbar">
     <a href="/">← skaters</a>
-    <span class="mid">non-price robustness explorer</span>
+    <span class="crumb">non-price robustness explorer</span>
     <a href="https://github.com/microprediction/skaters">GitHub</a>
   </nav>
   <header>


### PR DESCRIPTION
The top-bar centre label used `class="mid"`, colliding with the win-rate/frontier `.mid` 50%-reference-line rule (`position:absolute; left:50%; width:1px; height:full`). That turned the label into a stray full-height vertical bar with its text crushed one word per line. Renamed to `.crumb` + `white-space:nowrap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)