### PR TITLE
docs: heritage page moves here from timemachines

### DIFF
--- a/docs/anomaly-literature.html
+++ b/docs/anomaly-literature.html
@@ -25,6 +25,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -19,6 +19,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/challengers/pymc-forecast.html
+++ b/docs/challengers/pymc-forecast.html
@@ -25,6 +25,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/challengers/tabfm.html
+++ b/docs/challengers/tabfm.html
@@ -25,6 +25,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -27,6 +27,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/demos/normalization.html
+++ b/docs/demos/normalization.html
@@ -35,6 +35,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -39,6 +39,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/demos/pyodide.html
+++ b/docs/demos/pyodide.html
@@ -27,6 +27,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/demos/race.html
+++ b/docs/demos/race.html
@@ -52,6 +52,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/demos/rosenblatt.html
+++ b/docs/demos/rosenblatt.html
@@ -37,6 +37,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -19,6 +19,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -31,6 +31,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/heritage.html
+++ b/docs/heritage.html
@@ -1,0 +1,941 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>A history of the probability integral transform (with some bias/variance tradeoff)</title>
+  <meta name="description" content="From Fisher's p-values and Pearson's probability integral to Ulam's Monte Carlo, Rosenblatt's transform, copulas on Wall Street, z-streams, and PIT conjugation. One idea, a century of work." />
+  <link rel="stylesheet" href="./academic.css" />
+  <style>
+    .tl { position: relative; margin: 34px 0 10px; padding-left: 34px; }
+    .tl::before { content: ""; position: absolute; left: 9px; top: 6px; bottom: 6px;
+                  width: 2px; background: var(--accent); opacity: .35; border-radius: 1px; }
+    .tl-item { position: relative; margin: 0 0 30px; }
+    .tl-item::before { content: ""; position: absolute; left: -31px; top: 7px;
+                       width: 10px; height: 10px; border-radius: 50%;
+                       background: var(--accent); box-shadow: 0 0 0 3px var(--bg); }
+    .tl-item.warn::before { background: var(--warn); }
+    .tl-year { font-weight: 700; font-variant-numeric: tabular-nums;
+               color: var(--accent); letter-spacing: .02em; }
+    .tl-item.warn .tl-year { color: var(--warn); }
+    .tl-who { font-weight: 600; }
+    .tl-item p { margin: 4px 0 0; }
+    .cta { background: var(--panel); border: 1px solid var(--border);
+           border-left: 4px solid var(--accent); border-radius: 8px;
+           padding: 18px 20px; margin: 30px 0; }
+    .cta h2 { margin: 0 0 8px; font-size: 20px; }
+    .cta p { margin: 6px 0 0; }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="nav-inner">
+      <a class="brand" href="/">skaters</a>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/demos/">Demos</a>
+        <a href="/guide.html">Guide</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
+          <span class="drop">
+            <a href="/scope.html">Scope</a>
+            <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
+            <a href="/faq.html">FAQ</a>
+            <a href="/skills.html">Skills</a>
+          </span>
+        </span>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Challenges</a>
+            <a href="/sandwich.html">Sandwich</a>
+            <a href="/papers.html">Papers</a>
+          </span>
+        </span>
+        <a href="https://github.com/microprediction/skaters">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <h1>A history of the probability integral transform (with some bias/variance tradeoff)</h1>
+    <p class="subtitle">Push an observation through its own cumulative distribution and it
+      becomes uniform. Pull a uniform back through an inverse cdf and it becomes anything
+      you like.</p>
+
+    <p class="lead">That pair of moves is about a century old and it keeps finding new work:
+      significance testing, simulation, dependence modelling, forecast evaluation, generative
+      models, and lately streaming prediction and anomaly detection. Here is the family tree
+      as we understand it. Some of the later history is told firsthand, which is a source and
+      a bias at the same time. Corrections welcome:
+      <a href="https://github.com/microprediction/skaters/issues">open an issue</a>.</p>
+
+    <div style="background:#fff;border:1px solid var(--border);border-radius:8px;padding:16px 18px;margin:22px 0;">
+      <h2 style="font-size:19px;margin:0 0 4px;">Try it: every distribution is a costume</h2>
+      <p style="color:var(--muted);font-size:0.92em;margin:4px 0 10px;">
+        Samples fall from the left distribution, pass through <em>its own</em>
+        cdf to become uniform, then out through the right distribution's
+        inverse cdf. Swap either costume; the middle histogram never changes.
+        (The sampler itself is the reverse move: uniforms pulled through an
+        inverse cdf. The two moves of the whole timeline, live.)
+      </p>
+      <div style="display:flex;gap:10px;flex-wrap:wrap;align-items:center;margin-bottom:8px;font-size:0.9em;">
+        <span style="color:var(--muted)">from</span>
+        <span id="pitFrom"></span>
+        <span style="color:var(--muted)">to</span>
+        <span id="pitTo"></span>
+        <button id="pitReset" style="background:#fff;border:1px solid var(--border);border-radius:5px;padding:4px 10px;cursor:pointer;">restart</button>
+      </div>
+      <div style="display:flex;gap:8px;flex-wrap:wrap;">
+        <div style="flex:1 1 180px;min-width:160px;">
+          <div style="font-size:0.8em;color:var(--muted);text-align:center;">x ~ A</div>
+          <svg id="pitA" viewBox="0 0 220 120" style="width:100%"></svg>
+        </div>
+        <div style="flex:0 0 auto;align-self:center;color:var(--muted);font-size:1.4em;">&rarr;&nbsp;F<sub>A</sub>&nbsp;&rarr;</div>
+        <div style="flex:1 1 180px;min-width:160px;">
+          <div style="font-size:0.8em;color:var(--muted);text-align:center;">u = F<sub>A</sub>(x), always this</div>
+          <svg id="pitU" viewBox="0 0 220 120" style="width:100%"></svg>
+        </div>
+        <div style="flex:0 0 auto;align-self:center;color:var(--muted);font-size:1.4em;">&rarr;&nbsp;F<sub>B</sub><sup>&minus;1</sup>&nbsp;&rarr;</div>
+        <div style="flex:1 1 180px;min-width:160px;">
+          <div style="font-size:0.8em;color:var(--muted);text-align:center;">y = F<sub>B</sub><sup>&minus;1</sup>(u) ~ B</div>
+          <svg id="pitB" viewBox="0 0 220 120" style="width:100%"></svg>
+        </div>
+      </div>
+      <p style="color:var(--muted);font-size:0.9em;margin:10px 0 0;">
+        This is why continuous univariate random variables are inherently the
+        same object: any two are joined by a monotone map through the flat
+        middle. For the time-series version, where F is a live forecast and
+        the map becomes a causal bijection on whole paths, see the
+        <a href="https://skaters.microprediction.org/demos/rosenblatt.html">Rosenblatt
+        demo at skaters.microprediction.org</a>.
+      </p>
+    </div>
+
+    <script>
+    (function () {
+      const SQRT2 = Math.sqrt(2);
+      function erf(z) {
+        const t = 1 / (1 + 0.3275911 * Math.abs(z));
+        const y = 1 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741)
+          * t - 0.284496736) * t + 0.254829592) * t * Math.exp(-z * z);
+        return z >= 0 ? y : -y;
+      }
+      const ncdf = (x, m, s) => 0.5 * (1 + erf((x - m) / (s * SQRT2)));
+      function bisect(cdf, u, lo, hi) {
+        for (let i = 0; i < 60; i++) {
+          const mid = 0.5 * (lo + hi);
+          if (cdf(mid) < u) lo = mid; else hi = mid;
+        }
+        return 0.5 * (lo + hi);
+      }
+      const DISTS = {
+        normal: { label: "normal", range: [-4, 4],
+          cdf: x => ncdf(x, 0, 1) },
+        exponential: { label: "exponential", range: [0, 6],
+          cdf: x => x <= 0 ? 0 : 1 - Math.exp(-x),
+          q: u => -Math.log(1 - u) },
+        bimodal: { label: "bimodal", range: [-5, 5],
+          cdf: x => 0.55 * ncdf(x, -1.8, 0.7) + 0.45 * ncdf(x, 1.8, 0.9) },
+        heavy: { label: "heavy (Cauchy)", range: [-8, 8],
+          cdf: x => 0.5 + Math.atan(x) / Math.PI,
+          q: u => Math.tan(Math.PI * (u - 0.5)) },
+      };
+      for (const d of Object.values(DISTS)) {
+        if (!d.q) d.q = u => bisect(d.cdf, u, d.range[0] - 6, d.range[1] + 6);
+      }
+      let from = "bimodal", to = "exponential";
+      const BINS = 26;
+      let counts;
+      function reset() {
+        counts = { A: new Array(BINS).fill(0), U: new Array(BINS).fill(0),
+                   B: new Array(BINS).fill(0) };
+      }
+      reset();
+      function bin(v, lo, hi) {
+        const i = Math.floor((v - lo) / (hi - lo) * BINS);
+        return Math.min(BINS - 1, Math.max(0, i));
+      }
+      function draw(svgId, c, accent) {
+        const svg = document.getElementById(svgId);
+        const peak = Math.max(8, Math.max.apply(null, c));
+        let html = '<line x1="6" y1="112" x2="214" y2="112" stroke="#ddd"/>';
+        const w = 208 / BINS;
+        for (let i = 0; i < BINS; i++) {
+          const h = 104 * c[i] / peak;
+          html += `<rect x="${(6 + i * w).toFixed(1)}" y="${(112 - h).toFixed(1)}"`
+            + ` width="${(w - 1).toFixed(1)}" height="${h.toFixed(1)}"`
+            + ` rx="1.5" fill="${accent}"/>`;
+        }
+        svg.innerHTML = html;
+      }
+      function tick() {
+        const A = DISTS[from], B = DISTS[to];
+        for (let k = 0; k < 24; k++) {
+          const x = A.q(Math.random());
+          const u = A.cdf(x);
+          const y = B.q(Math.min(Math.max(u, 1e-9), 1 - 1e-9));
+          counts.A[bin(x, A.range[0], A.range[1])]++;
+          counts.U[bin(u, 0, 1)]++;
+          counts.B[bin(y, B.range[0], B.range[1])]++;
+        }
+        draw("pitA", counts.A, "#5a5a5a");
+        draw("pitU", counts.U, "#4a3aff");
+        draw("pitB", counts.B, "#5a5a5a");
+      }
+      function buttons(spanId, current, onpick) {
+        const span = document.getElementById(spanId);
+        span.innerHTML = "";
+        for (const key of Object.keys(DISTS)) {
+          const b = document.createElement("button");
+          b.textContent = DISTS[key].label;
+          const active = key === current;
+          b.style.cssText = "border:1px solid var(--border);border-radius:5px;"
+            + "padding:3px 9px;margin-right:4px;cursor:pointer;font-size:0.95em;"
+            + (active ? "background:var(--accent);color:#fff;border-color:var(--accent);"
+                      : "background:#fff;color:var(--text);");
+          b.onclick = () => onpick(key);
+          span.appendChild(b);
+        }
+      }
+      function rebuild() {
+        buttons("pitFrom", from, k => { from = k; reset(); rebuild(); });
+        buttons("pitTo", to, k => { to = k; reset(); rebuild(); });
+      }
+      document.getElementById("pitReset").onclick = () => reset();
+      rebuild();
+      setInterval(tick, 120);
+    })();
+    </script>
+
+    <div class="tl">
+
+      <div class="tl-item">
+        <span class="tl-year">1781</span> &middot; <span class="tl-who">Monge</span>
+        <p>Monge poses the transport question: move a pile of earth to a target shape at least cost. Two centuries on, the probability integral transform turns out to be a transport map, and its one-dimensional form the optimal one.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1875</span> &middot; <span class="tl-who">Galton</span>
+        <p>The cdf becomes a working object. In <a href="https://galton.org/essays/1870-1879/galton-1875-intercomparison.pdf">Statistics by Intercomparison</a> Galton plots the cumulative rank-to-magnitude curve of a trait and names it the ogive. Everything below is a use of this curve and its inverse.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1900</span> &middot; <span class="tl-who">Pearson</span>
+        <p>The <a href="https://www.tandfonline.com/doi/abs/10.1080/14786440009463897">chi-squared goodness-of-fit test</a>, the first general test of whether data fit a hypothesized law. Every EDF test below is an attempt to beat it by working on the transformed scale instead of binned counts.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1914</span> &middot; <span class="tl-who">Hazen</span>
+        <p>Flood-frequency analysis plots ordered observations at positions approximating F, the plotting-position idea that puts the empirical cdf on paper a generation before the transform is named.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1914</span> &middot; <span class="tl-who">Pearson</span>
+        <p><a href="https://archive.org/details/tablesforstatist00pearrich">Tables for Statisticians and Biometricians</a>. The cdf becomes computable: using F in practice meant looking it up, and Pearson’s laboratory industrialized the tables that made the ogive a working tool rather than a picture.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">~1922</span> &middot; <span class="tl-who">Fisher</span>
+        <p>Fisher's square-root approximation: for a chi-squared X, sqrt(2X) is roughly normal with mean sqrt(2k-1), the earliest cheap Gaussianizer, a poor man's PIT by moment matching.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1928&ndash;1931</span> &middot; <span class="tl-who">Cramer &amp; von Mises</span>
+        <p>The integrated-squared-deviation statistic omega-squared, computed on PIT-transformed data, the ancestor <a href="https://www.tandfonline.com/doi/abs/10.1080/03461238.1928.10416862">Cramer 1928</a> and von Mises 1931 gave and that Anderson and Darling merely re-weight.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1931</span> &middot; <span class="tl-who">Wilson &amp; Hilferty</span>
+        <p>The cube-root Gaussianizer: <a href="https://www.pnas.org/doi/10.1073/pnas.17.12.684">(X/k) to the one-third power</a> of a chi-squared is close to normal, the famous fixed-exponent stand-in for the exact PIT.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1932</span> &middot; <span class="tl-who">Fisher</span>
+        <p>The implicit era. A p-value is the PIT of a test statistic under the null. Fisher never quite says so, but his machinery leans on it: significance levels compare across experiments because null p-values are uniform, and his rule for combining independent tests is a fact about transformed uniforms, minus twice the sum of the log p-values is chi-squared<sup><a href="#fn1" style="text-decoration:none">1</a></sup>. His 1930 <a href="https://www.cambridge.org/core/journals/mathematical-proceedings-of-the-cambridge-philosophical-society/article/abs/inverse-probability/C9AB0A7C4566A3F9FCCEC489CA854814">fiducial argument</a> runs the transform in reverse.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1933</span> &middot; <span class="tl-who">Pearson</span>
+        <p>The transform gets a proper job. Pearson's <a href="https://academic.oup.com/biomet/article-abstract/25/3-4/379/200914">Biometrika paper</a> puts the probability integral to work on goodness of fit, transforming a sample to uniforms and testing it there.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1933</span> &middot; <span class="tl-who">Glivenko &amp; Cantelli</span>
+        <p>The empirical cdf earns trust: <a href="https://encyclopediaofmath.org/wiki/Glivenko-Cantelli_theorem">uniform convergence</a> to the population law, proved twice in the same 1933 volume of the <em>Giornale dell&rsquo;Istituto Italiano degli Attuari</em>. The license to treat Galton&rsquo;s ogive as an estimate; every EDF statistic below leans on it.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1933</span> &middot; <span class="tl-who">Kolmogorov</span>
+        <p>The first big structural payoff. The sup|F<sub>n</sub>&thinsp;&minus;&thinsp;F| statistic is distribution-free: after the PIT every continuous distribution is the same one, so a single table serves them all. It becomes the KS test.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1936</span> &middot; <span class="tl-who">Bartlett</span>
+        <p>The <a href="https://rss.onlinelibrary.wiley.com/doi/10.2307/2983678">square-root transform</a> stabilizes the variance of Poisson counts, an early member of the transform-to-tractable family the PIT perfects.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1936&ndash;1948</span> &middot; <span class="tl-who">Smirnov</span>
+        <p>Smirnov derives the limiting distribution of omega-squared and publishes <a href="https://projecteuclid.org/journals/annals-of-mathematical-statistics/volume-19/issue-2/Table-for-Estimating-the-Goodness-of-Fit-of-Empirical-Distributions/10.1214/aoms/1177730256.full">the tables</a> that make EDF testing practical, and the two-sample version of Kolmogorov’s statistic carries his name.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1937</span> &middot; <span class="tl-who">Neyman</span>
+        <p>Neyman builds his <a href="https://www.tandfonline.com/doi/abs/10.1080/03461238.1937.10404821">smooth goodness-of-fit tests</a> directly on PIT-transformed data, testing uniformity against smooth alternatives.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1938</span> &middot; <span class="tl-who">Pearson</span>
+        <p>Egon Pearson writes <a href="https://academic.oup.com/biomet/article-abstract/30/1-2/134/176485">the paper</a> that treats the transformation as a subject in its own right and gives it its name<sup><a href="#fn2" style="text-decoration:none">2</a></sup>.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1940</span> &middot; <span class="tl-who">Hoeffding</span>
+        <p>Dependence built on the uniform scale. <a href="https://link.springer.com/chapter/10.1007/978-1-4612-0865-5_4">Hoeffding</a> standardises each margin to uniform and studies the dependence that remains, a copula in all but name, in a Berlin institute series.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1947</span> &middot; <span class="tl-who">Ulam &amp; von Neumann</span>
+        <p>The inverse direction becomes an industry. Convalescing over solitaire, Ulam wondered whether dealing the hands out and counting beats combinatorics, and thought of neutron diffusion. A 1947 von Neumann letter, circulated as Los Alamos report LAMS-551, draws neutron free paths as the log of a uniform, the first surviving use of inverse-cdf sampling<sup><a href="#fn3" style="text-decoration:none">3</a></sup>.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1948</span> &middot; <span class="tl-who">Anscombe</span>
+        <p>The variance-stabilizing 2 sqrt(x + 3/8) for Poisson counts, another cheap monotone map toward a tractable distribution.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1948</span> &middot; <span class="tl-who">David &amp; Johnson</span>
+        <p>The transform meets estimation and loses its innocence. <a href="https://academic.oup.com/biomet/article-abstract/35/1-2/182/178943">David and Johnson</a> show that plugging sample-estimated parameters into the cdf destroys the iid-uniform property.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1949</span> &middot; <span class="tl-who">Metropolis &amp; Ulam</span>
+        <p>The paper that <a href="https://www.tandfonline.com/doi/abs/10.1080/01621459.1949.10483310">named the Monte Carlo method</a>, the home von Neumann inverse-transform sampling lives inside.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1949&ndash;1952</span> &middot; <span class="tl-who">Doob &amp; Donsker</span>
+        <p><a href="https://projecteuclid.org/journals/annals-of-mathematical-statistics/volume-20/issue-3/Heuristic-Approach-to-the-Kolmogorov-Smirnov-Theorems/10.1214/aoms/1177729991.full">Doob</a> conjectured and <a href="https://projecteuclid.org/journals/annals-of-mathematical-statistics/volume-23/issue-2/Justification-and-Extension-of-Doobs-Heuristic-Approach-to-the-Kolmogorov/10.1214/aoms/1177729445.full">Donsker</a> proved that the empirical process of PIT-transformed data converges to a Brownian bridge free of the law, which is why every EDF statistic has one universal null distribution and the result Durbin extends to estimated parameters.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1950</span> &middot; <span class="tl-who">Freeman &amp; Tukey</span>
+        <p>The <a href="https://projecteuclid.org/journals/annals-of-mathematical-statistics/volume-21/issue-4/Transformations-Related-to-the-Angular-and-the-Square-Root/10.1214/aoms/1177729756.full">double-square-root</a> refinement for Poisson counts, better near zero, a sharper variance stabilizer.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1950</span> &middot; <span class="tl-who">David &amp; Johnson</span>
+        <p>A second <a href="https://academic.oup.com/biomet/article-abstract/37/1-2/42/218253">David and Johnson paper</a>, on the PIT when the variable is discontinuous: at an atom F(X) is no longer uniform, and the fix is randomization inside the jump or a deliberate surrogate, the mid-PIT that arrives sixty years later. The innocent transform acquires boundary conditions.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1951</span> &middot; <span class="tl-who">Fr&eacute;chet</span>
+        <p>Fr&eacute;chet poses the given-margins problem and proves the sharp bounds on a joint distribution with fixed marginals, now the Fr&eacute;chet&ndash;Hoeffding bounds, the frame Sklar's theorem later fills.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1951</span> &middot; <span class="tl-who">von Neumann</span>
+        <p>The general statement X = F<sup>&minus;1</sup>(U) is written down in <a href="https://mcnp.lanl.gov/pdf_files/InBook_Computing_1961_Neumann_JohnVonNeumannCollectedWorks_VariousTechniquesUsedinConnectionwithRandomDigits.pdf">Various techniques used in connection with random digits</a>, alongside the rejection method as the fallback when the inverse is cumbersome. Every simulated random variable since is the inverse PIT. It is even named the inverse probability integral transform.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1952</span> &middot; <span class="tl-who">Rosenblatt</span>
+        <p><a href="https://projecteuclid.org/journals/annals-of-mathematical-statistics/volume-23/issue-3/Remarks-on-a-Multivariate-Transformation/10.1214/aoms/1177729394.full">Three pages in the Annals</a>. Chain the transform through conditional distributions, u<sub>t</sub> = F(x<sub>t</sub>&thinsp;|&thinsp;x<sub>&lt;t</sub>), and any joint law becomes iid uniforms, a causal bijection between an arbitrary process and pure noise. The universal whitener, and the theorem these packages stand on.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1952&ndash;1954</span> &middot; <span class="tl-who">Anderson &amp; Darling</span>
+        <p>Weighting the transformed process. <a href="https://projecteuclid.org/journals/annals-of-mathematical-statistics/volume-23/issue-2/Asymptotic-Theory-of-Certain-Goodness-of-Fit-Criteria-Based-on/10.1214/aoms/1177729437.full">Anderson and Darling</a> substitute u = F(x) and weight the uniform empirical process by 1/(u(1&minus;u)) to sharpen the tails, and supply usable significance points in 1954.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year"></span> &middot; <span class="tl-who">a second way to become uniform</span>
+        <p>There is another route to canonical noise: do not transform the value, transform the clock. For a continuous martingale the canonical clock is quadratic variation; for a point process it is the compensator. A correct conditional model turns raw observations into standard noise, Brownian or Poisson or exponential, and one last PIT makes it uniform.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1952</span> &middot; <span class="tl-who">van der Waerden</span>
+        <p>Normal scores: replace ranks by standard-normal quantiles and test there. The rank-to-Gaussian move, the PIT&rsquo;s flat middle re-dressed as a bell, and a bridge from distribution-free ranks to Gaussian machinery that Chernoff and Savage would later show gives up nothing.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1953&ndash;1963</span> &middot; <span class="tl-who">Doob &amp; Meyer</span>
+        <p>The stochastic clock becomes identifiable. A submartingale splits uniquely into a martingale plus a predictable increasing process; for a counting process that increasing process is the compensator, the model-implied amount of event time elapsed. Later point-process transforms do not push the value through a cdf, they push calendar time through this compensator.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1955</span> &middot; <span class="tl-who">Kac, Kiefer &amp; Wolfowitz</span>
+        <p><a href="https://projecteuclid.org/euclid.aoms/1177728538">First rigorous asymptotics</a> for distance-based EDF tests when parameters are estimated, the theory companion to the estimated-parameter problem.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1955</span> &middot; <span class="tl-who">Hastings</span>
+        <p>Minimax rational approximations to standard functions including the inverse normal cdf, the ancestor of every later inverse-normal fit used to turn uniforms into Gaussians.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1956</span> &middot; <span class="tl-who">Dvoretzky, Kiefer &amp; Wolfowitz</span>
+        <p>The finite-sample license: an <a href="https://projecteuclid.org/journals/annals-of-mathematical-statistics/volume-27/issue-3/Asymptotic-Minimax-Character-of-the-Sample-Distribution-Function-and-of/10.1214/aoms/1177728174.full">exponential bound</a> on the sup-error of the empirical cdf, sharpened by Massart in 1990 to its clean constant. Confidence bands for F itself, and non-asymptotic control for everything built on the transformed scale.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1957</span> &middot; <span class="tl-who">Knothe</span>
+        <p>The transport reading. <a href="https://projecteuclid.org/journals/michigan-mathematical-journal/volume-4/issue-1/Contributions-to-the-theory-of-convex-bodies/10.1307/mmj/1028990175.full">Knothe</a> builds a triangular map carrying one multivariate law onto another by sequential conditioning, the same object as Rosenblatt's transform, now called the Knothe&ndash;Rosenblatt rearrangement. The PIT is a transport map, and in one dimension it is literally the optimal one<sup><a href="#fn4" style="text-decoration:none">4</a></sup>.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1958</span> &middot; <span class="tl-who">Box &amp; Muller</span>
+        <p>Computing &Phi;<sup>&minus;1</sup> was hard enough that <a href="https://projecteuclid.org/journals/annals-of-mathematical-statistics/volume-29/issue-2/A-Note-on-the-Generation-of-Random-Normal-Deviates/10.1214/aoms/1177706645.full">Box and Muller</a> built a method to sample normals without it.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1959</span> &middot; <span class="tl-who">Sklar</span>
+        <p>Sklar's theorem: every joint distribution is a copula applied to its margins, unique when the margins are continuous, so dependence becomes an object you model apart from the margins. The <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4198458">three-page note</a> appeared in Paris, in French, at Fr&eacute;chet's request, three theorems stated without proof, and coined "copula" from the grammatical term for a linking word.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1960</span> &middot; <span class="tl-who">Schweizer &amp; Sklar</span>
+        <p>The copula goes underground for two decades. <a href="https://projecteuclid.org/journals/pacific-journal-of-mathematics/volume-10/issue-1/Statistical-metric-spaces/pjm/1103038644.full">Schweizer and Sklar</a> develop copulas inside probabilistic metric spaces, where they mostly stay until the 1980s.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1960</span> &middot; <span class="tl-who">Halton</span>
+        <p><a href="https://link.springer.com/article/10.1007/BF01386213">Low-discrepancy sequences</a> fill the cube more evenly than random points, and mapped through the inverse cdf they Gaussianize into quasi-Monte Carlo.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1960</span> &middot; <span class="tl-who">Sibuya</span>
+        <p><a href="https://link.springer.com/article/10.1007/BF01682329">Bivariate normals</a> are asymptotically independent in the tail, the observation that seeded the tail-dependence coefficients and the hunt for copulas that keep their tails.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1961</span> &middot; <span class="tl-who">Blum, Kiefer &amp; Rosenblatt</span>
+        <p><a href="https://projecteuclid.org/journals/annals-of-mathematical-statistics/volume-32/issue-2/Distribution-Free-Tests-of-Independence-Based-on-the-Sample-Distribution/10.1214/aoms/1177705055.full">Distribution-free independence tests</a> built from sample distribution functions: Hoeffding&rsquo;s margin-standardisation made an operating programme, dependence as an object on uniform margins ahead of the copula boom.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1961</span> &middot; <span class="tl-who">Watson</span>
+        <p><a href="https://academic.oup.com/biomet/article/48/1-2/109/225627">U-squared</a>, the rotation-invariant EDF statistic for circular and periodic data, the omega-squared idea on the circle.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1964</span> &middot; <span class="tl-who">Watanabe</span>
+        <p>The Poisson process gets its martingale certificate: if a unit-jump counting process has N(t) minus t as a martingale, it is unit-rate Poisson. The jump analogue of Levy characterizing Brownian motion as the canonical continuous martingale on its own clock.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1964</span> &middot; <span class="tl-who">Hertz</span>
+        <p>The inverse PIT reaches finance. Hertz's Harvard Business Review paper on risk analysis in capital investment samples uncertain inputs from specified distributions, Monte Carlo by inverse transform, in corporate decision-making.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1964</span> &middot; <span class="tl-who">Box &amp; Cox</span>
+        <p>The adaptive power family <a href="https://rss.onlinelibrary.wiley.com/doi/abs/10.1111/j.2517-6161.1964.tb00553.x">(x^lambda - 1)/lambda</a> chosen by likelihood to Gaussianize, the parametric generalization of the fixed-exponent root transforms.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1964</span> &middot; <span class="tl-who">Marsaglia &amp; Bray</span>
+        <p>The <a href="https://epubs.siam.org/doi/10.1137/1006063">polar method</a>, Box-Muller without the trigonometry, another route from uniforms to normals.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1965</span> &middot; <span class="tl-who">Dambis, Dubins &amp; Schwarz</span>
+        <p>The continuous-path PIT. A continuous local martingale is Brownian motion evaluated at its own quadratic-variation clock. Calendar time is the wrong coordinate and accumulated variance is the canonical one: the scalar PIT says use the probability scale, this says use information time.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1965</span> &middot; <span class="tl-who">Shapiro &amp; Wilk</span>
+        <p>The <a href="https://academic.oup.com/biomet/article-abstract/52/3-4/591/336553">order-statistic normality test</a>: correlate the ordered sample with expected normal order statistics. Quantile structure as a test statistic, and for decades the default answer to &ldquo;is it normal?&rdquo;</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1967</span> &middot; <span class="tl-who">Marshall &amp; Olkin</span>
+        <p>A <a href="https://www.tandfonline.com/doi/abs/10.1080/01621459.1967.10482885">multivariate exponential</a> from a fatal-shock model, whose dependence is the singular Marshall-Olkin copula, a genuine construction predating Sklar’s uptake.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1967</span> &middot; <span class="tl-who">Sobol’</span>
+        <p>The <a href="https://www.mathnet.ru/eng/zvmmf7334">Sobol sequence</a>, the workhorse low-discrepancy set, fed through the inverse cdf for quasi-Monte Carlo.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1967</span> &middot; <span class="tl-who">Lilliefors</span>
+        <p><a href="https://www.tandfonline.com/doi/abs/10.1080/01621459.1967.10482916">Monte-Carlo significance points</a> for the KS normality test when mean and variance are estimated, the practical fix for the estimated-parameter problem.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1968</span> &middot; <span class="tl-who">Cox &amp; Snell</span>
+        <p>Residuals for any parametric model. <a href="https://academic.oup.com/jrsssb/article/30/2/248/7027130">A General Definition of Residuals</a> pushes each observation through its own fitted distribution, and in survival analysis the Cox&ndash;Snell residual is a PIT residual, unit exponential after a minus log when the model is right<sup><a href="#fn5" style="text-decoration:none">5</a></sup>. Model criticism by transformed residuals starts here, and is what the parade does one tick at a time.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1968</span> &middot; <span class="tl-who">Wilk &amp; Gnanadesikan</span>
+        <p>The transform gets its picture. The <a href="https://academic.oup.com/biomet/article/55/1/1/262814">Q&ndash;Q plot</a> reads calibration off a straight line, the diagnostic descendant of the PIT that every forecaster still squints at.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1968</span> &middot; <span class="tl-who">Panofsky &amp; Brier</span>
+        <p>Quantile mapping is born. Correcting one distribution to match another by pushing it through F<sub>source</sub> then F<sub>target</sub><sup>&minus;1</sup> is inverse-PIT composition, and climate and hydrology have leaned on it ever since.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1969&ndash;1972</span> &middot; <span class="tl-who">Meyer &amp; Papangelou</span>
+        <p>The PIT learns to move time. For a point process with conditional intensity, transform event times by the compensator, the integral of that intensity, and under a correct model the result is unit-rate Poisson. The gaps in compensator time are iid exponential, and 1 minus their exponential is iid uniform, Rosenblatt for arrivals rather than values.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1973</span> &middot; <span class="tl-who">Durbin</span>
+        <p><a href="https://projecteuclid.org/journals/annals-of-statistics/volume-1/issue-2/Weak-Convergence-of-the-Sample-Distribution-Function-when-Parameters-are/10.1214/aos/1176342365.full">Weak convergence with estimated parameters</a>, the definitive limit theory for the empirical process when the cdf is fitted, not known. The estimated-parameter problem carries his name, and every model that scores its own residuals inherits it.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1974</span> &middot; <span class="tl-who">Stephens</span>
+        <p><a href="https://www.tandfonline.com/doi/abs/10.1080/01621459.1974.10480196">EDF statistics for goodness of fit</a>: the significance points and power comparisons that made D, W-squared, U-squared and A-squared standard equipment on transformed data.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">~1974</span> &middot; <span class="tl-who">histogram equalization</span>
+        <p><a href="https://homepages.inf.ed.ac.uk/rbf/HIPR2/histeq.htm">Histogram equalization</a>, formalized in image processing in the mid-1970s (Hummel and others), maps each pixel through the image's own cumulative histogram. That is the forward PIT applied to intensities, and the output comes out flat for exactly the reason the transform makes uniforms.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1975</span> &middot; <span class="tl-who">Hummel</span>
+        <p><a href="https://www.sciencedirect.com/science/article/abs/pii/0146664X7590009X">Histogram specification</a> proves the monotone gray-level map carrying one image histogram onto any target is unique, which is inverse-PIT composition, the matching complement to equalization.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1975</span> &middot; <span class="tl-who">Kimeldorf &amp; Sampson</span>
+        <p><a href="https://www.tandfonline.com/doi/abs/10.1080/03610928308827274">Kimeldorf and Sampson</a> reinvent copulas independently as uniform representations, unaware of the metric-space lineage, a sign of how obscure the idea still was.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1976</span> &middot; <span class="tl-who">Matheson &amp; Winkler</span>
+        <p>The score the forecasting world lives by is born far from it, in <a href="https://dl.acm.org/doi/abs/10.1287/mnsc.22.10.1087">Management Science</a>. The CRPS is the Brier score of the forecast cdf integrated over every threshold, and its reliability component reduces to rank-histogram, that is PIT, information.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1977</span> &middot; <span class="tl-who">Boyle</span>
+        <p><a href="https://ideas.repec.org/a/eee/jfinec/v4y1977i3p323-338.html">Options: A Monte Carlo Approach</a> prices derivatives by simulating asset paths from the risk-neutral law, inverse-transform sampling on Wall Street twenty-three years before the copula work. This is where the inverse PIT reaches finance in earnest.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1977</span> &middot; <span class="tl-who">Beasley &amp; Springer</span>
+        <p><a href="https://academic.oup.com/jrsssc/article/26/1/118/6953567">Algorithm AS 111</a>, the rational approximation to the normal quantile that inverse-transform pipelines shipped for a generation, later given a better tail by Moro and superseded by Wichura.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1978</span> &middot; <span class="tl-who">Aalen &amp; Hoem</span>
+        <p>Random time changes enter multivariate counting-process statistics: subtract the compensator for a martingale, or run on compensator time for Poisson noise. The hazard scale becomes the PIT scale for lifetimes and recurrent events.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1979</span> &middot; <span class="tl-who">Deheuvels</span>
+        <p>The <a href="https://www.persee.fr/doc/barb_0001-4141_1979_num_65_1_58521">empirical copula</a>, the rank-based nonparametric estimator of the dependence function, copulas built straight from the PIT’s empirical margins.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1979</span> &middot; <span class="tl-who">McKay, Beckman &amp; Conover</span>
+        <p><a href="https://www.jstor.org/stable/1268522">Latin hypercube sampling</a>: stratify each uniform into equal-probability bins, one draw per bin, then push through the inverse cdf. Stratified inverse PIT, and a staple of computer experiments ever since.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1980</span> &middot; <span class="tl-who">Box</span>
+        <p>Bayesian model criticism. <a href="https://academic.oup.com/jrsssa/article/143/4/383/7105478">Box</a> judges a model by where the data fall in its predictive distribution, the prior-predictive PIT check.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1981</span> &middot; <span class="tl-who">Schweizer &amp; Wolff</span>
+        <p><a href="https://projecteuclid.org/journals/annals-of-statistics/volume-9/issue-4/On-Nonparametric-Measures-of-Dependence-for-Random-Variables/10.1214/aos/1176345528.full">Schweizer and Wolff</a> build measures of dependence on the copula alone, invariant to monotone transforms of the margins.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1982</span> &middot; <span class="tl-who">Nelson</span>
+        <p>Probability plotting renders the PIT graphically: order the failure times, assign plotting positions approximating F, and a correct model falls on a straight line.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1982</span> &middot; <span class="tl-who">Iman &amp; Conover</span>
+        <p><a href="https://www.tandfonline.com/doi/abs/10.1080/03610918208812265">Rank-correlation induction</a>: impose a target dependence on samples with arbitrary margins by reordering them, dependence carried by the ordering of the uniforms, a copula idea in simulation clothing sixteen years before the credit copulas.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1982</span> &middot; <span class="tl-who">Dawid</span>
+        <p>The <a href="https://www.tandfonline.com/doi/abs/10.1080/01621459.1982.10477856">well-calibrated Bayesian</a>: a coherent forecaster must expect to be calibrated, the binary-event foundation the PIT extends to full distributions.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1983</span> &middot; <span class="tl-who">Peacock</span>
+        <p>The KS test becomes an everyday tool in astronomy for comparing luminosity functions and source counts, with the standing caution, from <a href="https://academic.oup.com/mnras/article/202/3/615/967854">Peacock</a>, that its distribution-free property fails in more than one dimension.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1984</span> &middot; <span class="tl-who">Dawid</span>
+        <p>The forecast-evaluation program, stated in full and mostly overlooked. <a href="https://www.jstor.org/stable/2981683">The prequential approach</a> has a section literally titled Probability Integral Transform, proposing that a sequential forecaster be judged by whether U<sub>n</sub> = F<sub>n</sub>(X<sub>n</sub>) looks like an iid uniform sample, citing Rosenblatt. This is what modern density-forecast checking does, fourteen years early<sup><a href="#fn6" style="text-decoration:none">6</a></sup>.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1984</span> &middot; <span class="tl-who">Rubin</span>
+        <p><a href="https://doi.org/10.1214/aos/1176346785">Posterior predictive checks</a>: simulate replicated data and ask whether the observed data are typical, the PIT pointed at the fitted model rather than a fixed one.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1986</span> &middot; <span class="tl-who">Genest &amp; MacKay</span>
+        <p><a href="https://www.tandfonline.com/doi/abs/10.1080/00031305.1986.10475414">The Joy of Copulas</a> finally sells the subject to statisticians, and it starts spreading beyond the metric-space corner.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1986</span> &middot; <span class="tl-who">Hawkins &amp; Wixley</span>
+        <p>The <a href="https://www.tandfonline.com/doi/abs/10.1080/00031305.1986.10475420">fourth root</a> of a chi-squared is close to normal, not uniform: Y = X^c is Weibull with shape 1/c, and the zero-skew shape sits near 3.60, so c near 0.277, with one quarter the convenient round number beside it. The obscure sharper sibling of Wilson-Hilferty, and the transform spectral analysts use to normalize periodogram ordinates, which are asymptotically exponential.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1986</span> &middot; <span class="tl-who">Devroye</span>
+        <p><a href="https://luc.devroye.org/chapter_two.pdf">Non-Uniform Random Variate Generation</a>, the canonical reference for turning uniforms into everything else. He calls the inverse-cdf recipe the inversion method, and the book is the field’s dictionary.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1988</span> &middot; <span class="tl-who">Wichura</span>
+        <p>Algorithm AS 241 gives the inverse normal to sixteen digits, closing the accuracy problem that had motivated Box and Muller thirty years earlier. It is the qnorm behind most software.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1988</span> &middot; <span class="tl-who">Brown &amp; Nair</span>
+        <p>A simple proof of the multivariate random time-change theorem, the clean statement that a point process rescaled by its compensator is unit-rate Poisson, the theorem Ogata turns into earthquake residual analysis the same year.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1988</span> &middot; <span class="tl-who">Ogata</span>
+        <p>ETAS residual analysis rescales earthquake times by the integrated conditional intensity so a correct model yields a unit-rate Poisson process tested for uniformity, the PIT for point processes.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1989</span> &middot; <span class="tl-who">Rayner &amp; Best</span>
+        <p>The <a href="https://books.google.com/books/about/Smooth_Tests_of_Goodness_of_Fit.html?id=c2_mCwAAQBAJ">smooth-test revival</a> puts Neyman's 1937 PIT-based framework back to work, showing many classical goodness-of-fit statistics are smooth tests or their components.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1991</span> &middot; <span class="tl-who">Brenier</span>
+        <p><a href="https://onlinelibrary.wiley.com/doi/10.1002/cpa.3160440402">The optimal transport map</a> for quadratic cost exists, is unique, and is the gradient of a convex function, the general-dimension theorem whose one-dimensional case is exactly the monotone PIT.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1993</span> &middot; <span class="tl-who">Genest &amp; Rivest</span>
+        <p><a href="https://www.tandfonline.com/doi/abs/10.1080/01621459.1993.10476372">Identifies and fits</a> bivariate Archimedean copulas through the Kendall distribution of the generator, the standard selection tool.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1993</span> &middot; <span class="tl-who">Seillier-Moiseiwitsch &amp; Dawid</span>
+        <p><a href="https://doi.org/10.1080/01621459.1993.10594328">Turns prequential calibration into tests</a> of sequential forecast validity, the testing theory between Dawid 1984 and later PIT tests.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1994</span> &middot; <span class="tl-who">RiskMetrics</span>
+        <p>The empirical PIT on trading desks. J.P. Morgan's <a href="https://www.msci.com/documents/10199/5915b101-4206-4ba0-aee2-3449d5c7e95a">RiskMetrics Technical Document</a> popularises historical-simulation VaR, which reads a loss quantile straight off the empirical cdf.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1995</span> &middot; <span class="tl-who">McCann</span>
+        <p><a href="https://projecteuclid.org/journals/duke-mathematical-journal/volume-80/issue-2/Existence-and-uniqueness-of-monotone-measure-preserving-maps/10.1215/S0012-7094-95-08013-2.short">Drops Brenier’s moment assumptions</a> and frames the optimal map as the monotone measure-preserving map, the clean generalization of the monotone rearrangement the PIT instantiates.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1995</span> &middot; <span class="tl-who">Moro</span>
+        <p>The Beasley-Springer inverse normal with a better tail, the Gaussianizer that became the finance and quasi-Monte Carlo default.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1996</span> &middot; <span class="tl-who">Dunn &amp; Smyth</span>
+        <p><a href="https://gksmyth.github.io/pubs/residual.pdf">Randomized quantile residuals</a>: the fitted cdf at each response, then the normal quantile, with randomization for discrete data, exactly-uniform-then-normal residuals, the discrete PIT that GLM diagnostics rest on.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1996</span> &middot; <span class="tl-who">Gelman, Meng &amp; Stern</span>
+        <p><a href="https://www3.stat.sinica.edu.tw/statistica/j6n4/j6n41/j6n41.htm">Posterior predictive p-values</a>, the everyday Bayesian model-check, a PIT statistic on realised discrepancies.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1996</span> &middot; <span class="tl-who">Anderson</span>
+        <p>Weather forecasting reinvents the PIT as the <a href="https://journals.ametsoc.org/view/journals/clim/9/7/1520-0442_1996_009_1518_amfpae_2_0_co_2.xml">rank histogram</a>, also called the Talagrand diagram: where the observation falls among the sorted ensemble members is uniform when the forecast is calibrated. Flat is the goal.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1996</span> &middot; <span class="tl-who">Joe</span>
+        <p><a href="https://projecteuclid.org/ebooks/institute-of-mathematical-statistics-lecture-notes-monograph-series/Distributions-with-fixed-marginals-and-related-topics/chapter/Families-of-m-variate-distributions-with-given-margins-and-mm/10.1214/lnms/1215452614">Joe</a> builds multivariate distributions from bivariate blocks, the first pair-copula construction, which is Rosenblatt's transform used to build distributions rather than test them.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1998</span> &middot; <span class="tl-who">Diebold, Gunther &amp; Tay</span>
+        <p>Forecast evaluation reaches econometrics. <a href="https://ideas.repec.org/a/ier/iecrev/v39y1998i4p863-83.html">Diebold, Gunther and Tay</a> make the PIT histogram the standard check for density forecasts, crediting Rosenblatt.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1998</span> &middot; <span class="tl-who">Frees &amp; Valdez</span>
+        <p><a href="https://www.tandfonline.com/doi/abs/10.1080/10920277.1998.10595667">Frees and Valdez</a> carry copulas to actuaries, the route by which they reached credit modelling.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1998</span> &middot; <span class="tl-who">Christoffersen</span>
+        <p><a href="https://www.jstor.org/stable/2527341">Conditional-coverage and independence tests</a> for interval forecasts, the calibration test underneath VaR backtesting.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1998&ndash;2000</span> &middot; <span class="tl-who">Zhang, Pang &amp; Cotton</span>
+        <p>A copula construction in credit: a hybrid default simulation at Morgan Stanley that nested both a copula and a doubly stochastic intensity, of which the copula approach later made famous in publication is the special case<sup><a href="#fn7" style="text-decoration:none">7</a></sup>.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1999</span> &middot; <span class="tl-who">Diebold, Hahn &amp; Tay</span>
+        <p>The <a href="https://direct.mit.edu/rest/article-abstract/81/4/661/57171">multivariate extension</a>: apply the Rosenblatt ordering to joint density forecasts and check the transforms for uniformity.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">1999</span> &middot; <span class="tl-who">Nelsen</span>
+        <p><a href="https://link.springer.com/book/10.1007/978-1-4757-3076-0">An Introduction to Copulas</a>, the textbook that made the subject teachable and its tail-dependence and rank-correlation vocabulary standard.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2000</span> &middot; <span class="tl-who">Hersbach</span>
+        <p><a href="https://journals.ametsoc.org/view/journals/wefo/15/5/1520-0434_2000_015_0559_dotcrp_2_0_co_2.xml">Decomposes the CRPS</a> so its reliability term is the rank histogram, formally uniting the scoring-rule thread and the PIT-histogram thread.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2000</span> &middot; <span class="tl-who">Marsaglia &amp; Tsang</span>
+        <p>The <a href="https://www.jstatsoft.org/article/view/v005i08">ziggurat method</a>, the modern speed champion for sampling normals, a rejection method and the enduring alternative to inversion.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2000</span> &middot; <span class="tl-who">Yeo &amp; Johnson</span>
+        <p>A <a href="https://academic.oup.com/biomet/article-abstract/87/4/954/232908">Box-Cox-style power family</a> extended to the whole real line, so signed and zero data can be Gaussianized too. It ships as a transform in skaters.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2001</span> &middot; <span class="tl-who">Berkowitz</span>
+        <p>A call to action for the PIT. <a href="https://www.tandfonline.com/doi/abs/10.1198/07350010152596718">Testing Density Forecasts</a> gaussianizes the transforms by the inverse normal, z = &Phi;<sup>&minus;1</sup>(PIT), so a correct density yields iid N(0,1) and ordinary tests of mean, variance and autocorrelation grade it. Berkowitz handed the field a clean way to score its forecasts and act on the score.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2001</span> &middot; <span class="tl-who">Hamill</span>
+        <p>A <a href="https://journals.ametsoc.org/view/journals/mwre/129/3/1520-0493_2001_129_0550_iorhfv_2.0.co_2.xml">flat rank histogram is necessary but not sufficient</a>: compensating conditional biases can average to uniform. The caveat that keeps PIT histograms from being over-read.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2002</span> &middot; <span class="tl-who">Embrechts, McNeil &amp; Straumann</span>
+        <p><a href="https://people.math.ethz.ch/~embrecht/ftp/pitfalls.pdf">Correlation and dependence in risk management</a>, the paper that separated linear correlation from copula dependence for practitioners.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2002</span> &middot; <span class="tl-who">Brown, Barbieri, Ventura, Kass &amp; Frank</span>
+        <p>The <a href="https://pubmed.ncbi.nlm.nih.gov/11802915/">time-rescaling theorem</a>: rescale spike times by the integrated conditional intensity and any point process becomes unit-rate Poisson with uniform interevent times, checked by KS, the same integrated-hazard construction as the credit-default nesting above.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2002</span> &middot; <span class="tl-who">Bedford &amp; Cooke</span>
+        <p><a href="https://projecteuclid.org/journals/annals-of-statistics/volume-30/issue-4/Vines--a-new-graphical-model-for-dependent-random-variables/10.1214/aos/1031689016.full">Vines</a> organize pair-copula decompositions into a graphical model, sequential conditioning made into a structure.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2003</span> &middot; <span class="tl-who">Breymann, Dias &amp; Embrechts</span>
+        <p>The <a href="https://www.tandfonline.com/doi/abs/10.1080/713666155">first applied copula goodness-of-fit test</a> built on the Rosenblatt transform as the PIT, tested on high-frequency finance.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2004</span> &middot; <span class="tl-who">Szekely &amp; Rizzo</span>
+        <p>The energy distance, in one dimension twice the Cramer squared-L2 gap between cdfs, the population object the CRPS and the energy score estimate. It is a kernel quantity, related to but distinct from the Wasserstein transport distance.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2005</span> &middot; <span class="tl-who">Vovk, Gammerman &amp; Shafer</span>
+        <p>Conformal prediction. Under exchangeability the rank of a fresh nonconformity score is uniform, the PIT without the continuity assumption, giving finite-sample-valid p-values, which the field then narrowed to coverage intervals.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2005</span> &middot; <span class="tl-who">Subramanian and coauthors</span>
+        <p>The KS statistic reaches biology. <a href="https://www.pnas.org/doi/10.1073/pnas.0506580102">Gene set enrichment analysis</a>, among the most cited methods in the field, runs a weighted Kolmogorov&ndash;Smirnov running-maximum-deviation statistic to test whether a gene set clusters at the top of a ranked list.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2006</span> &middot; <span class="tl-who">Cook, Gelman &amp; Rubin</span>
+        <p><a href="https://www.tandfonline.com/doi/abs/10.1198/106186006X136976">Validate Bayesian software</a> by checking that posterior quantiles of the true parameters are uniform, a PIT on the computation, the precursor to simulation-based calibration.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2007</span> &middot; <span class="tl-who">Gneiting &amp; Raftery</span>
+        <p><a href="https://doi.org/10.1198/016214506000001437">Strictly proper scoring rules</a> formalized, the propriety theory under every PIT-based evaluation and the home of the CRPS-as-Cramer-distance identity.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2007</span> &middot; <span class="tl-who">Gneiting, Balabdaoui &amp; Raftery</span>
+        <p><a href="https://rss.onlinelibrary.wiley.com/doi/abs/10.1111/j.1467-9868.2007.00587.x">Calibration and sharpness</a>: maximise sharpness subject to calibration, with the PIT histogram as the diagnostic, and the fair dual credit to Dawid 1984 and Diebold 1998.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2009</span> &middot; <span class="tl-who">Genest, Remillard &amp; Beaudoin</span>
+        <p><a href="https://brunoremillard.com/Papers/gof.pdf">Copula goodness-of-fit</a> built directly on the Rosenblatt transform: a vector has copula C if and only if its Rosenblatt transform is the independence copula, the multivariate PIT turned into a test.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2009</span> &middot; <span class="tl-who">Aas and coauthors</span>
+        <p><a href="https://ideas.repec.org/a/eee/insuma/v44y2009i2p182-198.html">Pair-copula constructions</a> made practical for inference, among the most cited papers in the field, and Rosenblatt's transform used constructively at scale.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2009</span> &middot; <span class="tl-who">Czado, Gneiting &amp; Held</span>
+        <p>The <a href="https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1541-0420.2009.01191.x">mid-PIT for count data</a>, the non-randomized fix that keeps discrete-data calibration checks centred, the same correction the sticky lattice path produces for free elsewhere.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2009</span> &middot; <span class="tl-who">Villani</span>
+        <p><a href="https://link.springer.com/book/10.1007/978-3-540-71050-9">Optimal Transport: Old and New</a> gives the Knothe-Rosenblatt rearrangement its textbook home, a named section presenting the triangular coupling to the transport community.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2010</span> &middot; <span class="tl-who">Carlier, Galichon &amp; Santambrogio</span>
+        <p>The higher-dimensional bridge. <a href="https://epubs.siam.org/doi/10.1137/080740647">They prove</a> that the Knothe&ndash;Rosenblatt map is the limit of Brenier optimal-transport maps as the quadratic cost anisotropically degenerates, so the conditional PIT is optimal transport in a precise limiting sense even where it is not the Brenier map outright.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2010&ndash;2017</span> &middot; <span class="tl-who">Tabak, Vanden-Eijnden &amp; Turner</span>
+        <p>Esteban Tabak introduces the flow of maps with Eric Vanden-Eijnden (<a href="https://projecteuclid.org/journals/communications-in-mathematical-sciences/volume-8/issue-1/Density-estimation-by-dual-ascent-of-the-log-likelihood/cms/1266935020.full">2010</a>) and names it with Cristina Turner (<a href="https://onlinelibrary.wiley.com/doi/10.1002/cpa.21423">2013</a>): a learned invertible map to a simple base density, trained by exact change of variables. Deep learning then rebuilds Rosenblatt at scale, mostly without knowing it. Rezende and Mohamed popularize the idea for inference, and the autoregressive flows <a href="https://arxiv.org/abs/1705.07057">MAF</a> and <a href="https://arxiv.org/abs/1606.04934">IAF</a> parameterise conditional cdfs, the Rosenblatt transform with neural networks for the conditionals. None of the founding deep-learning papers cite the 1952 result; the link was drawn retrospectively by the 2021 survey<sup><a href="#fn8" style="text-decoration:none">8</a></sup>.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2013</span> &middot; <span class="tl-who">Bonnotte</span>
+        <p>An <a href="https://arxiv.org/abs/1205.1099">independent second proof</a> that Knothe’s rearrangement is the degenerate limit of Brenier maps, by a continuation equation for the Kantorovich potential.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2014</span> &middot; <span class="tl-who">Gneiting &amp; Katzfuss</span>
+        <p><a href="https://doi.org/10.1146/annurev-statistics-062713-085831">Probabilistic Forecasting</a>, the review that fixes the modern vocabulary: proper scores, calibration, sharpness, and the PIT as the working diagnostic.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2014</span> &middot; <span class="tl-who">Dinh, Krueger &amp; Bengio</span>
+        <p><a href="https://arxiv.org/abs/1410.8516">NICE</a>: the first practical deep invertible density model, additive couplings with a free Jacobian, trained by exact change of variables. The flow era&rsquo;s engineering begins.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2015</span> &middot; <span class="tl-who">Cannon and coauthors</span>
+        <p>The <a href="https://journals.ametsoc.org/view/journals/clim/28/17/jcli-d-14-00754.1.xml">modern treatment</a> of quantile mapping for climate bias correction, with the warning that naive mapping can corrupt projected trends.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2016</span> &middot; <span class="tl-who">Marzouk, Moselhy, Parno &amp; Spantini</span>
+        <p><a href="https://arxiv.org/abs/1602.05023">Sampling via measure transport</a>: the program that made the triangular Knothe-Rosenblatt map the practical object for inference, the line normalizing flows grew from.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2016</span> &middot; <span class="tl-who">Dinh, Sohl-Dickstein &amp; Bengio</span>
+        <p><a href="https://arxiv.org/abs/1605.08803">Real NVP</a> scales the idea: affine coupling layers with cheap Jacobians make exact-likelihood invertible models large enough to matter.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2018</span> &middot; <span class="tl-who">Talts and coauthors</span>
+        <p><a href="https://arxiv.org/abs/1804.06788">Simulation-based calibration</a>: rank statistics of prior draws within posterior samples are uniform when the computation is correct, the PIT turned into a test of the algorithm rather than the forecast.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2018</span> &middot; <span class="tl-who">Kuleshov, Fenner &amp; Ermon</span>
+        <p><a href="https://arxiv.org/abs/1807.00263">Recalibrates</a> a neural network’s predictive cdf at the observation to be uniform by isotonic regression, the deep-learning entry point for PIT recalibration.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2018</span> &middot; <span class="tl-who">Cousins</span>
+        <p>Particle physics names the transform outright: Cousins' <a href="https://arxiv.org/abs/1807.05996">lectures</a> have a section titled Probability integral transform, recasting any goodness-of-fit test as the claim that the transformed sample is uniform.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2018</span> &middot; <span class="tl-who">Kingma &amp; Dhariwal</span>
+        <p><a href="https://arxiv.org/abs/1807.03039">Glow</a> adds invertible 1&times;1 convolutions and takes flows mainstream: large images, exact likelihoods, samples people shared.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2018</span> &middot; <span class="tl-who">Grathwohl and coauthors</span>
+        <p><a href="https://arxiv.org/abs/1810.01367">FFJORD</a>: the continuous-time limit, invertible dynamics as an ODE with likelihood by an unbiased trace. Transport as literal flow, on a page already full of time changes.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2018</span> &middot; <span class="tl-who">Lei, G’Sell, Rinaldo, Tibshirani &amp; Wasserman</span>
+        <p><a href="https://arxiv.org/abs/1604.04173">Distribution-free predictive inference for regression</a>, the split-conformal foundation. Coverage rests on the uniformity of conformity-score ranks, the PIT idea in rank clothing.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2019</span> &middot; <span class="tl-who">Romano, Patterson &amp; Cand&egrave;s</span>
+        <p><a href="https://arxiv.org/abs/1905.03222">Conformalized quantile regression</a> adapts interval width to the input, the stepping stone between split conformal and fully distributional conformal.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2019</span> &middot; <span class="tl-who">Gabry and coauthors</span>
+        <p><a href="https://arxiv.org/abs/1709.01449">Visualization in Bayesian workflow</a> makes the LOO-PIT plot a standard check: leave one observation out, transform it by the predictive cdf, and look for uniform.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2019</span> &middot; <span class="tl-who">Durkan, Bekasov, Murray &amp; Papamakarios</span>
+        <p><a href="https://arxiv.org/abs/1906.04032">Neural spline flows</a> sharpen the univariate monotone map itself: rational-quadratic splines as learned cdfs inside the couplings. Of the flow papers, the one closest in spirit to this page: better quantile functions, learned.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">~2020</span> &middot; <span class="tl-who">z-streams, microprediction.org</span>
+        <p>The transform becomes a market mechanism in a high-velocity distributional prediction market run by Intech Investments<sup><a href="#fn9" style="text-decoration:none">9</a></sup>: data pushed through a community implied cdf and then the inverse normal gives <a href="https://www.linkedin.com/pulse/short-introduction-z-streams-peter-cotton-phd">z-streams</a> that are themselves predicted<sup><a href="#fn10" style="text-decoration:none">10</a></sup>.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2021</span> &middot; <span class="tl-who">Chernozhukov, Wuthrich &amp; Zhu</span>
+        <p><a href="https://www.pnas.org/doi/10.1073/pnas.2107794118">Distributional conformal prediction</a> conformalizes the estimated conditional-cdf rank, stating outright that the conditional rank U = F(Y,X) is uniform and independent of X, the PIT made explicit in conformal prediction.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2021</span> &middot; <span class="tl-who">timemachines package</span>
+        <p><strong style="color:#c0392b">YOU ARE HERE.</strong> The package emphasized online distributional residuals via the "parade" book-keeping, and was the original home for prediction algorithms since moved to <a href="https://skaters.microprediction.org">skaters.microprediction.org</a>.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2022</span> &middot; <span class="tl-who">Irons, Scetbon, Pal &amp; Harchaoui</span>
+        <p><a href="https://arxiv.org/abs/2112.15595">States verbatim</a> that autoregressive flows are Knothe-Rosenblatt couplings and proves consistency of estimating them, the precise statement the flow literature had left implicit.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2023</span> &middot; <span class="tl-who">Dheur &amp; Ben Taieb</span>
+        <p>A <a href="https://arxiv.org/abs/2306.02738">large-scale study</a> that writes Z = F(Y|X) as the probability integral transform, proves uniform PIT equals probabilistic calibration, and recalibrates 57 neural regression datasets to it.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2023</span> &middot; <span class="tl-who">Baptista, Marzouk &amp; Zahm</span>
+        <p>The <a href="https://arxiv.org/abs/2009.10303">representation and learning theory</a> for monotone triangular transport maps, the parametric Knothe-Rosenblatt maps that autoregressive flows approximate.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2026</span> &middot; <span class="tl-who">Cotton</span>
+        <p>The height between a conformal band and a full predictive distribution gets a name and a closed form, the residual-information gap (<a href="https://conformalprediction.net/papers/marginally-useful/">Marginally Useful</a>). A three-line lemma thus kills conformal prediction as a field<sup><a href="#fn11" style="text-decoration:none">11</a></sup>.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2026</span> &middot; <span class="tl-who">Laplace (the algorithm)</span>
+        <p><a href="https://skaters.microprediction.org/">skaters</a> ships <code>laplace</code>, an online forecaster built around Rosenblatt's transform with its own predictive as the conditional law, tick by tick. The same bijection is offered as a change of coordinates for other models, and in the benchmarks run so far it has improved <a href="https://timemachines.microprediction.org/">most of those tried</a><sup><a href="#fn12" style="text-decoration:none">12</a></sup>.</p>
+      </div>
+
+      <div class="tl-item">
+        <span class="tl-year">2026</span> &middot; <span class="tl-who">Wald (the algorithm)</span>
+        <p>The detection head <code>wald</code> tests each tick's standardized surprise against its own tail, so the advertised false-alarm rate is <a href="https://timemachines.microprediction.org/#calibration">the measured one</a><sup><a href="#fn13" style="text-decoration:none">13</a></sup>. A century of the same idea, now running live.</p>
+      </div>
+
+    </div>
+
+    <h2 style="font-size:20px">Footnotes</h2>
+    <p id="fn1" style="color: var(--muted); font-size: 14px;"><sup>1</sup> The combining rule is universally cited as Fisher 1925, but it entered <em>Statistical Methods for Research Workers</em> in the fourth edition of 1932; Karl Pearson's 1933 paper cites that edition contemporaneously. See the <a href="https://arxiv.org/pdf/0705.2209">tracing</a>.</p>
+    <p id="fn2" style="color: var(--muted); font-size: 14px;"><sup>2</sup> Two Pearsons, routinely conflated: Karl (1933) invented the transform-to-uniform test; his son Egon (1938) coined the phrase "probability integral transformation". There is no Karl Pearson 1938 paper; he died in April 1936.</p>
+    <p id="fn3" style="color: var(--muted); font-size: 14px;"><sup>3</sup> Priority is layered. Eckhardt's 1987 memoir credits the idea to Ulam; the earliest surviving written use is the March 1947 von Neumann letter (report LAMS-551); the first published general statement is his 1951 <em>Various techniques</em>.</p>
+    <p id="fn4" style="color: var(--muted); font-size: 14px;"><sup>4</sup> Precise version: the PIT always pushes the data law onto the uniform, so it is a transport map. It is literally the Brenier optimal map only in one dimension, where for any strictly convex cost the monotone T = F<sub>target</sub><sup>&minus;1</sup> &compfn; F<sub>source</sub> is optimal. In higher dimensions the conditional PIT is the triangular Knothe-Rosenblatt map, optimal only as the degenerate limit of Brenier maps (Carlier, Galichon and Santambrogio 2010).</p>
+    <p id="fn5" style="color: var(--muted); font-size: 14px;"><sup>5</sup> Journal of the Royal Statistical Society Series B 30(2), pages 248-265. The range 248-275 copied through much of the literature is wrong.</p>
+    <p id="fn6" style="color: var(--muted); font-size: 14px;"><sup>6</sup> PIT-based density-forecast evaluation is routinely credited to Diebold, Gunther and Tay 1998 alone. Dawid 1984, Section 5.3, had already stated the program and cited Rosenblatt; Gneiting, Balabdaoui and Raftery 2007 give the correct dual attribution.</p>
+    <p id="fn7" style="color: var(--muted); font-size: 14px;"><sup>7</sup> The inverse PIT had been in finance for decades by 1998; the new part was coupling default times. The mechanism, which is where the two methods nest: exponential thresholds correlated by monotone transform to normal, the copula piece, then a default triggered when the integral of a stochastic hazard rate first exceeds the threshold, the Cox or doubly stochastic intensity piece. That timing half is exactly the point-process time-rescaling of Meyer and Papangelou (1969-1972 above), independently rediscovered for credit. The special case is David X. Li, <em>On Default Correlation: A Copula Function Approach</em>, RiskMetrics working paper with a first draft of September 1999, published in The Journal of Fixed Income 9(4), 2000, and it had been reached independently before: <a href="https://journals.sagepub.com/doi/10.1177/0306312713517157">MacKenzie and Spears</a>, documenting the era from 114 interviews, record Vasicek's unpublished correlated-default memoranda at KMV between 1987 and 1991 and CreditMetrics arriving at the Gaussian-copula form in 1997 before the copula terminology was attached. Those were the copula piece alone, not the copula-plus-Cox nesting.</p>
+    <p id="fn8" style="color: var(--muted); font-size: 14px;"><sup>8</sup> Papamakarios, Nalisnick, Rezende, Mohamed and Lakshminarayanan, <a href="https://arxiv.org/abs/1912.02762"><em>Normalizing Flows for Probabilistic Modeling and Inference</em></a> (JMLR 2021). A trap: Tabak and Turner 2013 cite Rosenblatt 1956, the kernel-density paper, not the 1952 transform.</p>
+    <p id="fn9" style="color: var(--muted); font-size: 14px;"><sup>9</sup> The mechanism was written down only in 2026: a <a href="https://mechanisms.microprediction.org/papers/scoring-point-cloud-distributional-submissions.html">nearest-the-pin parimutuel</a> that pays forecasters by proximity to the outcome, with a formalized noise addition to the target that makes the game incentive compatible. Paying by proximity rather than for backing a single bucket is what makes a crowd report a full predictive cdf instead of a point, and the calibrated noise is what makes truthful reporting optimal. Formalizing it closes the loop the platform ran by instinct, and connects the PIT to market design.</p>
+    <p id="fn10" style="color: var(--muted); font-size: 14px;"><sup>10</sup> The community implied cdf is the distribution implied by everyone's quarantined predictions at two horizons, roughly a minute and roughly an hour. Feeding the resulting z-streams back as new prediction targets is what lets the crowd sharpen its own coordinate system, across billions of micropredictions. It answered Berkowitz's 2001 call to action at a velocity he never imagined, and unlike conformal prediction it allows sharp predictions crossing the <a href="https://conformalprediction.net/papers/marginally-useful/">information gap</a>.</p>
+    <p id="fn11" style="color: var(--muted); font-size: 14px;"><sup>11</sup> Tongue in cheek. Nobody here is out to kill conformal prediction, least of all the author, who strengthens it in a separate result, <a href="https://conformalprediction.net/papers/fan/">the width of the conformal fan</a>. The lemma is an argument for finishing the job with full distributions, not for abandoning finite-sample validity.</p>
+    <p id="fn12" style="color: var(--muted); font-size: 14px;"><sup>12</sup> On held-out data, forecasters run on the transformed stream and scored back by exact change of variables gain around two nats per point; anomaly detectors gain several times their raw hit rate. It is the forecaster passing through, not the opponent.</p>
+    <p id="fn13" style="color: var(--muted); font-size: 14px;"><sup>13</sup> Alarm on p below alpha and the false-alarm rate is alpha by construction, no threshold to tune. On real anomaly-free streams <code>wald</code> is the best-calibrated of the streaming detectors measured at operating depth.</p>
+
+  </main>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,6 +31,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/languages.html
+++ b/docs/languages.html
@@ -25,6 +25,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/metrics.html
+++ b/docs/metrics.html
@@ -22,6 +22,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/papers.html
+++ b/docs/papers.html
@@ -28,6 +28,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/sandwich.html
+++ b/docs/sandwich.html
@@ -25,6 +25,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/scope.html
+++ b/docs/scope.html
@@ -19,6 +19,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -38,6 +38,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/tails.html
+++ b/docs/tails.html
@@ -29,6 +29,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/tiki-taka.html
+++ b/docs/tiki-taka.html
@@ -35,6 +35,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>

--- a/docs/timesfm.html
+++ b/docs/timesfm.html
@@ -19,6 +19,7 @@
           <span class="drop">
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
           </span>


### PR DESCRIPTION
Moves https://timemachines.microprediction.org/heritage.html into this site as /heritage.html: skaters chrome, Heritage in the Docs dropdown across all 24 pages, cross-site links made absolute, corrections CTA now points at skaters issues. The timemachines side keeps a redirect stub (separate push there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)