### PR TITLE
nav: promote Papers to top-level; link it more often

### DIFF
--- a/docs/anomaly-literature.html
+++ b/docs/anomaly-literature.html
@@ -21,6 +21,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -34,7 +35,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -15,6 +15,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -28,7 +29,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
@@ -51,7 +51,8 @@
       record below marks each of those corners where we found them, in its
       own row rather than averaged away. What laplace is for,
       and what it deliberately is not, is set out on the
-      <a href="/scope.html">scope page</a>.
+      <a href="/scope.html">scope page</a>, and the whole record is written
+      up in the <a href="/papers.html">papers</a>.
     </p>
 
     <p>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -15,6 +15,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -28,7 +29,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -27,6 +27,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -40,7 +41,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
@@ -52,6 +52,8 @@
     <h1>Guide</h1>
     <p class="subtitle">How the pieces fit: the <code>Dist</code> object, transforms, conjugation,
       and ensembles — everything returns a distribution, everything composes.</p>
+    <p>The formal write-up and the full benchmark study are in the
+      <a href="/papers.html">papers</a>.</p>
 
     <h2>Architecture: transforms all the way down</h2>
     <p>

--- a/docs/heritage.html
+++ b/docs/heritage.html
@@ -37,6 +37,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -50,7 +51,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -40,7 +41,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/languages.html
+++ b/docs/languages.html
@@ -21,6 +21,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -34,7 +35,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/metrics.html
+++ b/docs/metrics.html
@@ -18,6 +18,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -31,7 +32,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/papers.html
+++ b/docs/papers.html
@@ -24,6 +24,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -37,7 +38,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/sandwich.html
+++ b/docs/sandwich.html
@@ -21,6 +21,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -34,7 +35,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/scope.html
+++ b/docs/scope.html
@@ -15,6 +15,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -28,7 +29,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -34,6 +34,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -47,7 +48,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/tails.html
+++ b/docs/tails.html
@@ -25,6 +25,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -38,7 +39,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/tiki-taka.html
+++ b/docs/tiki-taka.html
@@ -31,6 +31,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -44,7 +45,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/timesfm.html
+++ b/docs/timesfm.html
@@ -15,6 +15,7 @@
         <a href="/">Home</a>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -28,7 +29,6 @@
           <span class="drop">
             <a href="/challengers.html">Challenges</a>
             <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>


### PR DESCRIPTION
People were missing **Papers** — it was buried in the "Results ▾" dropdown. Promoted it to a **top-level** nav item (after Guide) and removed the dropdown copy, swept identically across all 16 docs pages (nav stays byte-identical). Also added in-body `/papers.html` links from the guide intro and the challengers record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)