### PR TITLE
docs: link tiki-taka from the home and languages pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -143,6 +143,11 @@ f = laplace(k=1)</code></pre>
         <h3>Guide →</h3>
         <p>The <code>Dist</code> object, transforms, conjugation, and ensembles — how it all composes.</p>
       </a>
+      <a class="card" href="/tiki-taka.html">
+        <h3>Tiki-taka →</h3>
+        <p>The same algorithm as a football move: switch the ball out to an easier problem and
+          work it back to the original space to score — in your language and team.</p>
+      </a>
       <a class="card" href="/papers.html">
         <h3>Papers &amp; benchmarks →</h3>
         <p>The paper, and the studies vs ARIMA/ETS/GARCH/conformal and the foundation models.</p>

--- a/docs/languages.html
+++ b/docs/languages.html
@@ -36,6 +36,10 @@
     <h1>Languages</h1>
     <p class="subtitle">One model, several runtimes, and a referee that keeps
       them identical.</p>
+    <p style="font-size:0.92rem;margin-top:-2px;">
+      The skaters methodology is also described in the language of football:
+      the <a href="/tiki-taka.html">tiki-taka page</a>.
+    </p>
 
     <p class="lead">
       Every implementation is verified against the Python reference by a


### PR DESCRIPTION
Links the tiki-taka football explainer from two more places:

- **Home page**: a Tiki-taka card in the grid, beside the Guide.
- **Languages page**: a line under the subtitle noting the method is also described in the language of football, with a link.

It was already linked from the guide (via #105); this covers the rest of the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)