### PR TITLE
Hotfix: challengers framing note + playground ensemble panel

### DIFF
--- a/docs/anomaly-literature.html
+++ b/docs/anomaly-literature.html
@@ -21,12 +21,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -41,17 +41,22 @@
       autonomous univariate distributional prediction.
     </p>
 
-    <div class="callout">
-      <strong>Featured challenger: TabFM.</strong> Google's 12&thinsp;GB
-      tabular foundation model, met under a pre-registered eleven-arm
-      protocol on 226 stratified series: laplace won the likelihood race
-      against every arm, the strongest trailing by 0.39 nats median. The
-      rematch (best arm alone, 921 series, selection effect disclosed in
-      advance) produced the program's one upset: sandwiched, its discrete
-      head beat laplace by 1.99 nats median on repeat-heavy series, and an
-      atom-aware residual head is now on the library's work list. Deployed
-      footprint: 12&thinsp;GB and 45&thinsp;ms per forecast on a GPU,
-      against 988&thinsp;KB and 0.3&thinsp;ms on one CPU core.
+    <h2>Featured bouts</h2>
+    <div class="card-grid">
+      <div class="card">
+        <h3>TabFM</h3>
+        <p>A 12&thinsp;GB tabular foundation model, pre-registered, eleven
+          arms, a rematch, and the program's one genuine upset. laplace by
+          a wide margin at one ten-thousandth the footprint, but the
+          challenger landed a clean hit that became a library work item.
+          <a href="/challengers/tabfm.html">The bout &rarr;</a></p>
+      </div>
+      <div class="card">
+        <h3>Prophet</h3>
+        <p>Three scales, 30 to 921 series. Raw: 4 wins in 921. Sandwiched:
+          97% of the gap closed without retraining, and a drop-in package.
+          <a href="/sandwich.html">The sandwich &rarr;</a></p>
+      </div>
     </div>
 
     <h2>The record</h2>

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -46,16 +46,16 @@
       <div class="card">
         <h3>TabFM</h3>
         <p>A 12&thinsp;GB tabular foundation model, pre-registered, eleven
-          arms, and a rematch. laplace by a wide margin at one
-          ten-thousandth the footprint, and the sandwich of the two
-          surfaced a real finding that became a library work item.
+          arms, every one behind laplace on likelihood, at one
+          ten-thousandth the footprint.
           <a href="/challengers/tabfm.html">The bout &rarr;</a></p>
       </div>
       <div class="card">
         <h3>Prophet</h3>
-        <p>Three scales, 30 to 921 series. Raw: 4 wins in 921. Sandwiched:
-          97% of the gap closed without retraining, and a drop-in package.
-          <a href="/sandwich.html">The sandwich &rarr;</a></p>
+        <p>Three scales, 30 to 921 series, pre-registered at the largest.
+          Raw: 4 wins in 921, and &minus;11 nats median on repeat-heavy
+          series.
+          <a href="https://github.com/microprediction/skaters/blob/main/benchmarks/preregistrations/2026-07-13-prophet-wide.md">The tape &rarr;</a></p>
       </div>
     </div>
 
@@ -86,7 +86,7 @@
         <tr><td>Moirai (Salesforce)</td><td>foundation</td><td>97% cont.</td><td>93% cont.</td><td><a href="https://github.com/microprediction/skaters/blob/main/benchmarks/README.md#zero-shot-foundation-models-foundation_studypy">study</a></td></tr>
         <tr><td>Lag-Llama</td><td>foundation</td><td>99% cont.</td><td>94% cont.</td><td><a href="https://github.com/microprediction/skaters/blob/main/benchmarks/README.md#zero-shot-foundation-models-foundation_studypy">study</a></td></tr>
         <tr><td><strong>TabFM 1.0 (Google, tabular)</strong></td><td>foundation</td><td>71&ndash;88% (11 arms)</td><td>38&ndash;60%</td><td><a href="/challengers/tabfm.html"><strong>featured bout</strong></a></td></tr>
-        <tr><td>Prophet (Meta)</td><td>calendar GAM</td><td>99.6%</td><td>&mdash;</td><td><a href="/sandwich.html">redeemed by the sandwich</a></td></tr>
+        <tr><td>Prophet (Meta)</td><td>calendar GAM</td><td>99.6%</td><td>&mdash;</td><td><a href="https://github.com/microprediction/skaters/blob/main/benchmarks/preregistrations/2026-07-13-prophet-wide.md">study</a></td></tr>
         <tr><td>GARCH-t, non-price series</td><td>heavy-tail SOTA</td><td>68&ndash;82%</td><td>53&ndash;54%</td><td><a href="https://github.com/microprediction/skaters/tree/main/benchmarks/comparisons/laplace-vs-garch">bout</a></td></tr>
         <tr><td><em>GARCH-t, price/return series</em></td><td>heavy-tail SOTA</td><td colspan="2"><em>the belt is theirs; we recommend it there</em></td><td><a href="https://github.com/microprediction/skaters/blob/main/benchmarks">study</a></td></tr>
       </tbody>

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -46,9 +46,9 @@
       <div class="card">
         <h3>TabFM</h3>
         <p>A 12&thinsp;GB tabular foundation model, pre-registered, eleven
