### PR TITLE
Challengers page: deduplicate featured-bout cards

### DIFF
--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -41,6 +41,13 @@
     <h2>Featured bouts</h2>
     <div class="card-grid">
       <div class="card">
+        <h3>TimesFM &mdash; David v Goliath</h3>
+        <p>Google&rsquo;s 200M-parameter foundation model: 69 of 69
+          continuous series on likelihood, a 2.26-nat median gap, and
+          where Goliath actually wins (predicting zeros).
+          <a href="/timesfm.html">The bout &rarr;</a></p>
+      </div>
+      <div class="card">
         <h3>TabFM &mdash; David v Godzilla</h3>
         <p>A 12&thinsp;GB tabular foundation model, pre-registered, eleven
           arms, every one behind laplace on likelihood, at one
@@ -98,16 +105,6 @@
       </tbody>
     </table>
 
-    <h2>Featured bouts</h2>
-    <div class="card-grid">
-      <a class="card" href="/timesfm.html">
-        <h3>David v Goliath &rarr;</h3>
-        <p>Laplace vs TimesFM, Google&rsquo;s 200M-parameter foundation
-          model: 69 of 69 continuous series on likelihood, a 2.26-nat median
-          gap, the sorted-gap chart, the footprint table, and where Goliath
-          actually wins (predicting zeros).</p>
-      </a>
-    </div>
     <p style="color:var(--muted);font-size:0.92em;">
       Challengers that earn a full treatment get a bout page:
       <a href="/timesfm.html">TimesFM</a>,


### PR DESCRIPTION
The page had two "Featured bouts" sections: cards at the top (TabFM, Prophet, PYMC-Forecast) and a second grid below the record with a lone TimesFM card. Consolidated into the top grid; TimesFM leads it. The muted bout-page index paragraph is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)