### PR TITLE
Gate extreme finite inputs at the parade; guard prune against NaN

### DIFF
--- a/src/skaters/dist.py
+++ b/src/skaters/dist.py
@@ -218,6 +218,12 @@ class Dist:
                         break
                 if best_i is not None:
                     break
+            if best_i is None:
+                # Only reachable when a mean is NaN: every comparison above
+                # is False, for the argmin and the threshold scan alike.
+                # Merge the first pair so pruning terminates instead of
+                # indexing with None.
+                best_i, best_j = 0, 1
             # Merge the pair (moment-matching)
             wi, mi, si = comps[best_i]
             wj, mj, sj = comps[best_j]

--- a/src/skaters/parade.py
+++ b/src/skaters/parade.py
@@ -51,7 +51,27 @@ def parade(base, k: int):
                 u = min(max(u, _EPS), 1.0 - _EPS)
                 pit[m - 1] = u
                 z[m - 1] = _STD_NORMAL.quantile(u)
-        dists, state["base"] = base(y, state["base"])
+        # State sanity, part two: no *finite* input can crash the tree.
+        # Double arithmetic inside the transforms dies long before the float
+        # range ends (the AR inverse raises OverflowError on a 1e300 tick;
+        # predictive moments go NaN by 1e100), so gate the observation before
+        # the tree consumes it. The window is magnitude-relative, NOT
+        # sigma-relative — after a degenerate-variance stretch (missing-data
+        # zeros, say) a legitimate value sits billions of sigmas out and must
+        # pass — and twelve orders above the current level is unreachable by
+        # data yet far below the ~1e77 jump ratio where doubles actually die.
+        # The PIT/z diagnostics above are computed on the raw y; the gate is
+        # exact identity on any stream doubles can represent comfortably.
+        y_fed = y
+        if isinstance(y_fed, (int, float)) and math.isfinite(y_fed):
+            y_fed = min(max(y_fed, -1e60), 1e60)
+            if n:
+                d1 = pend[-1][0]              # the 1-step predictive for y
+                mp, sp = d1.mean, d1.std
+                if math.isfinite(mp) and math.isfinite(sp):
+                    w = 1e12 * (1.0 + abs(mp) + sp)
+                    y_fed = min(max(y_fed, mp - w), mp + w)
+        dists, state["base"] = base(y_fed, state["base"])
         pend.append(list(dists))
         state["pit"] = pit
         state["z"] = z