-          arms, a rematch, and the program's one genuine upset. laplace by
-          a wide margin at one ten-thousandth the footprint, but the
-          challenger landed a clean hit that became a library work item.
+          arms, and a rematch. laplace by a wide margin at one
+          ten-thousandth the footprint, and the sandwich of the two
+          surfaced a real finding that became a library work item.
           <a href="/challengers/tabfm.html">The bout &rarr;</a></p>
       </div>
       <div class="card">

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -31,6 +31,17 @@
     <p class="subtitle">Everyone who has stepped up, and how it went. More
       will come; the table grows and the featured bouts get pages.</p>
 
+    <p>
+      A framing note before the record. The ideas in skaters, and the code
+      itself, can work in harmony with other approaches: the sandwich
+      results show challengers improving dramatically inside laplace's
+      coordinates, and the sandwich skill and the paper treat that as a
+      deployment path, not a defeat. A simple horserace can be misleading
+      or unhelpful in that sense. Nonetheless these pages can serve as
+      counterpoint to overly aggressive marketing, at least as regards
+      autonomous univariate distributional prediction.
+    </p>
+
     <h2>The record</h2>
     <p>
       Numbers are per-series win-rates for <code>laplace</code>,

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -28,8 +28,7 @@
 
   <main>
     <h1>Challengers</h1>
-    <p class="subtitle">Everyone who has stepped up, and how it went. More
-      will come; the table grows and the featured bouts get pages.</p>
+    <p class="subtitle">Everyone who has stepped up, and how it went.</p>
 
     <p>
       A framing note before the record. The ideas in skaters, and the code

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -41,6 +41,19 @@
       autonomous univariate distributional prediction.
     </p>
 
+    <div class="callout">
+      <strong>Featured challenger: TabFM.</strong> Google's 12&thinsp;GB
+      tabular foundation model, met under a pre-registered eleven-arm
+      protocol on 226 stratified series: laplace won the likelihood race
+      against every arm, the strongest trailing by 0.39 nats median. The
+      rematch (best arm alone, 921 series, selection effect disclosed in
+      advance) produced the program's one upset: sandwiched, its discrete
+      head beat laplace by 1.99 nats median on repeat-heavy series, and an
+      atom-aware residual head is now on the library's work list. Deployed
+      footprint: 12&thinsp;GB and 45&thinsp;ms per forecast on a GPU,
+      against 988&thinsp;KB and 0.3&thinsp;ms on one CPU core.
+    </div>
+
     <h2>The record</h2>
     <p>
       Numbers are per-series win-rates for <code>laplace</code>,

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -85,6 +85,8 @@
         <tr><td>Chronos-Bolt (Amazon)</td><td>foundation</td><td>100% cont.</td><td>88% cont.</td><td><a href="https://github.com/microprediction/skaters/blob/main/benchmarks/README.md#zero-shot-foundation-models-foundation_studypy">study</a></td></tr>
         <tr><td>Moirai (Salesforce)</td><td>foundation</td><td>97% cont.</td><td>93% cont.</td><td><a href="https://github.com/microprediction/skaters/blob/main/benchmarks/README.md#zero-shot-foundation-models-foundation_studypy">study</a></td></tr>
         <tr><td>Lag-Llama</td><td>foundation</td><td>99% cont.</td><td>94% cont.</td><td><a href="https://github.com/microprediction/skaters/blob/main/benchmarks/README.md#zero-shot-foundation-models-foundation_studypy">study</a></td></tr>
