### PR TITLE
nav: single-source sweep, fix subdirectory drift, widen dropdown

### DIFF
--- a/docs/academic.css
+++ b/docs/academic.css
@@ -144,4 +144,4 @@ header.site-header nav .menu .drop {
 }
 header.site-header nav .menu:hover .drop,
 header.site-header nav .menu:focus-within .drop { display: block; }
-header.site-header nav .menu .drop a { display: block; padding: 4px 14px; }
+header.site-header nav .menu .drop a { display: block; padding: 4px 14px; white-space: nowrap; }

--- a/docs/challengers/pymc-forecast.html
+++ b/docs/challengers/pymc-forecast.html
@@ -19,8 +19,15 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -28,13 +35,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/challengers/tabfm.html
+++ b/docs/challengers/tabfm.html
@@ -19,8 +19,15 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -28,13 +35,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -21,8 +21,15 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -30,13 +37,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/demos/normalization.html
+++ b/docs/demos/normalization.html
@@ -29,8 +29,15 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -38,13 +45,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -33,8 +33,15 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -42,13 +49,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/demos/pyodide.html
+++ b/docs/demos/pyodide.html
@@ -21,8 +21,15 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -30,13 +37,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/demos/race.html
+++ b/docs/demos/race.html
@@ -46,8 +46,15 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -55,13 +62,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/demos/rosenblatt.html
+++ b/docs/demos/rosenblatt.html
@@ -31,8 +31,15 @@
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
         <a href="/demos/">Demos</a>
         <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/scope.html">Scope</a>
@@ -40,13 +47,6 @@
             <a href="/heritage.html">Heritage</a>
             <a href="/faq.html">FAQ</a>
             <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Challenges</a>
-            <a href="/sandwich.html">Sandwich</a>
-            <a href="/papers.html">Papers</a>
           </span>
         </span>
         <a href="https://github.com/microprediction/skaters">GitHub</a>

--- a/docs/sweep_nav.py
+++ b/docs/sweep_nav.py
@@ -1,0 +1,77 @@
+"""Single source of truth for the site header/navigation.
+
+CANONICAL below is the one authoritative header. This script stamps it into
+every docs/**/*.html (top-level AND subdirectories like demos/ and challengers/),
+replacing the existing <header class="site-header">...</header> block. It is
+idempotent and recursive, so the nav can never drift again: change CANONICAL,
+run the sweep, done. Absolute hrefs (/, /challengers.html, ...) mean the same
+block works verbatim at any directory depth.
+
+    python docs/sweep_nav.py          # rewrite every page from CANONICAL
+    python docs/sweep_nav.py --check  # audit only; exit 1 if any page differs
+"""
+import glob
+import os
+import re
+import sys
+
+CANONICAL = """  <header class="site-header">
+    <div class="nav-inner">
+      <a class="brand" href="/">skaters</a>
+      <nav>
+        <a href="/">Home</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Direct comparisons</a>
+            <a href="/sandwich.html">Collaborative use</a>
+          </span>
+        </span>
+        <a href="/demos/">Demos</a>
+        <a href="/guide.html">Guide</a>
+        <a href="/papers.html">Papers</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
+          <span class="drop">
+            <a href="/scope.html">Scope</a>
+            <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
+            <a href="/faq.html">FAQ</a>
+            <a href="/skills.html">Skills</a>
+          </span>
+        </span>
+        <a href="https://github.com/microprediction/skaters">GitHub</a>
+      </nav>
+    </div>
+  </header>"""
+
+HEADER_RE = re.compile(r'[ \t]*<header class="site-header">.*?</header>', re.DOTALL)
+
+
+def main():
+    check = "--check" in sys.argv
+    root = os.path.dirname(os.path.abspath(__file__))
+    files = sorted(glob.glob(os.path.join(root, "**", "*.html"), recursive=True))
+    drift, missing = [], []
+    for f in files:
+        s = open(f).read()
+        if not HEADER_RE.search(s):
+            missing.append(os.path.relpath(f, root))
+            continue
+        new = HEADER_RE.sub(lambda _m: CANONICAL, s, count=1)
+        if new != s:
+            drift.append(os.path.relpath(f, root))
+            if not check:
+                open(f, "w").write(new)
+    if missing:
+        print("no site-header (skipped): " + ", ".join(missing))
+    if check:
+        if drift:
+            print("NAV OUT OF SYNC:\n  " + "\n  ".join(drift))
+            return 1
+        print(f"nav in sync across {len(files) - len(missing)} pages")
+        return 0
+    print("swept:\n  " + "\n  ".join(drift) if drift else "all pages already in sync")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The header was hand-duplicated across 24 pages and the previous nav change only swept `docs/*.html`, so the **demos/** and **challengers/** subdirectory pages kept the old menu. Root-cause fix, not just a patch:

- **`docs/sweep_nav.py`** — one `CANONICAL` header, stamped into every `docs/**/*.html` recursively, idempotent, with `--check` audit. Single source of truth; nav can't drift again. All 24 pages now share one hash.
- Regenerated the 8 stale subdirectory pages.
- **`academic.css`** — `white-space:nowrap` on dropdown items so "Direct comparisons" fits on one line (menu grows to the widest label). Shared CSS → every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)