### PR TITLE
laplace: always-on heavy-tailed diffuse floor (collapse defense)

### DIFF
--- a/docs/js/skaters/api.mjs
+++ b/docs/js/skaters/api.mjs
@@ -3,6 +3,7 @@
 // One forecaster: laplace (general). Volatility/mean-reversion are composable transforms.
 
 import { leaf, scaleMixtureLeaf, crpsLeaf } from "./leaf.mjs";
+import { gaussianPdf, gaussianCdf } from "./dist.mjs";
 import { conjugate } from "./conjugate.mjs";
 import { terminalLeafEnsemble } from "./terminal.mjs";
 import { bayesianEnsemble } from "./bayesian.mjs";
@@ -173,11 +174,69 @@ function laplaceSingleScale(k, objective, sticky, scaleAlpha) {
 // predictive scale tracks volatility). Default 0.03 beats the older 0.01 on
 // held-out log-likelihood AND CRPS across the continuous FRED universe; pass
 // scaleAlpha = 0.01 to reproduce the earlier default.
-export function laplace(k = 1, objective = "crps", sticky = true, scales = null, scaleAlpha = 0.03, tails = "gpd") {
-  // conditional tail fit (body -> region -> tail), then parade reads PIT/z
-  // against the spliced predictive (see tails.mjs, parade.mjs)
+
+// Diffuse floor: an always-on heavy-tailed escape hatch on an ABSOLUTE, ratcheting
+// scale, so a collapsed predictive meeting a jump can no longer detonate logpdf.
+// Faithful mirror of skaters/api.py (_FloorDist / _with_diffuse); touches
+// logpdf/cdf only, so mean/std/quantile/crps stay the body's. Production safety
+// net, not a scoring trick (studies eliminate out-of-scope series instead).
+const DIFFUSE_DECADES = 3;
+
+class FloorDist {
+  constructor(base, W, eps) {
+    this.base = base;
+    this.eps = eps;
+    const m0 = base.mean;
+    const per = eps / DIFFUSE_DECADES;
+    this.comps = [];
+    for (let j = 0; j < DIFFUSE_DECADES; j++) this.comps.push([per, m0, W * Math.pow(10.0, j)]);
+  }
+  get mean() { return this.base.mean; }
+  get std() { return this.base.std; }
+  quantile(p, tol = 1e-9, maxIter = 100) { return this.base.quantile(p, tol, maxIter); }
+  crps(x) { return this.base.crps(x); }
+  cdf(x) {
+    let c = (1.0 - this.eps) * this.base.cdf(x);
+    for (const [w, m, s] of this.comps) c += w * gaussianCdf(x, m, s);
+    return c;
+  }
+  logpdf(x) {
+    const terms = [Math.log(1.0 - this.eps) + this.base.logpdf(x)];
+    for (const [w, m, s] of this.comps) {
+      const p = gaussianPdf(x, m, s);
+      if (p > 0.0) terms.push(Math.log(w) + Math.log(p));
+    }
+    const hi = Math.max(...terms);
+    let sum = 0.0;
+    for (const t of terms) sum += Math.exp(t - hi);
+    return hi + Math.log(sum);
+  }
+}
+
+function addDiffuse(d, W, eps) {
+  if (W <= 0.0 || eps <= 0.0) return d;
+  return new FloorDist(d, W, eps);
+}
+
+function withDiffuse(f, priorScale, eps) {
+  return (y, state) => {
+    const st = state || {};
+    let scale = st.scale || 0.0;
+    const ay = Math.abs(y);
+    if (ay > scale) scale = ay;
+    const [dists, inner2] = f(y, st.inner);
+    const W = priorScale > scale ? priorScale : scale;
+    const out = dists.map((d) => addDiffuse(d, W, eps));
+    return [out, { inner: inner2, scale }];
+  };
+}
+
+export function laplace(k = 1, objective = "crps", sticky = true, scales = null, scaleAlpha = 0.03, tails = "gpd", diffuse = 1e-12, priorScale = 0.0) {
+  // conditional tail fit (body -> region -> tail), then the diffuse floor, then
+  // parade reads PIT/z against the floored, spliced predictive
   let f = multiscale((kk) => laplaceSingleScale(kk, objective, sticky, scaleAlpha), k, { scales });
   if (tails === "gpd") f = gpdtails(f, k);
+  if (diffuse > 0.0) f = withDiffuse(f, priorScale, diffuse);
   f = parade(f, k);
   f.skaterName = `laplace(k=${k})`;
   return f;

--- a/docs/js/skaters/dist.mjs
+++ b/docs/js/skaters/dist.mjs
@@ -63,13 +63,13 @@ export function erf(x) {
 
 // --- pure-JS Gaussian math (mirrors dist.py) ---
 
-function gaussianPdf(x, mean, std) {
+export function gaussianPdf(x, mean, std) {
   if (std <= 0) return x === mean ? Infinity : 0.0;
   const z = (x - mean) / std;
   return Math.exp(-0.5 * z * z) / (std * SQRT2PI);
 }
 
-function gaussianCdf(x, mean, std) {
+export function gaussianCdf(x, mean, std) {
   if (std <= 0) return x >= mean ? 1.0 : 0.0;
   return 0.5 * (1.0 + erf((x - mean) / (std * SQRT2)));
 }

--- a/src/skaters/api.py
+++ b/src/skaters/api.py
@@ -18,7 +18,9 @@ Ornstein--Uhlenbeck group.
 """
 
 from __future__ import annotations
+import math
 from functools import partial
+from skaters.dist import _gaussian_pdf, _gaussian_cdf
 from skaters.leaf import leaf, scale_mixture_leaf, crps_leaf
 from skaters.conjugate import conjugate
 from skaters.transform import (
@@ -254,6 +256,99 @@ def _build_candidates(k: int, leaf_fn=leaf):
 
 
 # ---------------------------------------------------------------------------
+# Diffuse floor: an always-on heavy-tailed escape hatch on an ABSOLUTE scale.
+# ---------------------------------------------------------------------------
+# The leaf's scale dictionary is relative to the running sigma, so on a
+# near-constant run sigma -> 0 and every mixture component collapses with it;
+# a later jump then meets a near-zero-variance predictive and the log-score
+# detonates. Splicing a tiny-weight (eps) heavy tail on an ABSOLUTE, ratcheting
+# scale W bounds that: a catastrophic point costs ~tens of nats, not 1e20+,
+# while normal points are unchanged to ~eps. It cannot predict the FIRST jump on
+# an all-constant series (nothing can), only bound the damage once any scale has
+# been seen (W ratchets up with max|y|); prior_scale seeds W for the cold start.
+#
+# This is a PRODUCTION safety net, not a scoring trick. In a study it would be
+# unfair to let it rescue laplace's log-score unless every opponent got the same
+# floor, so benchmarks instead ELIMINATE out-of-scope series (see benchmarks/
+# README, "Out-of-scope series"): asking any model to predict when only one
+# value has ever been realized is meaningless, not a contest anyone can win.
+_DIFFUSE_DECADES = 3   # wide Gaussians at W, 10W, 100W approximate a heavy tail
+
+
+class _FloorDist:
+    """A base predictive with a total-weight-eps heavy tail mixed in for density
+    evaluation only. The tail is `_DIFFUSE_DECADES` Gaussians at W, 10W, 100W
+    centered at the base mean; it bounds ``logpdf`` (and shows in ``cdf``) so a
+    collapsed predictive meeting a jump can no longer detonate the log-score.
+    The point forecast, interval, and CRPS are the base's unchanged: the floor
+    is a log-score safety net, not a wider stated band. Type-agnostic so it wraps
+    a plain ``Dist`` or a ``SplicedDist`` alike."""
+    __slots__ = ("base", "eps", "comps")
+
+    def __init__(self, base, W, eps):
+        self.base = base
+        self.eps = eps
+        m0 = base.mean
+        per = eps / _DIFFUSE_DECADES
+        self.comps = [(per, m0, W * (10.0 ** j)) for j in range(_DIFFUSE_DECADES)]
+
+    @property
+    def mean(self):
+        return self.base.mean
+
+    @property
+    def std(self):
+        return self.base.std
+
+    def quantile(self, p):
+        return self.base.quantile(p)     # eps-mass tail is beyond any practical p
+
+    def crps(self, y):
+        return self.base.crps(y)
+
+    def cdf(self, y):
+        c = (1.0 - self.eps) * self.base.cdf(y)
+        for w, m, s in self.comps:
+            c += w * _gaussian_cdf(y, m, s)
+        return c
+
+    def logpdf(self, y):
+        terms = [math.log(1.0 - self.eps) + self.base.logpdf(y)]
+        for w, m, s in self.comps:
+            p = _gaussian_pdf(y, m, s)
+            if p > 0.0:
+                terms.append(math.log(w) + math.log(p))
+        hi = max(terms)
+        return hi + math.log(sum(math.exp(t - hi) for t in terms))
+
+
+def _add_diffuse(d, W, eps):
+    """Wrap d with the heavy-tailed floor on absolute scale W. No-op when W or
+    eps is non-positive (e.g. no scale seen yet and no prior_scale set)."""
+    if W <= 0.0 or eps <= 0.0:
+        return d
+    return _FloorDist(d, W, eps)
+
+
+def _with_diffuse(f, prior_scale, eps):
+    """Wrap a skater so every issued predictive carries the diffuse floor, with W
+    ratcheting on the largest |y| seen (never collapsing) and floored at
+    prior_scale for the cold start."""
+    def g(y, state):
+        st = state if state is not None else {}
+        inner = st.get("inner")
+        scale = st.get("scale", 0.0)
+        ay = abs(y)
+        if ay > scale:
+            scale = ay
+        dists, inner2 = f(y, inner)
+        W = prior_scale if prior_scale > scale else scale
+        out = [_add_diffuse(d, W, eps) for d in dists]
+        return out, {"inner": inner2, "scale": scale}
+    return g
+
+
+# ---------------------------------------------------------------------------
 # The named forecaster
 # ---------------------------------------------------------------------------
 
@@ -280,7 +375,7 @@ def _laplace_single_scale(k, objective, sticky, leaf, scale_alpha):
 
 def laplace(k: int = 1, objective: str = "crps", sticky: bool = True, leaf=None,
             scales: list[int] | None = None, scale_alpha: float = 0.03,
-            tails: str = "gpd"):
+            tails: str = "gpd", diffuse: float = 1e-12, prior_scale: float = 0.0):
     """The general forecaster.
 
     A likelihood-weighted Bayesian ensemble over the full candidate population
@@ -325,6 +420,17 @@ def laplace(k: int = 1, objective: str = "crps", sticky: bool = True, leaf=None,
             stated 1e-3 alarm rate approximately comes true — see
             ``benchmarks/anomaly/RESULTS.md`` sections 5-6). ``"gaussian"``
             disables the splice. Costs ~5% runtime.
+        diffuse: weight of an always-on heavy-tailed *floor* on the issued
+            predictive (default ``1e-12``; ``0`` disables). It bounds the
+            log-score when the predictive scale collapses on a near-constant run
+            and a jump arrives (otherwise ~1e20+); at ``1e-12`` normal series
+            shift by ~1e-3 nats and a collapse is capped near −35 instead of
+            detonating. A production safety net only: studies eliminate
+            out-of-scope series rather than rely on it (they would have to floor
+            every model alike to compare fairly).
+        prior_scale: cold-start width for the diffuse floor before any move is
+            seen (default ``0``: the floor activates once ``max|y| > 0``, since
+            an all-constant history offers no scale to anchor a width on).
 
     The returned state also carries calibration diagnostics, resolved online
     against the predictions previously made for each arriving point:
@@ -338,7 +444,9 @@ def laplace(k: int = 1, objective: str = "crps", sticky: bool = True, leaf=None,
                    k=k, scales=scales)
     if tails == "gpd":
         f = _gpdtails(f, k=k)     # conditional tail fit: body -> region -> tail
-    f = _parade(f, k=k)           # PIT/z read against the (spliced) predictive
+    if diffuse > 0.0:
+        f = _with_diffuse(f, prior_scale, diffuse)  # absolute heavy-tailed floor
+    f = _parade(f, k=k)           # PIT/z read against the (floored, spliced) predictive
     f.__name__ = f"laplace(k={k})"
     return f
 

--- a/tests/test_diffuse_floor.py
+++ b/tests/test_diffuse_floor.py
@@ -1,0 +1,66 @@
+"""The diffuse floor: laplace must never emit a predictive so narrow that a jump
+detonates the log-score.
+
+Real FRED series triggered this in the study (WLCFOCEL, USINTDMRKTJPY, the H41RES*
+Fed balance-sheet series): a long near-constant run collapses the predictive scale
+toward zero, then one jump gives a logpdf of ~-1e23. Those series live in the
+gitignored FRED cache and are screened out of the *study* as out-of-scope, so
+here we reproduce the same failure mode synthetically and assert the *core*
+forecaster degrades gracefully once any scale has been seen.
+"""
+import math
+import random
+
+from skaters import laplace
+
+
+def _roll(changes, diffuse):
+    f = laplace(1, diffuse=diffuse)
+    state = None
+    pend = None
+    lps = []
+    for y in changes:
+        if pend is not None:
+            lps.append(pend[0].logpdf(y))
+        pend, state = f(y, state)
+    return lps
+
+
+def test_floor_bounds_a_collapse_then_jump():
+    """After a scale has been seen, a large jump costs tens of nats, not 1e20."""
+    rng = random.Random(0)
+    ch = [rng.gauss(0.0, 1.0) for _ in range(400)] + [1.0e4] + [rng.gauss(0.0, 1.0) for _ in range(10)]
+    lps = _roll(ch, diffuse=1e-12)
+    assert all(math.isfinite(v) for v in lps)
+    assert min(lps) > -1.0e3        # bounded — no detonation
+
+
+def test_floor_is_negligible_on_a_normal_series():
+    """At the default weight the floor barely moves a well-behaved series."""
+    rng = random.Random(1)
+    ch = [rng.gauss(0.0, 1.0) for _ in range(500)]
+    on = _roll(ch, diffuse=1e-12)
+    off = _roll(ch, diffuse=0.0)
+    m_on = sum(on) / len(on)
+    m_off = sum(off) / len(off)
+    assert abs(m_on - m_off) < 5e-3
+
+
+def test_floor_preserves_point_interval_and_crps():
+    """The floor touches logpdf/cdf only; mean, std, quantiles, CRPS are the body's."""
+    rng = random.Random(2)
+    ch = [rng.gauss(0.0, 1.0) for _ in range(300)]
+    fa, fb = laplace(1, diffuse=1e-12), laplace(1, diffuse=0.0)
+    sa = sb = None
+    da = db = None
+    for y in ch:
+        da, sa = fa(y, sa)
+        db, sb = fb(y, sb)
+    a, b = da[0], db[0]
+    assert a.mean == b.mean
+    assert a.std == b.std
+    for p in (0.025, 0.5, 0.975):
+        assert a.quantile(p) == b.quantile(p)
+    y0 = a.mean
+    assert a.crps(y0) == b.crps(y0)
+    assert math.isfinite(a.logpdf(y0))


### PR DESCRIPTION
Fixes the variance-collapse detonation the study surfaced: a near-constant run collapses laplace's relative scale dictionary toward zero, then a jump meets a ~zero-variance predictive and the log-score hits ~−1e23.

**The floor:** the *issued* predictive always carries a tiny-weight (`diffuse`, default **1e-12**) heavy tail — Gaussians at `W, 10W, 100W` centered at the mean — on an **absolute, ratcheting** width `W = max|y|` seen (`prior_scale` seeds the cold start). It bounds a collapsed point to ~−35 nats instead of detonating, and touches **logpdf/cdf only** — mean, std, quantiles, and CRPS stay the body's.

- **Parity-clean:** at 1e-12 the floor doesn't move the probe points, so **JS (105,658 values) and Rust parity both pass unchanged**. Adding the same floor to JS/Rust/R is a production-robustness follow-up, not a parity blocker.
- **Not a scoring trick:** it's a production safety net. Studies *eliminate* out-of-scope series instead (flooring only laplace would be unfair to opponents; predicting from a single realized value is meaningless). The code says so.
- **Tests:** `test_diffuse_floor.py` reproduces the WLCFOCEL failure mode synthetically (the real FRED series live in the gitignored cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)