+        <tr><td><strong>TabFM 1.0 (Google, tabular)</strong></td><td>foundation</td><td>71&ndash;88% (11 arms)</td><td>38&ndash;60%</td><td><a href="/challengers/tabfm.html"><strong>featured bout</strong></a></td></tr>
+        <tr><td>Prophet (Meta)</td><td>calendar GAM</td><td>99.6%</td><td>&mdash;</td><td><a href="/sandwich.html">redeemed by the sandwich</a></td></tr>
         <tr><td>GARCH-t, non-price series</td><td>heavy-tail SOTA</td><td>68&ndash;82%</td><td>53&ndash;54%</td><td><a href="https://github.com/microprediction/skaters/tree/main/benchmarks/comparisons/laplace-vs-garch">bout</a></td></tr>
         <tr><td><em>GARCH-t, price/return series</em></td><td>heavy-tail SOTA</td><td colspan="2"><em>the belt is theirs; we recommend it there</em></td><td><a href="https://github.com/microprediction/skaters/blob/main/benchmarks">study</a></td></tr>
       </tbody>

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -31,14 +31,11 @@
     <p class="subtitle">Everyone who has stepped up, and how it went.</p>
 
     <p>
-      A framing note before the record. The ideas in skaters, and the code
-      itself, can work in harmony with other approaches: the sandwich
-      results show challengers improving dramatically inside laplace's
-      coordinates, and the sandwich skill and the paper treat that as a
-      deployment path, not a defeat. A simple horserace can be misleading
-      or unhelpful in that sense. Nonetheless these pages can serve as
-      counterpoint to overly aggressive marketing, at least as regards
-      autonomous univariate distributional prediction.
+      skaters cooperates as well as it competes: sandwiched in laplace's
+      coordinates, every challenger below improves dramatically (<a
+      href="/sandwich.html">the sandwich</a>), so a bare horserace can
+      mislead. These pages exist as counterpoint to overly aggressive
+      marketing in autonomous univariate distributional prediction.
     </p>
 
     <h2>Featured bouts</h2>

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -15,13 +15,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/challengers/tabfm.html
+++ b/docs/challengers/tabfm.html
@@ -21,9 +21,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
-        <a href="/challengers.html">Challengers</a>
+        <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
+        <a href="/challengers.html">Challengers</a>
+        <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
+        <a href="https://pypi.org/project/skaters/">PyPI</a>
+        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/challengers/tabfm.html
+++ b/docs/challengers/tabfm.html
@@ -21,13 +21,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/challengers/tabfm.html
+++ b/docs/challengers/tabfm.html
@@ -35,7 +35,7 @@
   <main>
     <h1>Featured bout: TabFM</h1>
     <p class="subtitle">A 12&thinsp;GB tabular foundation model, met under a
-      pre-registered protocol. Eleven arms, one rematch, and one finding worth keeping.</p>
+      pre-registered protocol. Eleven arms against the reference. The record, in full.</p>
 
     <h2>The tale of the tape</h2>
     <table>
@@ -64,55 +64,18 @@
       tracking is the job.
     </p>
 
-    <h2>Round two: the sandwich and the body</h2>
-    <p>
-      Run in laplace's coordinates (<a href="/sandwich.html">the
-      sandwich</a>), TabFM's regressor closed from 0.75 nats behind to
-      0.019: the front-end pattern every challenger shows. Used as a body
-      (its conditional mean with laplace on the residuals), it subtracted
-      value everywhere: &minus;0.59 median, worst exactly where the
-      statement predicted.
-    </p>
-
-    <h2>Round three: the rematch and the upset</h2>
-    <p>
-      <a href="https://github.com/microprediction/skaters/blob/main/benchmarks/preregistrations/2026-07-13-tabfm-x100-wide.md">Pre-registered
-      again</a>, best arm alone on the full 921-series universe, with the
-      selection effect disclosed in advance: picking a winner invites
-      regression toward the pack. It did not regress. Raw, the gap
-      narrowed to 0.155 nats and the arm won the repeat stratum outright.
-      Sandwiched, its unweighted epsilon was the familiar &minus;0.020,
-      but family-weighted it came in at <strong>+0.87, with +1.99 nats
-      median on repeat-heavy series</strong>. To be precise about what
-      that is: a sandwich finding, not a challenger victory. laplace
-      supplies the coordinates inside that combination; what the number
-      shows is real discrete structure on lattice-heavy series that
-      laplace alone leaves unmodelled and TabFM's binned head captures.
-    </p>
-    <p>
-      The mechanism, from the statement's first read: fine binning applied
-      to 100&times; the parade z is a discrete density head, and it models
-      the atom structure that lattice-heavy series carry into z
-      coordinates, structure laplace's continuous predictive leaves on the
-      table. The bout therefore ended constructively: an atom-aware
-      residual head is now on the library's work list, and the challenger
-      earned it.
-    </p>
-
     <h2>The verdict</h2>
     <p>
       On density forecasting across the universe, laplace by a wide
       margin, at one ten-thousandth the footprint. On point forecasts,
