### PR TITLE
Open Graph tags for the project site

### DIFF
--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -4,6 +4,15 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>skaters — interactive demos</title>
+  <meta name="description" content="Watch laplace forecast live in the browser: the uncertainty band, the k-step fan, the transform paths, and the clocks being mixed." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters — interactive demos" />
+  <meta property="og:description" content="Watch laplace forecast live in the browser: the uncertainty band, the k-step fan, the transform paths, and the clocks being mixed." />
+  <meta property="og:url" content="https://skaters.microprediction.org/demos/" />
+  <meta property="og:image" content="https://skaters.microprediction.org/assets/frontier.png" />
+  <meta property="og:image:alt" content="Accuracy vs speed: laplace has the best held-out likelihood at a fraction of the baselines' runtime." />
+  <meta name="twitter:card" content="summary_large_image" />
   <link rel="stylesheet" href="../academic.css" />
 </head>
 <body>

--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -4,6 +4,15 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>skaters — forecasting playground</title>
+  <meta name="description" content="A live in-browser demonstration of the laplace forecaster: pick a data regime and watch the predictive distribution, transform paths, and scale mixture adapt." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters — forecasting playground" />
+  <meta property="og:description" content="A live in-browser demonstration of the laplace forecaster: pick a data regime and watch the predictive distribution, transform paths, and scale mixture adapt." />
+  <meta property="og:url" content="https://skaters.microprediction.org/demos/playground.html" />
+  <meta property="og:image" content="https://skaters.microprediction.org/assets/frontier.png" />
+  <meta property="og:image:alt" content="Accuracy vs speed: laplace has the best held-out likelihood at a fraction of the baselines' runtime." />
+  <meta name="twitter:card" content="summary_large_image" />
   <link rel="stylesheet" href="../academic.css" />
   <style>
     .weights-panel { margin-top: 14px; }

--- a/docs/demos/pyodide.html
+++ b/docs/demos/pyodide.html
@@ -4,6 +4,15 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>skaters — running in Pyodide</title>
+  <meta name="description" content="The pure-Python package running unmodified in Pyodide, live in the browser." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters — Python in the browser" />
+  <meta property="og:description" content="The pure-Python package running unmodified in Pyodide, live in the browser." />
+  <meta property="og:url" content="https://skaters.microprediction.org/demos/pyodide.html" />
+  <meta property="og:image" content="https://skaters.microprediction.org/assets/frontier.png" />
+  <meta property="og:image:alt" content="Accuracy vs speed: laplace has the best held-out likelihood at a fraction of the baselines' runtime." />
+  <meta name="twitter:card" content="summary_large_image" />
   <link rel="stylesheet" href="../academic.css" />
 </head>
 <body>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -4,6 +4,15 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>skaters — guide</title>
+  <meta name="description" content="The Dist object, composable transforms, conjugation, and the terminal-leaf ensemble — how online distributional forecasting composes." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters — guide" />
+  <meta property="og:description" content="The Dist object, composable transforms, conjugation, and the terminal-leaf ensemble — how online distributional forecasting composes." />
+  <meta property="og:url" content="https://skaters.microprediction.org/guide.html" />
+  <meta property="og:image" content="https://skaters.microprediction.org/assets/frontier.png" />
+  <meta property="og:image:alt" content="Accuracy vs speed: laplace has the best held-out likelihood at a fraction of the baselines' runtime." />
+  <meta name="twitter:card" content="summary_large_image" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" crossorigin="anonymous">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" crossorigin="anonymous"

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,15 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>skaters — fast online univariate time series</title>
+  <meta name="description" content="One call, zero dependencies, every prediction a full probability distribution — online, in pure Python and JavaScript. Wins the held-out likelihood race against AutoARIMA, AutoETS, conformal, GARCH-t and zero-shot foundation models on non-price economic series." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters — fast online distributional forecasting" />
+  <meta property="og:description" content="One call, zero dependencies, every prediction a full probability distribution — online, in pure Python and JavaScript. Wins the held-out likelihood race against AutoARIMA, AutoETS, conformal, GARCH-t and zero-shot foundation models on non-price economic series." />
+  <meta property="og:url" content="https://skaters.microprediction.org/" />
+  <meta property="og:image" content="https://skaters.microprediction.org/assets/frontier.png" />
+  <meta property="og:image:alt" content="Accuracy vs speed: laplace has the best held-out likelihood at a fraction of the baselines' runtime." />
+  <meta name="twitter:card" content="summary_large_image" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" crossorigin="anonymous">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" crossorigin="anonymous"

--- a/docs/papers.html
+++ b/docs/papers.html
@@ -4,6 +4,15 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>skaters — papers &amp; benchmarks</title>
+  <meta name="description" content="The paper and the benchmark studies: twelve distributional baselines, foundation models, multi-step horizons, and the martingality gradient." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters — papers & benchmarks" />
+  <meta property="og:description" content="The paper and the benchmark studies: twelve distributional baselines, foundation models, multi-step horizons, and the martingality gradient." />
+  <meta property="og:url" content="https://skaters.microprediction.org/papers.html" />
+  <meta property="og:image" content="https://skaters.microprediction.org/assets/frontier.png" />
+  <meta property="og:image:alt" content="Accuracy vs speed: laplace has the best held-out likelihood at a fraction of the baselines' runtime." />
+  <meta name="twitter:card" content="summary_large_image" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" crossorigin="anonymous">
   <link rel="stylesheet" href="./academic.css" />
 </head>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -4,6 +4,15 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>skaters — Claude skills</title>
+  <meta name="description" content="Code-review and benchmarking skills for using skaters well." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters — Claude skills" />
+  <meta property="og:description" content="Code-review and benchmarking skills for using skaters well." />
+  <meta property="og:url" content="https://skaters.microprediction.org/skills.html" />
+  <meta property="og:image" content="https://skaters.microprediction.org/assets/frontier.png" />
+  <meta property="og:image:alt" content="Accuracy vs speed: laplace has the best held-out likelihood at a fraction of the baselines' runtime." />
+  <meta name="twitter:card" content="summary_large_image" />
   <link rel="stylesheet" href="./academic.css" />
   <style>
     .skill-copy { margin: 22px 0; padding-bottom: 18px; border-bottom: 1px solid var(--border, #e6e6ef); }


### PR DESCRIPTION
Sharing pypi.org/project/skaters on LinkedIn unfurls as Cloudflare's "Client Challenge" (their crawler is bot-blocked at PyPI's edge — not fixable from this repo). This adds `og:title`/`og:description`/`og:image` (+ twitter card) to every page of the project site so **https://skaters.microprediction.org** is the shareable link and unfurls with the frontier chart.

The paper's lattice paragraph also just gained measured atom-width sensitivity numbers (separate commit to follow with the msw table swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)