--- a/tests/test_extreme_inputs.py
+++ b/tests/test_extreme_inputs.py
@@ -1,0 +1,86 @@
+"""Extreme finite inputs: no finite float may crash or poison the tree.
+
+Found 2026-07-08 while hardening timemachines. Three failure modes on
+huge-but-finite observations, all fixed by the parade input gate (state
+sanity, part two) plus a NaN guard in ``Dist.prune``:
+
+1. A 1e300 tick raised OverflowError inside the AR inverse (Python
+   floats raise on ``**`` overflow where ``*`` would give inf).
+2. A 1e100 tick did not raise but silently drove the predictive mean to
+   NaN, which is arguably worse.
+3. Once components went NaN, ``Dist.prune`` crashed with a TypeError:
+   its pair-selection scan never assigned ``best_i`` because every NaN
+   comparison is False.
+
+The gate is magnitude-relative (twelve orders above the current
+predictive level, absolute cap 1e60), NOT sigma-relative: after a
+degenerate-variance stretch a legitimate value sits billions of sigmas
+out and must pass. The tests at the bottom pin that identity property.
+"""
+
+import math
+
+from skaters import laplace
+from skaters.dist import Dist
+
+BASE = [math.sin(0.1 * t) for t in range(200)]
+
+
+def _feed(ys, k=1):
+    f, st = laplace(k), None
+    for y in ys:
+        dists, st = f(y, st)
+    return dists, st
+
+
+def _all_finite(dists):
+    return all(math.isfinite(d.mean) and math.isfinite(d.std) for d in dists)
+
+
+def test_1e300_spike_does_not_crash():
+    dists, st = _feed(BASE + [1e300] + BASE)
+    assert _all_finite(dists)
+
+
+def test_1e100_spike_keeps_predictive_finite():
+    dists, _ = _feed(BASE + [1e100] + BASE)
+    assert _all_finite(dists)
+
+
+def test_prune_survives_nan_components():
+    d = Dist([(0.5, float("nan"), 1.0)] + [(0.5 / 30, float(i), 1.0)
+                                           for i in range(30)])
+    assert len(d.prune(8)) <= 8
+
+
+def test_relentless_extremes():
+    for ys in ([1e300] * 100,
+               [10.0 ** (t % 280) for t in range(300)],
+               [10.0 ** -(t % 280) for t in range(300)],
+               BASE + [-1e300, 1e300] * 3 + BASE):
+        dists, _ = _feed(ys)
+        assert _all_finite(dists)
+
+
+def test_spike_still_reads_as_maximal_surprise():
+    """The gate must not blunt the diagnostics: PIT/z see the raw y."""
+    f, st = laplace(1), None
+    for y in BASE:
+        _, st = f(y, st)
+    _, st = f(1e300, st)
+    assert abs(st["z"][0]) > 6.9
+
+
+def test_gate_passes_legitimate_recovery_from_degenerate_variance():
+    """After a stretch of zeros the predictive variance collapses; a real
+    value arriving then is billions of sigmas out and must NOT be gated
+    (this killed a sigma-relative gate design)."""
+    dists, st = _feed([0.0] * 100 + [35.0] * 30)
+    assert abs(dists[0].mean - 35.0) < 1.0
+
+
+def test_gate_is_identity_on_ultra_predictable_streams():
+    """A date-like stream has predictive std far below its step size; its
+    steps are legitimate and the forecast must track them exactly."""
+    dists, _ = _feed([736000.0 + t for t in range(300)])
+    assert abs(dists[0].mean - 736300.0) < 1.0


### PR DESCRIPTION
## The holes

Found 2026-07-08 while hardening timemachines. Any finite float should be survivable, but:

1. A 1e300 tick raised `OverflowError` in the AR inverse (`phi[j] ** 2` — Python floats raise on `**` overflow where `*` would give inf).
2. A 1e100 tick did not raise but silently drove the predictive mean to NaN, which is arguably worse.
3. Once components went NaN, `Dist.prune` crashed with `TypeError`: its pair-selection scan never assigns `best_i` because every NaN comparison is False.

## The fix

State sanity, part two: the parade already guarantees no input produces an infinite z; it now also guarantees no finite input can crash the tree. The observation is winsorized before the tree consumes it: absolute cap 1e60, plus a magnitude-relative window twelve orders above the current 1-step predictive level (which the parade already holds in its pending deque, so state shape is unchanged).

Two design points worth review:

- **Magnitude-relative, not sigma-relative.** A sigma-relative gate fails on real data: after a degenerate-variance stretch (missing-data zeros in a poll series) a legitimate value sits billions of sigmas out and must pass, and ultra-predictable streams (dates) have predictive std below their own step size. Both cases are pinned by tests.
- **Diagnostics see raw y.** PIT/z are computed before the gate, so a 1e300 spike still saturates at |z| = 7.03 exactly as before.

The gate is exact identity on any stream doubles can represent comfortably (the window sits far below the ~1e77 jump ratio where double arithmetic actually dies), so published benchmark numbers are unaffected. Full suite: 630 passed, including JS parity; the JS twin needs nothing for representable streams.

`Dist.prune` additionally merges the first pair when the scan finds none (only reachable with NaN means), so pruning terminates instead of indexing with None.

## Tests

`tests/test_extreme_inputs.py`: the three repros as hard assertions, a relentless battery (all-1e300, exponential ladders up and down, alternating ±1e300), spike-still-saturates, and the two gate-identity properties (recovery from degenerate variance, date-like streams).

timemachines carries the same gate on its side of the API boundary, so it is protected on released skaters versions too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)