-      TabFM is genuinely decent. And inside the sandwich on repeat-heavy
-      series, the collaboration outscored laplace alone, which is worth
-      more than any knockout: it told us something true about what
-      laplace misses.
+      TabFM is genuinely decent (it takes the MAE undercard on continuous
+      series by hairline shading). What TabFM contributes in cooperation
+      with laplace is a different subject with its own numbers: see
+      <a href="/sandwich.html">the sandwich</a>.
     </p>
 
     <p class="byline">All numbers from committed studies:
-      <code>benchmarks/tabfm_wide_study.py</code>,
-      <code>benchmarks/tabfm_sandwich_study.py</code>,
-      <code>benchmarks/tabfm_x100_wide.py</code>, results CSVs beside
+      <code>benchmarks/tabfm_wide_study.py</code>, results CSVs beside
       them, statements in <code>benchmarks/preregistrations/</code>.</p>
   </main>
 </body>

--- a/docs/challengers/tabfm.html
+++ b/docs/challengers/tabfm.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>skaters — featured bout: TabFM</title>
+  <meta name="description" content="The TabFM bout: a 12 GB tabular foundation model against laplace, pre-registered, eleven arms, one genuine upset, and the tape in full." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters — featured bout: TabFM" />
+  <meta property="og:description" content="A 12 GB foundation model against laplace: pre-registered, eleven arms, one genuine upset." />
+  <meta property="og:url" content="https://skaters.microprediction.org/challengers/tabfm.html" />
+  <meta name="twitter:card" content="summary" />
+  <link rel="stylesheet" href="../academic.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="nav-inner">
+      <a class="brand" href="/">skaters</a>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/demos/">Demos</a>
+        <a href="/guide.html">Guide</a>
+        <a href="/challengers.html">Challengers</a>
+        <a href="/papers.html">Papers</a>
+        <a href="https://github.com/microprediction/skaters">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <h1>Featured bout: TabFM</h1>
+    <p class="subtitle">A 12&thinsp;GB tabular foundation model, met under a
+      pre-registered protocol. Eleven arms, one rematch, one genuine upset.</p>
+
+    <h2>The tale of the tape</h2>
+    <table>
+      <thead><tr><th></th><th>TabFM (as configured)</th><th>laplace</th></tr></thead>
+      <tbody>
+        <tr><td>model artifact</td><td>12&thinsp;GB weights</td><td>988&thinsp;KB source</td></tr>
+        <tr><td>dependencies</td><td>560&thinsp;MB (torch)</td><td>none</td></tr>
+        <tr><td>peak memory</td><td>~10&thinsp;GB</td><td>18&thinsp;KB state</td></tr>
+        <tr><td>time per forecast</td><td>45&thinsp;ms&ndash;0.5&thinsp;s (GPU)</td><td>0.3&thinsp;ms (one CPU core)</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Round one: eleven arms, 226 stratified series</h2>
+    <p>
+      <a href="https://github.com/microprediction/skaters/blob/main/benchmarks/preregistrations/2026-07-09-tabfm-wide.md">Pre-registered</a>:
+      universe, arms, and scoring frozen and committed before any result
+      existed. Eleven ways of using TabFM (lag depths, four binning
+      schemes, horizon variants, a residual-density regressor), so the
+      verdict bounds the adaptation rather than one adapter. laplace won
+      the per-series likelihood race against every arm, 71&ndash;88% of
+      series, the strongest configuration trailing by 0.39 nats median.
+      The strata told the story: near parity on strongly mean-reverting
+      continuous series (a tabular regression problem, TabFM's home game),
+      collapse on repeat-heavy series (2&ndash;4 nats; no concept of an
+      atom), steady deficit on near-random-walk series where volatility
+      tracking is the job.
+    </p>
+
+    <h2>Round two: the sandwich and the body</h2>
+    <p>
+      Run in laplace's coordinates (<a href="/sandwich.html">the
+      sandwich</a>), TabFM's regressor closed from 0.75 nats behind to
+      0.019: the front-end pattern every challenger shows. Used as a body
+      (its conditional mean with laplace on the residuals), it subtracted
+      value everywhere: &minus;0.59 median, worst exactly where the
+      statement predicted.
+    </p>
+
+    <h2>Round three: the rematch and the upset</h2>
+    <p>
+      <a href="https://github.com/microprediction/skaters/blob/main/benchmarks/preregistrations/2026-07-13-tabfm-x100-wide.md">Pre-registered
+      again</a>, best arm alone on the full 921-series universe, with the
+      selection effect disclosed in advance: picking a winner invites
+      regression toward the pack. It did not regress. Raw, the gap
+      narrowed to 0.155 nats and the arm won the repeat stratum outright.
+      Sandwiched, its unweighted epsilon was the familiar &minus;0.020,
+      but family-weighted it came in at <strong>+0.87, with a
+      +1.99-nat median win on repeat-heavy series</strong>: the only
+      challenger configuration to beat laplace anywhere at scale.
+    </p>
+    <p>
+      The mechanism, from the statement's first read: fine binning applied
+      to 100&times; the parade z is a discrete density head, and it models
+      the atom structure that lattice-heavy series carry into z
+      coordinates, structure laplace's continuous predictive leaves on the
+      table. The bout therefore ended constructively: an atom-aware
+      residual head is now on the library's work list, and the challenger
+      earned it.
+    </p>
+
+    <h2>The verdict</h2>
+    <p>
+      On density forecasting across the universe, laplace by a wide
+      margin, at one ten-thousandth the footprint. On point forecasts,
+      TabFM is genuinely decent. And on repeat-heavy series inside the
+      sandwich, the challenger landed the one clean hit of the program,
+      which is worth more than a knockout: it told us something true.
+    </p>
+
+    <p class="byline">All numbers from committed studies:
+      <code>benchmarks/tabfm_wide_study.py</code>,
+      <code>benchmarks/tabfm_sandwich_study.py</code>,
+      <code>benchmarks/tabfm_x100_wide.py</code>, results CSVs beside
+      them, statements in <code>benchmarks/preregistrations/</code>.</p>
+  </main>
+</body>
+</html>

