### PR TITLE
nav: Results second tab + renamed items; radar drop-oldest selection

### DIFF
--- a/docs/anomaly-literature.html
+++ b/docs/anomaly-literature.html
@@ -19,6 +19,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -29,12 +35,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -13,6 +13,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -23,12 +29,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>
@@ -178,16 +178,31 @@
       function metric() {
         return document.querySelector("input[name=radar-metric]:checked").value;
       }
+      var selOrder = ["Prophet"];        // selection order, for drop-oldest
+      function uncheckByName(nm) {
+        var inputs = box.querySelectorAll("input[type=checkbox]");
+        for (var j = 0; j < inputs.length; j++) {
+          if (inputs[j].value === nm) { inputs[j].checked = false; break; }
+        }
+      }
       function onToggle(e) {
-        var sel = selected();
+        var name = e.target.value;
         if (e.target.checked) {
-          if (sel.length > MAXSEL) { e.target.checked = false; return; }
-          var used = sel.map(function (n) { return slotOf[n]; });
+          selOrder.push(name);
+          // Drop the oldest so picking a new challenger never needs unclicking one first.
+          while (selOrder.length > MAXSEL) {
+            var old = selOrder.shift();
+            uncheckByName(old);
+            delete slotOf[old];
+          }
+          var used = selected().map(function (n) { return slotOf[n]; });
           for (var s = 0; s < MAXSEL; s++) {
-            if (used.indexOf(s) < 0) { slotOf[e.target.value] = s; break; }
+            if (used.indexOf(s) < 0) { slotOf[name] = s; break; }
           }
         } else {
-          delete slotOf[e.target.value];   // others keep their colors
+          var i = selOrder.indexOf(name);
+          if (i >= 0) selOrder.splice(i, 1);
+          delete slotOf[name];             // others keep their colors
         }
         draw();
       }

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -13,6 +13,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -23,12 +29,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -25,6 +25,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -35,12 +41,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/heritage.html
+++ b/docs/heritage.html
@@ -35,6 +35,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -45,12 +51,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,6 +25,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -35,12 +41,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/languages.html
+++ b/docs/languages.html
@@ -19,6 +19,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -29,12 +35,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/metrics.html
+++ b/docs/metrics.html
@@ -16,6 +16,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -26,12 +32,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/papers.html
+++ b/docs/papers.html
@@ -22,6 +22,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -32,12 +38,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/sandwich.html
+++ b/docs/sandwich.html
@@ -19,6 +19,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -29,12 +35,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/scope.html
+++ b/docs/scope.html
@@ -13,6 +13,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -23,12 +29,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -32,6 +32,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -42,12 +48,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/tails.html
+++ b/docs/tails.html
@@ -23,6 +23,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -33,12 +39,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/tiki-taka.html
+++ b/docs/tiki-taka.html
@@ -29,6 +29,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -39,12 +45,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/timesfm.html
+++ b/docs/timesfm.html
@@ -13,6 +13,12 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
@@ -23,12 +29,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>


### PR DESCRIPTION
- **Results is now the 2nd nav tab** (after Home) — it's what most readers want — with items renamed to **Direct comparisons** and **Collaborative use**. Swept identically across all 16 docs pages.
- **Radar UX:** picking a 5th challenger now **drops the oldest** (FIFO) instead of blocking the click, so you never have to unclick one first. Four-colour scheme preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)