### PR TITLE
Anomaly skill: waveform caveat

### DIFF
--- a/docs/skills.html
+++ b/docs/skills.html
@@ -688,7 +688,16 @@ Flat means the z-thresholds mean what they say. U-shaped means the model is
 overconfident there (heavier tails than it thinks — raise the threshold);
 hump-shaped means underconfident (alarms will be rare and late).
 
-Two caveats. On **grid/repeating series** (posted prices, policy rates) the
+Three caveats. On **waveform-heavy data** — ECGs, vibration traces, machine
+acoustics, anything whose normal behaviour is a repeating *shape* rather than
+a stochastic level — this is probably not the best tool: the anomaly there is
+a deformed pattern, not a surprising next value, and shape-native methods
+(matrix-profile/discord discovery, spectral distance) are built for exactly
+that. `laplace`'s seasonal candidates absorb clean periodicity, but a subtle
+waveform deformity can hide inside a well-calibrated one-step predictive.
+Reach for this skill when the stream is a level/rate/count with stochastic
+dynamics; reach for the matrix profile when it looks like an oscilloscope. On
+**grid/repeating series** (posted prices, policy rates) the
 lattice projection places near-Dirac mass on revisited values, so PITs cluster
 at the atom edges — threshold on `pit`, not `z`, and treat "off-lattice at all"
 as the event. On **price/return series** volatility clusters: a 4σ day inside

--- a/skills/anomaly-detection.md
+++ b/skills/anomaly-detection.md
@@ -60,7 +60,16 @@ Flat means the z-thresholds mean what they say. U-shaped means the model is
 overconfident there (heavier tails than it thinks — raise the threshold);
 hump-shaped means underconfident (alarms will be rare and late).
 
-Two caveats. On **grid/repeating series** (posted prices, policy rates) the
+Three caveats. On **waveform-heavy data** — ECGs, vibration traces, machine
+acoustics, anything whose normal behaviour is a repeating *shape* rather than
+a stochastic level — this is probably not the best tool: the anomaly there is
+a deformed pattern, not a surprising next value, and shape-native methods
+(matrix-profile/discord discovery, spectral distance) are built for exactly
+that. `laplace`'s seasonal candidates absorb clean periodicity, but a subtle
+waveform deformity can hide inside a well-calibrated one-step predictive.
+Reach for this skill when the stream is a level/rate/count with stochastic
+dynamics; reach for the matrix profile when it looks like an oscilloscope. On
+**grid/repeating series** (posted prices, policy rates) the
 lattice projection places near-Dirac mass on revisited values, so PITs cluster
 at the atom edges — threshold on `pit`, not `z`, and treat "off-lattice at all"
 as the event. On **price/return series** volatility clusters: a 4σ day inside


### PR DESCRIPTION
Adds the scoping caveat: on waveform-heavy data (ECGs, vibration, machine acoustics) the anomaly is a deformed *shape*, not a surprising next value — shape-native methods (matrix profile / discord discovery, spectral distance) are probably the better tool, and a subtle waveform deformity can hide inside a well-calibrated one-step predictive. Skill file + embedded copy on the Skills page.

The matching one-clause addition to the paper's anomaly paragraph is deliberately held back until #98 (which touches `papers/skaters-jss.tex`) merges, to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)