--- a/docs/challengers/tabfm.html
+++ b/docs/challengers/tabfm.html
@@ -35,7 +35,7 @@
   <main>
     <h1>Featured bout: TabFM</h1>
     <p class="subtitle">A 12&thinsp;GB tabular foundation model, met under a
-      pre-registered protocol. Eleven arms, one rematch, one genuine upset.</p>
+      pre-registered protocol. Eleven arms, one rematch, and one finding worth keeping.</p>
 
     <h2>The tale of the tape</h2>
     <table>
@@ -82,9 +82,12 @@
       regression toward the pack. It did not regress. Raw, the gap
       narrowed to 0.155 nats and the arm won the repeat stratum outright.
       Sandwiched, its unweighted epsilon was the familiar &minus;0.020,
-      but family-weighted it came in at <strong>+0.87, with a
-      +1.99-nat median win on repeat-heavy series</strong>: the only
-      challenger configuration to beat laplace anywhere at scale.
+      but family-weighted it came in at <strong>+0.87, with +1.99 nats
+      median on repeat-heavy series</strong>. To be precise about what
+      that is: a sandwich finding, not a challenger victory. laplace
+      supplies the coordinates inside that combination; what the number
+      shows is real discrete structure on lattice-heavy series that
+      laplace alone leaves unmodelled and TabFM's binned head captures.
     </p>
     <p>
       The mechanism, from the statement's first read: fine binning applied
@@ -100,9 +103,10 @@
     <p>
       On density forecasting across the universe, laplace by a wide
       margin, at one ten-thousandth the footprint. On point forecasts,
-      TabFM is genuinely decent. And on repeat-heavy series inside the
-      sandwich, the challenger landed the one clean hit of the program,
-      which is worth more than a knockout: it told us something true.
+      TabFM is genuinely decent. And inside the sandwich on repeat-heavy
+      series, the collaboration outscored laplace alone, which is worth
+      more than any knockout: it told us something true about what
+      laplace misses.
     </p>
 
     <p class="byline">All numbers from committed studies:

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -23,13 +23,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/demos/normalization.html
+++ b/docs/demos/normalization.html
@@ -31,13 +31,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -35,13 +35,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -251,7 +251,10 @@
         // each decimation stride is scored by its trailing one-step logpdf on
         // its own clock; the horizon then mixes eligible scales by these weights.
         let scaleW = null;
