### PR TITLE
Parade: PIT/z calibration state + anomaly-detection and residual-review skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ f = laplace(k=1, objective="likelihood")  # pure-likelihood leaf
 f = laplace(k=1, sticky=False)            # no lattice projection
 ```
 
+**Calibration state, free.** Every arriving point is resolved against the
+forecasts previously made *for it*: `state["pit"][m-1]` is its probability
+integral transform under the m-step-ahead predictive issued m steps ago
+(roughly Uniform(0,1) when calibrated) and `state["z"][m-1]` the same through
+the standard-normal quantile (roughly N(0,1) — so `abs(z) > 4` is an anomaly
+detector with no extra compute; z is clamped to ±7.03, never infinite). See
+the [anomaly-detection skill](https://skaters.microprediction.org/skills.html#anomaly-detection).
+
 **Price/return series** (`garch_leaf`). The default terminal leaf tracks its scale
 with an EWMA (RiskMetrics/IGARCH — no variance mean-reversion). For series with
 volatility *clustering and reversion* (equity/fx/commodity returns), swap in a

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -57,6 +57,12 @@
           uncertainty band update live, with rolling log-likelihood and coverage.
           Native JavaScript — instant and offline.</p>
       </a>
+      <a class="card" href="./normalization.html">
+        <h3>Running normalization →</h3>
+        <p>One ugly stream, two normalizers. A rolling z-score smears, fattens, and
+          scars; <code>laplace</code>'s calibration state turns the same points into
+          the same N(0,1) bell every time — and anything with |z| &gt; 4 earned it.</p>
+      </a>
       <a class="card" href="./pyodide.html">
         <h3>Running in Pyodide →</h3>
         <p>The actual Python package, compiled to WebAssembly, running unmodified in

--- a/docs/demos/normalization.html
+++ b/docs/demos/normalization.html
@@ -1,0 +1,308 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>skaters — running normalization</title>
+  <meta name="description" content="The same ugly stream, two normalizers: a rolling z-score stays ugly; laplace's calibration state turns it into the same N(0,1) bell every time." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters — running normalization" />
+  <meta property="og:description" content="The same ugly stream, two normalizers: a rolling z-score stays ugly; laplace's calibration state turns it into the same N(0,1) bell every time." />
+  <meta property="og:url" content="https://skaters.microprediction.org/demos/normalization.html" />
+  <meta property="og:image" content="https://skaters.microprediction.org/assets/frontier.png" />
+  <meta property="og:image:alt" content="Accuracy vs speed: laplace has the best held-out likelihood at a fraction of the baselines' runtime." />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="stylesheet" href="../academic.css" />
+  <style>
+    .histo-row { display: flex; gap: 18px; flex-wrap: wrap; margin-top: 14px; }
+    .histo-cell { flex: 1 1 300px; min-width: 300px; }
+    .histo-title { font-size: 0.9rem; font-weight: 600; margin-bottom: 4px; }
+    .histo-sub { font-weight: 400; color: #888; font-size: 0.8rem; }
+    .stats { font-size: 0.82rem; color: #666; font-variant-numeric: tabular-nums; margin-top: 4px; }
+    .stats b { color: #1a1a1a; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="nav-inner">
+      <a class="brand" href="/">skaters</a>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/demos/">Demos</a>
+        <a href="/guide.html">Guide</a>
+        <a href="/faq.html">FAQ</a>
+        <a href="/papers.html">Papers</a>
+        <a href="/skills.html">Skills</a>
+        <a href="https://github.com/microprediction/skaters">GitHub</a>
+        <a href="https://pypi.org/project/skaters/">PyPI</a>
+        <a href="https://www.npmjs.com/package/skaters">npm</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <h1>Running normalization</h1>
+    <p class="subtitle">
+      One ugly stream, two normalizers. The joke: whatever you feed it, the same
+      bell comes out.
+    </p>
+
+    <div class="panel">
+      <div class="controls">
+        <div class="control">
+          <label for="regime">Data</label>
+          <select id="regime">
+            <option value="multiplicative">multiplicative (level-dependent noise)</option>
+            <option value="jumps">level jumps</option>
+            <option value="hetero">slowly-varying noise</option>
+            <option value="trend">trend + noise</option>
+            <option value="seasonal">seasonal (period 7)</option>
+            <option value="rw">random walk</option>
+            <option value="meanrevert">weak mean reversion</option>
+            <option value="sqrtvar">variance ∝ level (√ coord)</option>
+            <option value="longmem">long memory (fractional)</option>
+          </select>
+        </div>
+        <div class="control">
+          <label for="speed">Speed <span class="val" id="speedVal">4</span></label>
+          <input type="range" id="speed" min="1" max="20" value="4" />
+        </div>
+        <button class="btn" id="run">Regenerate</button>
+        <button class="btn secondary" id="pause">Pause</button>
+      </div>
+
+      <canvas class="plot" id="strip" width="940" height="120"></canvas>
+      <p class="status" id="status">—</p>
+
+      <div class="histo-row">
+        <div class="histo-cell">
+          <div class="histo-title">What goes in
+            <span class="histo-sub">— rolling z-score of the raw stream (window 30): what naive standardisation gives you</span></div>
+          <canvas class="plot" id="histNaive" width="450" height="240"></canvas>
+          <div class="stats" id="statNaive">—</div>
+        </div>
+        <div class="histo-cell">
+          <div class="histo-title">What comes out
+            <span class="histo-sub">— <code>state["z"]</code>: the PIT of each point under the forecast made for it, through Φ⁻¹</span></div>
+          <canvas class="plot" id="histZ" width="450" height="240"></canvas>
+          <div class="stats" id="statZ">—</div>
+        </div>
+      </div>
+      <div class="legend">
+        <span><span class="swatch" style="background:#9a9aa6"></span>rolling z-score</span>
+        <span><span class="swatch" style="background:#4a3aff"></span>laplace z</span>
+        <span><span class="swatch" style="background:#1a1a1a; height:2px; margin-bottom:5px"></span>N(0,1)</span>
+      </div>
+    </div>
+
+    <p>
+      Both panels normalize the <em>same</em> observations onto the same axis.
+      The left panel divides by a trailing standard deviation — so trends smear
+      it sideways, volatility bursts fatten its tails, and jumps leave scars for
+      thirty steps. The right panel is <code>laplace</code>'s calibration state:
+      each arriving point's probability integral transform under the predictive
+      distribution issued <em>for</em> it, mapped through the standard-normal
+      quantile. Because the model has already absorbed the trend, the
+      volatility clock, the seasonality, and the coordinate, what remains is
+      (roughly) pure N(0,1) innovation — <em>running normalization</em>. That
+      residue is also an anomaly detector: anything with |z| &gt; 4 earned it.
+    </p>
+    <p>
+      Pick the multiplicative or jumps regime for the full effect. The bars are
+      recomputed live as the stream reveals; the black curve never changes.
+    </p>
+  </main>
+
+  <footer>
+    <a href="https://github.com/microprediction/skaters">Source</a> &middot;
+    Part of the <a href="https://github.com/microprediction">microprediction</a> family
+    (see also <a href="http://thurstone.microprediction.org">thurstone</a>,
+    <a href="http://schur.microprediction.org">schur</a>).
+  </footer>
+
+  <script type="module">
+    import { laplace } from "../js/skaters/index.mjs";
+
+    // Reproducible-but-varied RNG (mulberry32). Seed bumps each regenerate.
+    function rng(seed) {
+      return function () {
+        seed |= 0; seed = (seed + 0x6D2B79F5) | 0;
+        let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+    function gauss(r) {
+      let u = 0, v = 0;
+      while (u === 0) u = r();
+      while (v === 0) v = r();
+      return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+    }
+
+    function makeSeries(regime, seed, n = 600) {
+      const r = rng(seed);
+      if (regime === "longmem") {
+        const d = 0.42, Wn = 140;
+        const wt = [1]; for (let k = 1; k < Wn; k++) wt.push(wt[k - 1] * (d + k - 1) / k);
+        const eps = []; for (let i = 0; i < n + Wn; i++) eps.push(gauss(r));
+        const out = [];
+        for (let t = 0; t < n; t++) { let acc = 0; for (let j = 0; j < Wn; j++) acc += wt[j] * eps[t + Wn - 1 - j]; out.push(acc); }
+        return out;
+      }
+      const s = [];
+      let lvl = 0, logv = Math.log(40), sq = 200;
+      for (let t = 0; t < n; t++) {
+        if (regime === "trend") s.push(0.06 * t + 2 * gauss(r));
+        else if (regime === "seasonal") s.push(5 * Math.sin((2 * Math.PI * t) / 7) + gauss(r));
+        else if (regime === "rw") { lvl += gauss(r); s.push(lvl); }
+        else if (regime === "meanrevert") { lvl += 0.04 * (0 - lvl) + 1.2 * gauss(r); s.push(lvl); }
+        else if (regime === "multiplicative") { logv += 0.06 * gauss(r); s.push(Math.exp(logv)); }
+        else if (regime === "sqrtvar") { sq = Math.max(sq + 1.2 * Math.sqrt(Math.max(sq, 1)) * gauss(r), 1); s.push(sq); }
+        else if (regime === "hetero") {
+          const sigma = Math.exp(Math.log(0.3) + (Math.log(3) - Math.log(0.3)) * (0.5 + 0.5 * Math.sin((2 * Math.PI * t) / 120)));
+          s.push(gauss(r) * sigma);
+        } else if (regime === "jumps") {
+          if (t % 60 === 0) lvl += 12 * (r() - 0.5);
+          s.push(lvl + gauss(r));
+        }
+      }
+      return s;
+    }
+
+    let rows = [], cursor = 0, timer = null, seed = 1, paused = false;
+
+    function compute() {
+      const regime = document.getElementById("regime").value;
+      const series = makeSeries(regime, seed);
+      const f = laplace(1);
+      let state = null;
+      const W = 30;                       // naive rolling window
+      rows = [];
+      for (let t = 0; t < series.length; t++) {
+        const y = series[t];
+        // naive rolling z-score BEFORE absorbing y (same information set as laplace)
+        let naive = null;
+        if (t >= W) {
+          const win = series.slice(t - W, t);
+          const mu = win.reduce((a, b) => a + b, 0) / W;
+          const sd = Math.sqrt(win.reduce((a, b) => a + (b - mu) * (b - mu), 0) / W);
+          if (sd > 1e-12) naive = Math.max(-8, Math.min(8, (y - mu) / sd));
+        }
+        const [, st] = f(y, state);
+        state = st;
+        rows.push({ y, naive, z: st.z[0] });
+      }
+      cursor = 1;
+    }
+
+    // --- drawing -----------------------------------------------------------
+    const stripC = document.getElementById("strip"), stripX = stripC.getContext("2d");
+    const nC = document.getElementById("histNaive"), nX = nC.getContext("2d");
+    const zC = document.getElementById("histZ"), zX = zC.getContext("2d");
+    const LO = -5, HI = 5, BINS = 40;
+
+    function drawStrip(upto) {
+      const W = stripC.width, H = stripC.height, PAD = 10;
+      stripX.clearRect(0, 0, W, H);
+      const view = rows.slice(0, upto);
+      let mn = Infinity, mx = -Infinity;
+      for (const r of view) { mn = Math.min(mn, r.y); mx = Math.max(mx, r.y); }
+      if (!isFinite(mn) || mx === mn) { mn -= 1; mx += 1; }
+      const X = (i) => PAD + (i / (rows.length - 1)) * (W - 2 * PAD);
+      const Y = (v) => H - PAD - ((v - mn) / (mx - mn)) * (H - 2 * PAD);
+      stripX.fillStyle = "#1a1a1a";
+      for (let i = 0; i < view.length; i++) {
+        stripX.beginPath(); stripX.arc(X(i), Y(view[i].y), 1.2, 0, 2 * Math.PI); stripX.fill();
+      }
+    }
+
+    function drawHist(ctx, canvas, values, color, statsEl) {
+      const W = canvas.width, H = canvas.height, PAD = 26;
+      ctx.clearRect(0, 0, W, H);
+      const bins = new Array(BINS).fill(0);
+      let n = 0, sum = 0, sum2 = 0, big = 0;
+      for (const v of values) {
+        if (v === null) continue;
+        const b = Math.max(0, Math.min(BINS - 1, Math.floor(((v - LO) / (HI - LO)) * BINS)));
+        bins[b] += 1; n += 1; sum += v; sum2 += v * v;
+        if (Math.abs(v) > 3) big += 1;
+      }
+      const X = (v) => PAD + ((v - LO) / (HI - LO)) * (W - 2 * PAD);
+      // N(0,1) reference: convert density to expected bin share
+      const binw = (HI - LO) / BINS;
+      const phi = (x) => Math.exp(-0.5 * x * x) / Math.sqrt(2 * Math.PI);
+      let ymax = phi(0) * binw * 1.35;
+      if (n) for (const b of bins) ymax = Math.max(ymax, (b / n) * 1.08);
+      const Y = (share) => H - PAD - (share / ymax) * (H - 2 * PAD);
+      // baseline
+      ctx.strokeStyle = "#e2e2e2"; ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(PAD, H - PAD); ctx.lineTo(W - PAD, H - PAD); ctx.stroke();
+      // bars
+      if (n) {
+        ctx.fillStyle = color;
+        for (let b = 0; b < BINS; b++) {
+          if (!bins[b]) continue;
+          const x0 = X(LO + b * binw), x1 = X(LO + (b + 1) * binw);
+          const y = Y(bins[b] / n);
+          ctx.fillRect(x0 + 0.5, y, (x1 - x0) - 1, H - PAD - y);
+        }
+      }
+      // N(0,1) overlay
+      ctx.strokeStyle = "#1a1a1a"; ctx.lineWidth = 1.6; ctx.setLineDash([5, 3]);
+      ctx.beginPath();
+      for (let i = 0; i <= 160; i++) {
+        const v = LO + (i / 160) * (HI - LO);
+        const y = Y(phi(v) * binw);
+        if (i === 0) ctx.moveTo(X(v), y); else ctx.lineTo(X(v), y);
+      }
+      ctx.stroke(); ctx.setLineDash([]);
+      // tick labels
+      ctx.fillStyle = "#888"; ctx.font = "11px sans-serif"; ctx.textAlign = "center";
+      for (const v of [-4, -2, 0, 2, 4]) ctx.fillText(String(v), X(v), H - PAD + 14);
+      // stats
+      if (n) {
+        const mean = sum / n, sd = Math.sqrt(Math.max(sum2 / n - mean * mean, 0));
+        statsEl.innerHTML = `n <b>${n}</b> &nbsp; mean <b>${mean.toFixed(2)}</b> &nbsp; std <b>${sd.toFixed(2)}</b> &nbsp; |z|&gt;3 <b>${(100 * big / n).toFixed(1)}%</b> <span style="color:#aaa">(N(0,1): 0.3%)</span>`;
+      } else statsEl.textContent = "—";
+    }
+
+    function frame() {
+      const view = rows.slice(0, cursor);
+      drawStrip(cursor);
+      drawHist(nX, nC, view.map((r) => r.naive), "#9a9aa6", document.getElementById("statNaive"));
+      drawHist(zX, zC, view.map((r) => r.z), "#4a3aff", document.getElementById("statZ"));
+      document.getElementById("status").textContent = `step ${cursor} / ${rows.length}`;
+    }
+
+    function tick() {
+      if (paused) return;
+      const step = parseInt(document.getElementById("speed").value, 10);
+      cursor = Math.min(rows.length, cursor + step);
+      frame();
+      if (cursor < rows.length) timer = requestAnimationFrame(tick);
+    }
+
+    function start() {
+      if (timer) cancelAnimationFrame(timer);
+      compute();
+      paused = false;
+      document.getElementById("pause").textContent = "Pause";
+      timer = requestAnimationFrame(tick);
+    }
+
+    document.getElementById("run").addEventListener("click", () => { seed++; start(); });
+    document.getElementById("regime").addEventListener("change", start);
+    document.getElementById("speed").addEventListener("input", (e) => {
+      document.getElementById("speedVal").textContent = e.target.value;
+    });
+    document.getElementById("pause").addEventListener("click", (e) => {
+      paused = !paused;
+      e.target.textContent = paused ? "Resume" : "Pause";
+      if (!paused) timer = requestAnimationFrame(tick);
+    });
+
+    start();
+  </script>
+</body>
+</html>

--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -250,8 +250,9 @@
         // each decimation stride is scored by its trailing one-step logpdf on
         // its own clock; the horizon then mixes eligible scales by these weights.
         let scaleW = null;
-        if (st && st.score) {
-          const entries = Object.entries(st.score);
+        const msState = st && st.base && st.base.score ? st.base : st;   // parade wraps multiscale
+        if (msState && msState.score) {
+          const entries = Object.entries(msState.score);
           const vals = entries.map(([, m]) => m).filter((m) => m !== null);
           if (vals.length) {
             const top = Math.max(...vals);

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,6 +95,17 @@
       <a href="/papers.html">The foundation study →</a>
     </div>
 
+    <div class="callout">
+      <strong>Anomaly detection falls out for free.</strong> Every arriving point is scored
+      against the forecast that was made <em>for it</em>: the state carries its probability
+      integral transform (<code>state["pit"]</code>, ~Uniform when the stream behaves) and its
+      normalized surprise (<code>state["z"]</code>, ~N(0,1)) at every horizon — running
+      normalization with no extra compute, and a threshold on |z| is an anomaly detector
+      calibrated by construction.
+      <a href="/demos/normalization.html">See it live →</a> ·
+      <a href="/skills.html#anomaly-detection">the skill →</a>
+    </div>
+
     <p>
       <code>pip install skaters</code>. Every prediction is a <code>Dist</code> — a weighted
       Gaussian mixture carrying the mean, the spread, quantiles, and a density at once. You build

--- a/docs/js/skaters/api.mjs
+++ b/docs/js/skaters/api.mjs
@@ -8,6 +8,7 @@ import { terminalLeafEnsemble } from "./terminal.mjs";
 import { bayesianEnsemble } from "./bayesian.mjs";
 import { sticky as project } from "./sticky.mjs";
 import { multiscale } from "./multiscale.mjs";
+import { parade } from "./parade.mjs";
 import {
   difference, fractionalDifference, standardize, emaTransform, ouTransform, drift,
   holtLinear, ar, theta, seasonalDifference, garch, powerTransform, yeoJohnson,
@@ -162,7 +163,8 @@ function laplaceSingleScale(k, objective, sticky) {
 // (default {1, ceil(sqrt(k)), k}), horizons mix eligible scales by likelihood.
 // Pass scales = [1] for the single-scale (native fan-out) variant.
 export function laplace(k = 1, objective = "crps", sticky = true, scales = null) {
-  const f = multiscale((kk) => laplaceSingleScale(kk, objective, sticky), k, { scales });
+  // parade adds state.pit / state.z calibration diagnostics (see parade.mjs)
+  const f = parade(multiscale((kk) => laplaceSingleScale(kk, objective, sticky), k, { scales }), k);
   f.skaterName = `laplace(k=${k})`;
   return f;
 }

--- a/docs/js/skaters/index.mjs
+++ b/docs/js/skaters/index.mjs
@@ -22,6 +22,7 @@ export {
   buildCandidates, laplace,
 } from "./api.mjs";
 export { multiscale } from "./multiscale.mjs";
+export { parade } from "./parade.mjs";
 export { sticky } from "./sticky.mjs";
 export {
   build, name as specName, toJson, fromJson,

--- a/docs/js/skaters/package.json
+++ b/docs/js/skaters/package.json
@@ -35,7 +35,10 @@
     "garch",
     "zero-dependency",
     "browser",
-    "microprediction"
+    "microprediction",
+    "anomaly-detection",
+    "calibration",
+    "pit"
   ],
   "homepage": "https://skaters.microprediction.org",
   "repository": {

--- a/docs/js/skaters/parade.mjs
+++ b/docs/js/skaters/parade.mjs
@@ -1,0 +1,45 @@
+// The prediction parade — JS port of skaters/parade.py.
+//
+// Resolve each arriving observation against the predictions previously made
+// for it: state.pit[m-1] is the PIT of y under the m-step-ahead predictive
+// issued m steps ago (roughly Uniform(0,1) when calibrated); state.z[m-1] is
+// the same through the standard-normal quantile (roughly N(0,1)). Entries are
+// null until horizon m has matured. Pass-through for the forecasts themselves.
+// Named for the prediction parade of the timemachines package.
+
+import { Dist } from "./dist.mjs";
+
+const STD_NORMAL = Dist.gaussian(0.0, 1.0);
+// Clamp the PIT away from {0,1}: |z| is then bounded by ~7.03 and the
+// bisection in Dist.quantile stays inside its +-8 sigma bracket. No input can
+// produce an infinite z. Non-finite CDF values leave the entry null.
+const EPS = 1e-12;
+
+export function parade(base, k) {
+  return function skater(y, state) {
+    if (state === null || state === undefined) {
+      state = { base: null, pending: [], pit: new Array(k).fill(null), z: new Array(k).fill(null) };
+    }
+    const pend = state.pending;
+    const n = pend.length;
+    const pit = new Array(k).fill(null);
+    const z = new Array(k).fill(null);
+    for (let m = 1; m <= k; m++) {
+      if (m <= n) {
+        const d = pend[n - m][m - 1];      // issued m steps ago, horizon m
+        let u = d.cdf(y);
+        if (!Number.isFinite(u)) continue; // degenerate predictive or bad y
+        u = Math.min(Math.max(u, EPS), 1.0 - EPS);
+        pit[m - 1] = u;
+        z[m - 1] = STD_NORMAL.quantile(u);
+      }
+    }
+    const [dists, st] = base(y, state.base);
+    state.base = st;
+    pend.push(dists.slice());
+    if (pend.length > k) pend.shift();
+    state.pit = pit;
+    state.z = z;
+    return [dists, state];
+  };
+}

--- a/docs/scope.html
+++ b/docs/scope.html
@@ -55,6 +55,20 @@
       a good <em>monitor</em> — the always-on distributional layer under a system
       that has better things to spend attention on.
     </p>
+    <p>
+      <strong>Anomaly detection falls out for free.</strong> Because every
+      prediction is a density, every arriving point gets a probability integral
+      transform against the forecast that was made <em>for it</em>: the state
+      carries <code>state["pit"]</code> (roughly Uniform when the stream is
+      behaving) and <code>state["z"]</code> (roughly N(0,1)) at every horizon
+      1..k, resolved online with no extra compute. A |z| of five is an anomaly
+      by construction — scored against a model that has already adapted to the
+      stream's drift, volatility clock, seasonality, and coordinate, which is
+      precisely what separates an anomaly from a regime the model should have
+      learned. Multi-horizon agreement (the same point surprising at h = 1, 5,
+      and 20) separates one-off spikes from genuine breaks. See the
+      <a href="/skills.html#anomaly-detection">anomaly-detection skill</a>.
+    </p>
 
     <h2>The objections it is not refuted by</h2>
     <p>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -518,6 +518,190 @@ a paper without edits, the page is done.
 </code></pre>
       </details>
     </div>
+    <div class="skill-copy">
+      <div class="skill-copy-head">
+        <h2 id="anomaly-detection"><code>anomaly-detection</code></h2>
+        <button class="btn copy-btn" data-target="src-anomaly-detection">Copy skill</button>
+      </div>
+      <p class="skill-label">Online anomaly detection from the calibration state: every point is scored against the forecast made <em>for it</em> — thresholds on ~N(0,1) z's, multi-horizon break confirmation, CUSUM drifts.</p>
+      <details>
+        <summary>Show the skill (markdown) · or <a href="https://github.com/microprediction/skaters/blob/main/skills/anomaly-detection.md">view on GitHub</a></summary>
+        <pre id="src-anomaly-detection"><code># anomaly-detection skill
+
+When asked to detect anomalies, outliers, or regime breaks in a univariate
+stream, use `skaters.laplace` — not a rolling z-score, not an isolation forest
+on one column, not a hand-tuned threshold on raw values. The reason is the
+denominator: an anomaly is only meaningful *relative to a forecast*, and a
+rolling mean ± kσ is a bad forecast. `laplace` adapts online to drift, the
+volatility clock, seasonality, and coordinate, so what remains surprising is
+actually surprising.
+
+```
+pip install skaters
+```
+
+## The whole detector
+
+Every prediction is a density, so calibration diagnostics come with the state
+for free — no extra compute, no second pass:
+
+```python
+from skaters import laplace
+
+f = laplace(k=1)
+state = None
+for y in stream:
+    dists, state = f(y, state)
+    z = state["z"][0]          # y scored against the forecast made FOR it:
+    if z is not None and abs(z) &gt; 4:
+        alert(y, z)            # ~N(0,1) when the stream is behaving
+```
+
+`state["pit"][m-1]` is the probability integral transform of the arriving
+point under the m-step-ahead predictive issued m steps ago — roughly
+Uniform(0,1) on a well-behaved stream. `state["z"][m-1]` is the same value
+through the standard-normal quantile — roughly N(0,1), so `|z|` reads directly
+as "how many sigmas of surprise". Entries are `None` for the first m steps and
+whenever the predictive can't score the point; `|z|` is clamped to ≈7.03, so
+thresholds never race an infinity.
+
+## Choosing the rule
+
+- **Point anomalies**: `|z| &gt; 4` is a defensible default (one-in-16,000 under
+  calibration). `|z| &gt; 3` on noisy ops data pages someone every day; know that
+  going in.
+- **Regime breaks vs one-off spikes**: run `laplace(k=20)` and require the
+  surprise to agree across horizons — a spike is anomalous at `m=1` and
+  forgotten by `m=20`; a break is anomalous at every matured horizon at once
+  (`all(abs(z) &gt; 3 for z in state["z"] if z is not None)`).
+- **Slow drifts the model keeps absorbing**: CUSUM the z's
+  (`S = max(0, S + z - 0.5)`; alarm on `S &gt; 8`). Individual z's stay modest
+  while their sum marches.
+- **One-sided risk** (only crashes matter): threshold `state["pit"][0] &lt; 1e-4`
+  instead of `|z|` — the PIT is the tail probability itself.
+
+## Trust, but verify the detector
+
+Before believing any threshold, check calibration on YOUR stream: collect a few
+hundred `state["pit"][0]` values from a quiet period and eyeball the histogram.
+Flat means the z-thresholds mean what they say. U-shaped means the model is
+overconfident there (heavier tails than it thinks — raise the threshold);
+hump-shaped means underconfident (alarms will be rare and late).
+
+Two caveats. On **grid/repeating series** (posted prices, policy rates) the
+lattice projection places near-Dirac mass on revisited values, so PITs cluster
+at the atom edges — threshold on `pit`, not `z`, and treat "off-lattice at all"
+as the event. On **price/return series** volatility clusters: a 4σ day inside
+a volatility storm is less anomalous than the same move in a calm — `laplace`
+tracks this through its volatility transforms, which is exactly why raw-value
+thresholds are the wrong tool.
+
+## What NOT to do
+
+- Don't z-score against a rolling window of raw values: trends and volatility
+  clustering guarantee both false alarms and missed breaks.
+- Don't threshold the forecast *error* (`y - mean`): without the predictive's
+  own spread it's meaningless across regimes.
+- Don't tune thresholds to reproduce a labelled incident list you were handed —
+  fit the model, verify calibration, then let the tail probability be the tail
+  probability.
+</code></pre>
+      </details>
+    </div>
+    <div class="skill-copy">
+      <div class="skill-copy-head">
+        <h2 id="residual-review"><code>residual-review</code></h2>
+        <button class="btn copy-btn" data-target="src-residual-review">Copy skill</button>
+      </div>
+      <p class="skill-label">Review any model by forecasting its residuals. If <code>laplace</code> beats GARCH-t on them, your model is leaving conditional-mean signal on the table. You might have work to do regardless.</p>
+      <details>
+        <summary>Show the skill (markdown) · or <a href="https://github.com/microprediction/skaters/blob/main/skills/residual-review.md">view on GitHub</a></summary>
+        <pre id="src-residual-review"><code># residual-review skill
+
+When asked to review, validate, or stress-test a forecasting model — any model,
+any library — run this test before reading a line of its code: **feed its
+residuals to `skaters.laplace` and see who wins.**
+
+A model's residuals are its confession. If they were truly done — no mean
+structure, no volatility structure the model missed — nothing could forecast
+them. So forecast them:
+
+```
+pip install skaters
+```
+
+```python
+from skaters import laplace
+
+def residual_review(residuals, burn=300):
+    """Score laplace and a frozen-Gaussian baseline on YOUR model's residuals."""
+    import math, statistics
+    mu, sd = statistics.mean(residuals[:burn]), statistics.pstdev(residuals[:burn])
+    f = laplace(k=1); state = None; pend = None
+    lap = base = 0.0; n = 0
+    for i, r in enumerate(residuals):
+        if pend is not None and i &gt;= burn:
+            lap += pend.logpdf(r)
+            base += -0.5 * math.log(2 * math.pi * sd * sd) - (r - mu) ** 2 / (2 * sd * sd)
+            n += 1
+        d, state = f(r, state); pend = d[0]
+    return {"laplace": lap / n, "frozen_gaussian": base / n, "gap_nats": (lap - base) / n}
+```
+
+## Reading the verdict
+
+- **`laplace` beats a frozen Gaussian on your residuals** (`gap_nats &gt; ~0.02`):
+  there is *structure of some kind* left — drift, autocorrelation, volatility
+  clustering, seasonality, a wrong coordinate. You have work to do.
+- **`laplace` beats `GARCH-t` on your residuals**: this is the sharper verdict.
+  On the martingality gradient, `laplace` beats `GARCH-t` precisely where a
+  series has exploitable *mean* structure (it wins 78% of the most
+  mean-predictable series and 10% of pure-noise-like price returns). So if
+  `laplace` outforecasts the volatility specialist on your residuals, your
+  model is leaving conditional-mean signal on the table — the one thing a
+  forecaster is least entitled to leave behind. Fit `arch`'s
+  `arch_model(resid, dist="t")` rolling one-step as the opponent, score both
+  on held-out log-likelihood via the same `Dist` interface.
+- **`GARCH-t` beats `laplace`, and both beat the frozen Gaussian**: your mean
+  model is fine; your *error model* is wrong. The residuals have a volatility
+  clock (heteroscedasticity) your model's constant-variance intervals ignore.
+  Your point forecasts survive; your uncertainty bands do not.
+- **Nobody beats the frozen Gaussian**: congratulations — and suspicion. Check
+  the test isn't leaking (fit and evaluation on the same window) before
+  celebrating, because residuals this clean are rarer than they should be.
+
+You might have work to do regardless: this test only sees what is forecastable
+*from the residual stream itself*. Structure explainable by covariates your
+model ignores is invisible here — a pass is necessary, not sufficient.
+
+## The five-minute version
+
+No harness, no baseline — just watch the calibration state:
+
+```python
+f = laplace(k=1); state = None
+zs = []
+for r in residuals:
+    _, state = f(r, state)
+    if state["z"][0] is not None:
+        zs.append(state["z"][0])
+```
+
+If `laplace`'s one-step z's on your residuals have `std(zs)` meaningfully below
+1, `laplace` found predictability (its forecasts were sharper than the
+residuals' marginal spread). A PIT histogram of `state["pit"][0]` that isn't
+flat says the same thing in shape: U-shaped = your residuals have fat tails it
+exploited; skewed = a drift your model misses.
+
+## Etiquette
+
+Report the gap in nats per observation, the burn-in, and the window — not just
+the winner. A 0.005-nat win is a rounding error; a 0.2-nat win is a bug in the
+reviewed model. And run the review on *held-out* residuals: reviewing in-sample
+residuals flatters everyone.
+</code></pre>
+      </details>
+    </div>
   </main>
 
   <footer>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ license = "MIT"
 authors = [
     { name = "Peter Cotton", email = "peter.cotton@microprediction.com" }
 ]
+keywords = [
+    "time series", "forecasting", "online", "distributional", "probabilistic",
+    "anomaly detection", "calibration", "pit", "crps", "quantile", "pyodide",
+]
 requires-python = ">=3.10"
 dependencies = []
 

--- a/skills/anomaly-detection.md
+++ b/skills/anomaly-detection.md
@@ -1,0 +1,79 @@
+# anomaly-detection skill
+
+When asked to detect anomalies, outliers, or regime breaks in a univariate
+stream, use `skaters.laplace` — not a rolling z-score, not an isolation forest
+on one column, not a hand-tuned threshold on raw values. The reason is the
+denominator: an anomaly is only meaningful *relative to a forecast*, and a
+rolling mean ± kσ is a bad forecast. `laplace` adapts online to drift, the
+volatility clock, seasonality, and coordinate, so what remains surprising is
+actually surprising.
+
+```
+pip install skaters
+```
+
+## The whole detector
+
+Every prediction is a density, so calibration diagnostics come with the state
+for free — no extra compute, no second pass:
+
+```python
+from skaters import laplace
+
+f = laplace(k=1)
+state = None
+for y in stream:
+    dists, state = f(y, state)
+    z = state["z"][0]          # y scored against the forecast made FOR it:
+    if z is not None and abs(z) > 4:
+        alert(y, z)            # ~N(0,1) when the stream is behaving
+```
+
+`state["pit"][m-1]` is the probability integral transform of the arriving
+point under the m-step-ahead predictive issued m steps ago — roughly
+Uniform(0,1) on a well-behaved stream. `state["z"][m-1]` is the same value
+through the standard-normal quantile — roughly N(0,1), so `|z|` reads directly
+as "how many sigmas of surprise". Entries are `None` for the first m steps and
+whenever the predictive can't score the point; `|z|` is clamped to ≈7.03, so
+thresholds never race an infinity.
+
+## Choosing the rule
+
+- **Point anomalies**: `|z| > 4` is a defensible default (one-in-16,000 under
+  calibration). `|z| > 3` on noisy ops data pages someone every day; know that
+  going in.
+- **Regime breaks vs one-off spikes**: run `laplace(k=20)` and require the
+  surprise to agree across horizons — a spike is anomalous at `m=1` and
+  forgotten by `m=20`; a break is anomalous at every matured horizon at once
+  (`all(abs(z) > 3 for z in state["z"] if z is not None)`).
+- **Slow drifts the model keeps absorbing**: CUSUM the z's
+  (`S = max(0, S + z - 0.5)`; alarm on `S > 8`). Individual z's stay modest
+  while their sum marches.
+- **One-sided risk** (only crashes matter): threshold `state["pit"][0] < 1e-4`
+  instead of `|z|` — the PIT is the tail probability itself.
+
+## Trust, but verify the detector
+
+Before believing any threshold, check calibration on YOUR stream: collect a few
+hundred `state["pit"][0]` values from a quiet period and eyeball the histogram.
+Flat means the z-thresholds mean what they say. U-shaped means the model is
+overconfident there (heavier tails than it thinks — raise the threshold);
+hump-shaped means underconfident (alarms will be rare and late).
+
+Two caveats. On **grid/repeating series** (posted prices, policy rates) the
+lattice projection places near-Dirac mass on revisited values, so PITs cluster
+at the atom edges — threshold on `pit`, not `z`, and treat "off-lattice at all"
+as the event. On **price/return series** volatility clusters: a 4σ day inside
+a volatility storm is less anomalous than the same move in a calm — `laplace`
+tracks this through its volatility transforms, which is exactly why raw-value
+thresholds are the wrong tool.
+
+## What NOT to do
+
+- Don't z-score against a rolling window of raw values: trends and volatility
+  clustering guarantee both false alarms and missed breaks.
+- Don't threshold the forecast *error* (`y - mean`): without the predictive's
+  own spread it's meaningless across regimes.
+- Don't tune thresholds to reproduce a labelled incident list you were handed —
+  fit the model, verify calibration, then let the tail probability be the tail
+  probability.

--- a/skills/residual-review.md
+++ b/skills/residual-review.md
@@ -1,0 +1,83 @@
+# residual-review skill
+
+When asked to review, validate, or stress-test a forecasting model — any model,
+any library — run this test before reading a line of its code: **feed its
+residuals to `skaters.laplace` and see who wins.**
+
+A model's residuals are its confession. If they were truly done — no mean
+structure, no volatility structure the model missed — nothing could forecast
+them. So forecast them:
+
+```
+pip install skaters
+```
+
+```python
+from skaters import laplace
+
+def residual_review(residuals, burn=300):
+    """Score laplace and a frozen-Gaussian baseline on YOUR model's residuals."""
+    import math, statistics
+    mu, sd = statistics.mean(residuals[:burn]), statistics.pstdev(residuals[:burn])
+    f = laplace(k=1); state = None; pend = None
+    lap = base = 0.0; n = 0
+    for i, r in enumerate(residuals):
+        if pend is not None and i >= burn:
+            lap += pend.logpdf(r)
+            base += -0.5 * math.log(2 * math.pi * sd * sd) - (r - mu) ** 2 / (2 * sd * sd)
+            n += 1
+        d, state = f(r, state); pend = d[0]
+    return {"laplace": lap / n, "frozen_gaussian": base / n, "gap_nats": (lap - base) / n}
+```
+
+## Reading the verdict
+
+- **`laplace` beats a frozen Gaussian on your residuals** (`gap_nats > ~0.02`):
+  there is *structure of some kind* left — drift, autocorrelation, volatility
+  clustering, seasonality, a wrong coordinate. You have work to do.
+- **`laplace` beats `GARCH-t` on your residuals**: this is the sharper verdict.
+  On the martingality gradient, `laplace` beats `GARCH-t` precisely where a
+  series has exploitable *mean* structure (it wins 78% of the most
+  mean-predictable series and 10% of pure-noise-like price returns). So if
+  `laplace` outforecasts the volatility specialist on your residuals, your
+  model is leaving conditional-mean signal on the table — the one thing a
+  forecaster is least entitled to leave behind. Fit `arch`'s
+  `arch_model(resid, dist="t")` rolling one-step as the opponent, score both
+  on held-out log-likelihood via the same `Dist` interface.
+- **`GARCH-t` beats `laplace`, and both beat the frozen Gaussian**: your mean
+  model is fine; your *error model* is wrong. The residuals have a volatility
+  clock (heteroscedasticity) your model's constant-variance intervals ignore.
+  Your point forecasts survive; your uncertainty bands do not.
+- **Nobody beats the frozen Gaussian**: congratulations — and suspicion. Check
+  the test isn't leaking (fit and evaluation on the same window) before
+  celebrating, because residuals this clean are rarer than they should be.
+
+You might have work to do regardless: this test only sees what is forecastable
+*from the residual stream itself*. Structure explainable by covariates your
+model ignores is invisible here — a pass is necessary, not sufficient.
+
+## The five-minute version
+
+No harness, no baseline — just watch the calibration state:
+
+```python
+f = laplace(k=1); state = None
+zs = []
+for r in residuals:
+    _, state = f(r, state)
+    if state["z"][0] is not None:
+        zs.append(state["z"][0])
+```
+
+If `laplace`'s one-step z's on your residuals have `std(zs)` meaningfully below
+1, `laplace` found predictability (its forecasts were sharper than the
+residuals' marginal spread). A PIT histogram of `state["pit"][0]` that isn't
+flat says the same thing in shape: U-shaped = your residuals have fat tails it
+exploited; skewed = a drift your model misses.
+
+## Etiquette
+
+Report the gap in nats per observation, the burn-in, and the window — not just
+the winner. A 0.005-nat win is a rounding error; a 0.2-nat win is a bug in the
+reviewed model. And run the review on *held-out* residuals: reviewing in-sample
+residuals flatters everyone.

--- a/src/skaters/__init__.py
+++ b/src/skaters/__init__.py
@@ -29,6 +29,7 @@ from skaters.search import search
 from skaters.periodicity import period_detector, top_periods
 from skaters.api import laplace
 from skaters.multiscale import multiscale
+from skaters.parade import parade
 from skaters.sticky import sticky
 from skaters.spec import (
     build, name as spec_name, to_json, from_json,
@@ -71,6 +72,7 @@ __all__ = [
     "bayesian_ensemble",
     "terminal_leaf_ensemble",
     "multiscale",
+    "parade",
     "search",
     # Spec system
     "build",

--- a/src/skaters/api.py
+++ b/src/skaters/api.py
@@ -29,6 +29,7 @@ from skaters.transform import (
 )
 from skaters.terminal import terminal_leaf_ensemble
 from skaters.multiscale import multiscale
+from skaters.parade import parade as _parade   # PIT/z calibration state
 from skaters.sticky import sticky as _project  # lattice projection (handles repeats)
 
 
@@ -296,8 +297,16 @@ def laplace(k: int = 1, objective: str = "crps", sticky: bool = True, leaf=None,
         scales: decimation strides for the multi-scale mixture (stride s serves
             horizons h >= s). Default ``{1, ceil(sqrt(k)), k}``; ``[1]`` opts
             out of multi-scale.
+
+    The returned state also carries calibration diagnostics, resolved online
+    against the predictions previously made for each arriving point:
+    ``state["pit"][m-1]`` is the PIT of y under the m-step-ahead predictive
+    issued m steps ago (roughly Uniform(0,1) when calibrated) and
+    ``state["z"][m-1]`` the same through the standard-normal quantile (roughly
+    N(0,1)); ``None`` until horizon m has matured. See :mod:`skaters.parade`.
     """
     f = multiscale(lambda kk: _laplace_single_scale(kk, objective, sticky, leaf),
                    k=k, scales=scales)
+    f = _parade(f, k=k)
     f.__name__ = f"laplace(k={k})"
     return f

--- a/src/skaters/parade.py
+++ b/src/skaters/parade.py
@@ -1,0 +1,61 @@
+"""The prediction parade: online calibration diagnostics in the state.
+
+Each incoming observation is resolved against the predictions previously made
+*for it* — the m-step-ahead predictive issued m steps ago, for m = 1..k. After
+``dists, state = f(y, state)`` on a parade-wrapped skater:
+
+    state["pit"][m-1]   the probability integral transform of y under the
+                        m-step-ahead predictive issued m steps ago — roughly
+                        Uniform(0, 1) when that predictive is calibrated;
+    state["z"][m-1]     the same value pushed through the standard-normal
+                        quantile — roughly N(0, 1) when calibrated, so |z|
+                        reads directly as "how surprising was this point".
+
+Entries are ``None`` until the corresponding prediction has matured (the first
+m observations, for horizon m). The wrapper is pass-through for the forecasts
+themselves: ``dists`` is exactly the base skater's output.
+
+Named for the prediction parade of the ``timemachines`` package, where
+forecasts marched in quarantine until they met their ground truth.
+"""
+
+from __future__ import annotations
+import math
+from collections import deque
+from skaters.dist import Dist
+
+_STD_NORMAL = Dist.gaussian(0.0, 1.0)
+# Clamp the PIT away from {0, 1}: |z| is then bounded by the standard-normal
+# quantile at 1e-12, about 7.03, and the bisection in Dist.quantile stays
+# inside its +-8 sigma bracket. No input can produce an infinite z.
+_EPS = 1e-12
+
+
+def parade(base, k: int):
+    """Wrap ``base`` (a skater emitting k horizons) with PIT/z bookkeeping."""
+
+    def _skater(y: float, state: dict | None) -> tuple[list[Dist], dict]:
+        if state is None:
+            state = {"base": None, "pending": deque(maxlen=k),
+                     "pit": [None] * k, "z": [None] * k}
+        pend = state["pending"]
+        n = len(pend)
+        pit = [None] * k
+        z = [None] * k
+        for m in range(1, k + 1):
+            if m <= n:
+                d = pend[n - m][m - 1]        # issued m steps ago, horizon m
+                u = d.cdf(y)
+                if not math.isfinite(u):      # degenerate predictive or bad y:
+                    continue                  # leave this horizon's entry None
+                u = min(max(u, _EPS), 1.0 - _EPS)
+                pit[m - 1] = u
+                z[m - 1] = _STD_NORMAL.quantile(u)
+        dists, state["base"] = base(y, state["base"])
+        pend.append(list(dists))
+        state["pit"] = pit
+        state["z"] = z
+        return dists, state
+
+    _skater.__name__ = f"parade({getattr(base, '__name__', '?')}, k={k})"
+    return _skater

--- a/tests/test_multiscale.py
+++ b/tests/test_multiscale.py
@@ -26,13 +26,13 @@ def test_single_scale_opt_out():
     f = laplace(5, scales=[1])
     x, state = f(1.0, None)
     assert len(x) == 5
-    assert "score" not in (state or {})   # no multi-scale bookkeeping
+    assert "score" not in (state["base"] or {})   # no multi-scale bookkeeping
 
 
 def test_default_scales_from_k():
     f = laplace(20)
     _, state = f(0.1, None)
-    assert sorted(state["score"]) == [1, 5, 20]
+    assert sorted(state["base"]["score"]) == [1, 5, 20]
 
 
 def test_shapes_and_finiteness():
@@ -64,7 +64,7 @@ def test_scale_scores_populate():
         _, state = f(y, state)
     # every scale has been scored (one phase copy steps per tick, so scoring
     # starts after s ticks for scale s)
-    assert all(m is not None for m in state["score"].values())
+    assert all(m is not None for m in state["base"]["score"].values())
 
 
 def test_coarse_weight_rises_on_fine_noise():
@@ -80,7 +80,7 @@ def test_coarse_weight_rises_on_fine_noise():
         state = None
         for y in ys:
             _, state = f(y, state)
-        return state["score"][1] - state["score"][5]
+        return state["base"]["score"][1] - state["base"]["score"][5]
 
     assert gap(smooth) > gap(noisy)
 

--- a/tests/test_parade.py
+++ b/tests/test_parade.py
@@ -1,0 +1,79 @@
+"""Tests for the prediction parade (PIT/z calibration state)."""
+
+import math
+import random
+from skaters import laplace, parade, leaf
+
+
+def test_shapes_and_warmup():
+    f = laplace(3)
+    state = None
+    d, state = f(0.1, state)
+    assert state["pit"] == [None, None, None]     # nothing matured yet
+    d, state = f(0.2, state)
+    assert state["pit"][0] is not None and state["pit"][1] is None
+    d, state = f(0.3, state)
+    d, state = f(0.4, state)
+    assert all(v is not None for v in state["pit"])
+    assert all(v is not None for v in state["z"])
+    assert len(state["pit"]) == len(state["z"]) == 3
+
+
+def test_pass_through():
+    """The wrapper must not change the forecasts."""
+    random.seed(2)
+    ys = [random.gauss(0, 1) for _ in range(80)]
+    g = leaf(k=2)
+    f = parade(leaf(k=2), k=2)
+    sg = sf = None
+    for y in ys:
+        dg, sg = g(y, sg)
+        df, sf = f(y, sf)
+    assert dg[0].mean == df[0].mean and dg[1].std == df[1].std
+
+
+def test_roughly_uniform_and_normal():
+    random.seed(7)
+    f = laplace(1)
+    state = None
+    us, zs = [], []
+    for i in range(700):
+        _, state = f(random.gauss(0, 1), state)
+        if i >= 100 and state["pit"][0] is not None:
+            us.append(state["pit"][0])
+            zs.append(state["z"][0])
+    n = len(us)
+    assert abs(sum(us) / n - 0.5) < 0.05                       # PIT mean ~ 1/2
+    assert abs(sum(1 for u in us if u < 0.5) / n - 0.5) < 0.07  # median ~ 1/2
+    zbar = sum(zs) / n
+    zstd = math.sqrt(sum((z - zbar) ** 2 for z in zs) / n)
+    assert abs(zbar) < 0.15
+    assert 0.7 < zstd < 1.3
+
+
+def test_horizon_alignment():
+    """z at horizon m must resolve against the prediction made m steps ago:
+    an outlier registers as surprising at every matured horizon at once."""
+    random.seed(11)
+    f = laplace(3)
+    state = None
+    for _ in range(200):
+        _, state = f(random.gauss(0, 0.1), state)
+    _, state = f(25.0, state)                    # a screaming outlier
+    assert all(z is not None and z > 4 for z in state["z"])
+
+
+def test_no_infinities_on_extreme_inputs():
+    """Outliers, constants, and huge jumps must never yield infinite z."""
+    f = laplace(2)
+    state = None
+    stream = [0.0] * 30 + [1e12, -1e12, 0.0, 5.0] + [3.3] * 20 + [float(10 ** 9)]
+    for y in stream:
+        _, state = f(y, state)
+        for z in state["z"]:
+            if z is not None:
+                assert math.isfinite(z)
+                assert abs(z) <= 7.05             # the documented clamp bound
+        for u in state["pit"]:
+            if u is not None:
+                assert 0.0 < u < 1.0


### PR DESCRIPTION
## The feature

`laplace`'s state now carries **online calibration diagnostics**, resolved parade-style (a homage to timemachines): each arriving point is scored against the predictions previously made *for it* —

- `state["pit"][m-1]` — PIT under the m-step-ahead predictive issued m steps ago; ~Uniform(0,1) when calibrated
- `state["z"][m-1]` — the same through the standard-normal quantile; ~N(0,1), so `|z|` reads as sigmas of surprise

for m = 1..k, `None` until horizon m matures. Pass-through for forecasts; O(k) bookkeeping; Python + JS twins.

**No infinities, by construction**: PIT clamped to `[1e-12, 1-1e-12]` bounds `|z| ≤ ~7.03` and keeps the quantile bisection in-bracket; non-finite CDF values leave entries `None` (explicitly guarded — NaN ordering differs between Python `min/max` and JS `Math.min/max`). Test feeds 1e12 jumps and constant runs and asserts finiteness.

Calibration sanity on iid noise: PIT mean 0.501, z mean +0.002, std 0.92.

## The site

- **scope.html**: "anomaly detection falls out for free" paragraph.
- **Keywords**: `anomaly-detection`/`calibration`/`pit` added to npm + pyproject.
- **Two new skills** on skills.html: `anomaly-detection` (z-thresholds, multi-horizon break vs spike, CUSUM, PIT-histogram verification, grid/price caveats) and `residual-review` (feed your model's residuals to laplace; if it beats GARCH-t on them you have conditional-mean work to do — you might have work to do regardless).

Parity OK (104,678 values, 53 scenarios); 619 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)