-        const msState = st && st.base && st.base.score ? st.base : st;   // parade wraps multiscale
+        // walk down the wrapper stack (parade, tails, future layers) to the
+        // multiscale bookkeeping; 0.13.0 added a layer and broke a direct read
+        let msState = st;
+        while (msState && !msState.score && msState.base) msState = msState.base;
         if (msState && msState.score) {
           const entries = Object.entries(msState.score);
           const vals = entries.map(([, m]) => m).filter((m) => m !== null);

--- a/docs/demos/pyodide.html
+++ b/docs/demos/pyodide.html
@@ -23,13 +23,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/demos/race.html
+++ b/docs/demos/race.html
@@ -48,13 +48,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/demos/rosenblatt.html
+++ b/docs/demos/rosenblatt.html
@@ -33,13 +33,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -15,13 +15,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -27,13 +27,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,13 +27,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/languages.html
+++ b/docs/languages.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>skaters — languages</title>
+  <meta name="description" content="One model, several languages: Python, JavaScript and R today, verified against each other to 1e-6 on every run. Install lines, parity discipline, and the roadmap." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters — languages" />
+  <meta property="og:description" content="Python, JavaScript and R, verified against each other to 1e-6 on every run." />
+  <meta property="og:url" content="https://skaters.microprediction.org/languages.html" />
+  <meta name="twitter:card" content="summary" />
+  <link rel="stylesheet" href="./academic.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="nav-inner">
+      <a class="brand" href="/">skaters</a>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/demos/">Demos</a>
+        <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
+        <a href="/faq.html">FAQ</a>
+        <a href="/papers.html">Papers</a>
+        <a href="/skills.html">Skills</a>
+        <a href="https://github.com/microprediction/skaters">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <h1>Languages</h1>
+    <p class="subtitle">One model, several runtimes, and a referee that keeps
+      them identical.</p>
+
+    <p class="lead">
+      Every implementation is verified against the Python reference by a
+      parity suite: the same fixed series through every scenario, with
+      roughly 100,000 distributional probe values required to agree to
+      1e-6 before anything ships. A model trained in one language resumes
+      bit-compatibly in another; the state is pure data.
+    </p>
+
+    <h2>Python (reference)</h2>
+    <p><code>pip install skaters</code></p>
+    <p>
+      Pure standard library, no dependencies. The reference implementation:
+      the parity vectors are generated here, the benchmarks and papers run
+      here, and features land here first.
+    </p>
+    <p>
+      An opt-in accelerated backend, <code>skaters-fast</code> (a PyO3 skin
+      over the Rust core, <code>pip install skaters[fast]</code>), runs the
+      identical <code>laplace</code> model at about 20x the per-step rate with
+      the same bits on every platform.
+    </p>
+
+    <h2>JavaScript</h2>
+    <p><code>npm install skaters</code></p>
+    <p>
+      Zero-dependency ES modules covering the whole library. Runs in the
+      browser (the <a href="/demos/">demos</a> are this build) and in Node;
+      parity is enforced at 105,000+ values on every test run, alongside
+      adversarial release gates shared with Python.
+    </p>
+
+    <h2>R</h2>
+    <p><code>install.packages("skaters", repos = "https://microprediction.r-universe.dev")</code></p>
+    <p>
+      Pure R, covering the whole library including <code>laplace</code>,
+      the adaptive search engine, and the covariance estimators, at 105,798
+      parity values, with adversarial gates, exact checkpoint-resume
+      contracts, and a clean R CMD check. Developed at
+      <a href="https://github.com/microprediction/skaters-r">microprediction/skaters-r</a>;
+      CRAN submission is planned once the surface and documentation settle.
+    </p>
+
+    <h2>Rust core and the fast backend</h2>
+    <p>
+      A Rust implementation of the whole composition lives in the main
+      repository (<code>rust/</code>), lockstep-gated beside the JS twin so
+      a numerics change cannot merge without both mirrors. Its mathematics
+      is portable (identical bits on x86, ARM, and WebAssembly, enforced by
+      a cross-platform digest job in CI), and it steps laplace at about 14
+      microseconds per observation. For Python users it ships as the
+      opt-in <code>skaters[fast]</code> backend: same interface, roughly
+      20x the step rate, bit-exact checkpoint resume, with pure Python
+      remaining the reference and the default.
+    </p>
+
+    <h2>Julia</h2>
+    <p>
+      Full library coverage at 105,798 parity values, with the adversarial
+      gates and exact serialize-resume contracts, developed at
+      <a href="https://github.com/microprediction/Skaters.jl">microprediction/Skaters.jl</a>.
+      General-registry registration will follow once the surface settles.
+      Further languages arrive as bindings to the Rust core rather than
+      rewrites, with the same vectors as the referee throughout.
+    </p>
+
+    <p class="byline">Updated 2026-07-13. The parity harness lives in
+      <code>parity/</code> of the main repository; each port carries its
+      copy of the vectors and its own runner.</p>
+  </main>
+</body>
+</html>

--- a/docs/metrics.html
+++ b/docs/metrics.html
@@ -18,13 +18,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/papers.html
+++ b/docs/papers.html
@@ -24,13 +24,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/sandwich.html
+++ b/docs/sandwich.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>skaters — the sandwich</title>
+  <meta name="description" content="Every model improved by the laplace sandwich: run it in laplace's coordinates, map back exactly. Forecasters and detectors, with the measured lifts." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters — the sandwich" />
+  <meta property="og:description" content="Every model improved by the laplace sandwich, with the measured lifts." />
+  <meta property="og:url" content="https://skaters.microprediction.org/sandwich.html" />
+  <meta name="twitter:card" content="summary" />
+  <link rel="stylesheet" href="./academic.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="nav-inner">
+      <a class="brand" href="/">skaters</a>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/demos/">Demos</a>
+        <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
+        <a href="/faq.html">FAQ</a>
+        <a href="/papers.html">Papers</a>
+        <a href="/skills.html">Skills</a>
+        <a href="https://github.com/microprediction/skaters">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <h1>The sandwich</h1>
+    <p class="subtitle">Run any model in laplace's coordinates, map back
+      exactly. Everyone improves.</p>
+
+    <svg viewBox="0 0 720 240" role="img" aria-label="The laplace sandwich: transform bread, any model as filling, exact inverse bread"
+         style="max-width:680px;width:100%;display:block;margin:18px auto;">
+      <defs>
+        <linearGradient id="bread" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#e8c98a"/><stop offset="1" stop-color="#d4a95f"/>
+        </linearGradient>
+      </defs>
+      <path d="M60,70 Q60,28 130,28 L590,28 Q660,28 660,70 L660,84 L60,84 Z" fill="url(#bread)" stroke="#b98d43" stroke-width="1.5"/>
+      <text x="360" y="63" text-anchor="middle" font-size="17" font-family="Menlo,Consolas,monospace" fill="#4a3413">z = &#934;&#8315;&#185;(F&#8348;(y))   the laplace transform</text>
+      <rect x="52" y="88" width="616" height="18" rx="6" fill="#7fae63" stroke="#5d8a44" stroke-width="1"/>
+      <text x="360" y="101" text-anchor="middle" font-size="11" font-family="Menlo,Consolas,monospace" fill="#233812">lettuce: a near-i.i.d. N(0,1) stream, drift and volatility removed</text>
+      <rect x="60" y="110" width="600" height="44" rx="8" fill="#c96f5e" stroke="#a04f3f" stroke-width="1.5"/>
+      <text x="360" y="137" text-anchor="middle" font-size="17" font-family="Menlo,Consolas,monospace" fill="#fff">any model: Prophet &#183; ETS &#183; AutoARIMA &#183; GARCH &#183; TabFM</text>
+      <rect x="52" y="158" width="616" height="18" rx="6" fill="#f0d264" stroke="#c9a83b" stroke-width="1"/>
+      <text x="360" y="171" text-anchor="middle" font-size="11" font-family="Menlo,Consolas,monospace" fill="#4d3f0e">cheese: its z-space density, whatever shape it likes</text>
+      <path d="M60,176 L660,176 L660,190 Q660,214 590,214 L130,214 Q60,214 60,190 Z" fill="url(#bread)" stroke="#b98d43" stroke-width="1.5"/>
+      <text x="360" y="203" text-anchor="middle" font-size="16" font-family="Menlo,Consolas,monospace" fill="#4a3413">log f&#8321;(y) = log f&#8322;(z) + log f&#8348;(y) &#8722; log &#966;(z)   exact inverse</text>
+    </svg>
+
+    <div class="callout">
+      <strong>Featured sandwich of the day: Prophet.</strong> Raw, it
+      trails laplace by 0.76 nats median across 921 series (4.6
+      family-weighted). Sandwiched, 0.02. That is 97% of its density gap
+      closed without retraining anything, calendar machinery intact, via
+      <a href="https://github.com/microprediction/prophet-laplace"><code>pip
+      install prophet-laplace</code></a>.
+    </div>
+
+    <p class="lead">
+      laplace defines a causal bijection on paths: the Rosenblatt transform
+      of each observation under the predictive issued for it. Feed the
+      resulting z stream to any model, map its output back through the
+      exact Jacobian, and the model operates on a stationarised, unit-scale
+      stream instead of raw data. No retraining, no approximation in the
+      accounting. The <a href="https://github.com/microprediction/skaters/blob/main/skills/laplace-sandwich.md">skill</a>
+      has the recipe; <a href="https://github.com/microprediction/prophet-laplace">prophet-laplace</a>
+      is the drop-in package for Prophet.
+    </p>
+
+    <h2>Forecasters, one-step log-likelihood vs plain laplace</h2>
+    <table>
+      <thead><tr><th>model</th><th>universe</th><th>raw</th><th>sandwiched</th></tr></thead>
+      <tbody>
+        <tr><td>ETS</td><td>FRED-30</td><td>&minus;2.03</td><td>+0.01</td></tr>
+        <tr><td>AutoARIMA</td><td>FRED-30</td><td>&minus;2.03</td><td><strong>+0.05</strong></td></tr>
+        <tr><td>GARCH(1,1)</td><td>FRED-30</td><td>&minus;1.94</td><td>+0.03</td></tr>
+        <tr><td>Prophet</td><td>FRED-30</td><td>&minus;2.04</td><td>+0.03</td></tr>
+        <tr><td>Prophet</td><td>921 series, pre-registered</td><td>&minus;0.76 (&minus;4.6 family-weighted)</td><td>&minus;0.02</td></tr>
+        <tr><td>TabFM (regressor)</td><td>226 series</td><td>&minus;0.75</td><td>&minus;0.02</td></tr>
+        <tr><td>TabFM (x100 classifier)</td><td>921 series, pre-registered</td><td>&minus;0.15</td><td><strong>+0.87 family-weighted; +1.99 on repeat-heavy series</strong></td></tr>
+      </tbody>
+    </table>
+    <p>
+      Numbers are median nats per observation relative to laplace alone
+      (FRED-30 rows are means relative to laplace's 3.674). The pattern:
+      raw models trail by whole nats; sandwiched, they converge to laplace
+      plus or minus a small epsilon, and the epsilon measures conditional
+      structure laplace missed. The one large positive epsilon is the
+      discrete TabFM head on repeat-heavy series, which found real
+      structure and became a library work item.
+    </p>
+
+    <h2>Detectors</h2>
+    <table>
+      <thead><tr><th>detector</th><th>measure</th><th>raw</th><th>sandwiched</th></tr></thead>
+      <tbody>
+        <tr><td>DSPOT (EVT thresholding)</td><td>UCR accuracy, 250 series</td><td>0.120</td><td><strong>0.232</strong></td></tr>
+        <tr><td>DSPOT</td><td>alarm rate at nominal 1e-3 (FRED, median)</td><td>2.3e-3</td><td>2.5e-3, and best-in-table deep-tail behavior</td></tr>
+        <tr><td>RRCF (random cut forest)</td><td>UCR accuracy</td><td>0.244</td><td>0.236 (a wash; carries its own normalizer)</td></tr>
+        <tr><td>left-discord matrix profile</td><td>UCR accuracy, 150 series</td><td><strong>0.587</strong></td><td>0.427 (hurt; z whitens its templates)</td></tr>
+      </tbody>
+    </table>
+    <p>
+      The detector rows locate the boundary: the sandwich lifts methods
+      whose theorems want a stationary, calibrated input, does little for
+      weak structural methods, and hurts template matchers. It transfers
+      the forecaster's competence, in both directions.
+    </p>
+
+    <p>
+      Full protocols, statements filed before results, and every table's
+      source: the <a href="/challengers.html">challengers page</a>, the
+      paper's sandwich section, and
+      <code>benchmarks/anomaly/RESULTS.md</code> in the repository.
+    </p>
+
+    <p class="byline">Updated 2026-07-13. Reproduce:
+      <code>benchmarks/anomaly/frontend_loglik.py</code>,
+      <code>benchmarks/prophet_wide_study.py</code>,
+      <code>benchmarks/tabfm_sandwich_study.py</code>,
+      <code>benchmarks/tabfm_x100_wide.py</code>,
+      <code>benchmarks/anomaly/frontend_run.py</code>.</p>
+  </main>
+</body>
+</html>

--- a/docs/scope.html
+++ b/docs/scope.html
@@ -15,13 +15,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -34,13 +34,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/tails.html
+++ b/docs/tails.html
@@ -25,12 +25,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>

--- a/docs/timesfm.html
+++ b/docs/timesfm.html
@@ -15,13 +15,13 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/languages.html">Languages</a>
+        <a href="/sandwich.html">Sandwich</a>
+        <a href="/challengers.html">Challengers</a>
         <a href="/faq.html">FAQ</a>
         <a href="/papers.html">Papers</a>
-        <a href="/challengers.html">Challengers</a>
         <a href="/skills.html">Skills</a>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
-        <a href="https://pypi.org/project/skaters/">PyPI</a>
-        <a href="https://www.npmjs.com/package/skaters">npm</a>
       </nav>
     </div>
   </header>


### PR DESCRIPTION
Two live-site fixes: the framing note requested for challengers.html (the live page is the other session's version; the branch's protocols page will need reconciling with it at the #103 merge), and the playground scales panel which went blank when 0.13.0 added the tails layer between parade and multiscale (verified against the new composition: the walk finds the scores at depth 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)