### PR TITLE
Move anomaly-detection claims to timemachines; skaters keeps the signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,11 @@ f = laplace(k=1, sticky=False)            # no lattice projection
 forecasts previously made *for it*: `state["pit"][m-1]` is its probability
 integral transform under the m-step-ahead predictive issued m steps ago
 (roughly Uniform(0,1) when calibrated) and `state["z"][m-1]` the same through
-the standard-normal quantile (roughly N(0,1) — so `abs(z) > 4` is an anomaly
-detector with no extra compute; z is clamped to ±7.03, never infinite). See
-the [anomaly-detection skill](https://skaters.microprediction.org/skills.html#anomaly-detection).
+the standard-normal quantile (roughly N(0,1); z is clamped to ±7.03, never
+infinite). That calibrated-surprise signal is the null model streaming anomaly
+detection is built on, and that work lives in its own project:
+[**timemachines**](https://timemachines.microprediction.org/) — calibrated
+online anomaly detection with honest false-alarm rates, built on skaters.
 
 **Tails that keep their stated rates (v0.13.0).** Every predictive carries censored-ML
 generalized-Pareto tails beyond the body's ~2% region (the *conditional tail

--- a/docs/anomaly-literature.html
+++ b/docs/anomaly-literature.html
@@ -47,6 +47,13 @@
     <p class="subtitle">Organized around one question: who can promise a false-alarm rate
       on a drifting stream?</p>
 
+    <p class="lead" style="border-left:3px solid var(--accent,#4a3aff);padding-left:12px">
+      The detector this map is about lives in its own project,
+      <a href="https://timemachines.microprediction.org/"><strong>timemachines</strong></a>
+      (calibrated online anomaly detection, built on skaters). Start there for the method,
+      its measured false-alarm rates, and benchmarks. The map below is kept as reference.
+    </p>
+
     <p class="lead">
       Streaming anomaly detection is two jobs wearing one name. <strong>Job 1 — where is the
       anomaly</strong> — is subsequence search and ranking, and it is well occupied. <strong>Job 2
@@ -238,23 +245,18 @@
         calibration-aware evaluation found anywhere is inside the W1-ACAS paper itself.</li>
     </ul>
 
-    <h2>Where skaters sits</h2>
+    <h2>Where this sits</h2>
     <p>
-      The library's claim is upstream of every line above: <code>laplace</code> is an online
-      forecaster whose parade state exposes PIT/z residuals — manufacturing, on a drifting
+      skaters' contribution is upstream of every line above: <code>laplace</code> is an online
+      forecaster whose parade state exposes PIT/z residuals, manufacturing, on a drifting
       seasonal stream, the near-i.i.d. uniforms that conformal, online-FDR, and e-process
-      machinery all assume and none can create. The <a
-      href="https://github.com/microprediction/skaters/blob/main/benchmarks/anomaly/RESULTS.md">full-archive
-      studies</a> locate the value precisely: the front-end lifts distributional alarm heads
-      (DSPOT 2–5&times;), does nothing for similarity-search heads (they carry their own
-      normalizer) — and the calibration panel (empirical false-alarm rate vs nominal &alpha;,
-      prequentially, on the benchmarks' own certified-clean data) first <em>failed</em> the
-      library's Gaussian tails at 1e-3, then, as of v0.13.0, passes them: censored-ML GPD tails
-      are spliced into every predictive (SPOT's theorem, native to the surprise stream), the
-      stated alarm rate comes true within the genuine-anomaly base rate, and the 99.9% interval
-      is empirically 99.85% (Gaussian read: 99.13%). See the
-      <a href="/robustness.html">coverage study</a> — the 90% interval that is actually 90%,
-      now extended to the tail.
+      machinery all assume and none can create. The detector built on that signal, with its
+      measured false-alarm rates and its lifts to third-party heads (DSPOT, RRCF), is
+      <a href="https://timemachines.microprediction.org/"><strong>timemachines</strong></a> —
+      that is where the alarm logic and the full-archive studies live. (skaters keeps the tail
+      story that makes the surprise stream honest: censored-ML GPD tails are spliced into every
+      predictive from v0.13.0, so the 99.9% interval is empirically 99.85%; see the
+      <a href="/robustness.html">coverage study</a> and <a href="/tails.html">the tail essay</a>.)
     </p>
 
     <p class="byline">Assembled 2026-07-09 from a verified forward-citation sweep (25/25 claims

--- a/docs/demos/normalization.html
+++ b/docs/demos/normalization.html
@@ -117,7 +117,8 @@
       quantile. Because the model has already absorbed the trend, the
       volatility clock, the seasonality, and the coordinate, what remains is
       (roughly) pure N(0,1) innovation — <em>running normalization</em>. That
-      residue is also an anomaly detector: anything with |z| &gt; 4 earned it.
+      residue is also a calibrated surprise signal; turning it into a streaming anomaly
+      detector is <a href="https://timemachines.microprediction.org/">timemachines</a>.
     </p>
     <p>
       Pick the multiplicative or jumps regime for the full effect. The bars are

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -98,8 +98,9 @@
       GARCH or Prophet and they find almost nothing left, a few hundredths
       of a nat between them
       (<a href="https://github.com/microprediction/timemachines/blob/main/benchmarks/RESULTS.md">results
-      log</a>); hand it to anomaly detectors and they run five times better
-      than on raw data. The dependence problem is not relocated, it is
+      log</a>); hand it to the streaming anomaly detectors in
+      <a href="https://timemachines.microprediction.org/">timemachines</a> and they run
+      several times better than on raw data. The dependence problem is not relocated, it is
       mostly finished by the time z exists.
     </p>
     <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -86,10 +86,13 @@
     </p>
 
     <p>
-      Anomaly detection comes with the state. Each point is scored against the forecast
-      issued for it, so <code>state["z"]</code> is a normalized surprise and a threshold on
-      it is a calibrated detector at no extra cost.
+      A calibrated surprise signal comes with the state: each point is scored against the
+      forecast issued for it, so <code>state["z"]</code> is a normalized residual and
+      <code>state["pit"]</code> its probability integral transform.
       <a href="/demos/normalization.html">See it live →</a>
+      Turning that signal into streaming anomaly detection with honest false-alarm rates is
+      its own project, <a href="https://timemachines.microprediction.org/">timemachines</a>,
+      built on skaters.
     </p>
 
     <figure class="hero-figure">

--- a/docs/scope.html
+++ b/docs/scope.html
@@ -67,18 +67,18 @@
       that has better things to spend attention on.
     </p>
     <p>
-      <strong>Anomaly detection falls out for free.</strong> Because every
+      <strong>A calibrated surprise signal falls out for free.</strong> Because every
       prediction is a density, every arriving point gets a probability integral
       transform against the forecast that was made <em>for it</em>: the state
       carries <code>state["pit"]</code> (roughly Uniform when the stream is
       behaving) and <code>state["z"]</code> (roughly N(0,1)) at every horizon
-      1..k, resolved online with no extra compute. A |z| of five is an anomaly
-      by construction — scored against a model that has already adapted to the
-      stream's drift, volatility clock, seasonality, and coordinate, which is
-      precisely what separates an anomaly from a regime the model should have
-      learned. Multi-horizon agreement (the same point surprising at h = 1, 5,
-      and 20) separates one-off spikes from genuine breaks. See the
-      <a href="/skills.html#anomaly-detection">anomaly-detection skill</a>.
+      1..k, resolved online with no extra compute — scored against a model that
+      has already adapted to the stream's drift, volatility clock, seasonality,
+      and coordinate, which is precisely what separates a genuine surprise from a
+      regime the model should have learned. Turning that signal into streaming
+      anomaly detection with honest false-alarm rates is its own project,
+      <a href="https://timemachines.microprediction.org/">timemachines</a>,
+      built on skaters.
     </p>
 
     <h2>The objections it is not refuted by</h2>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -733,27 +733,23 @@ a paper without edits, the page is done.
         <h2 id="anomaly-detection"><code>anomaly-detection</code></h2>
         <button class="btn copy-btn" data-target="src-anomaly-detection">Copy skill</button>
       </div>
-      <p class="skill-label">Online anomaly detection from the calibration state: every point is scored against the forecast made <em>for it</em> — thresholds on ~N(0,1) z's, multi-horizon break confirmation, CUSUM drifts.</p>
+      <p class="skill-label">skaters exposes the calibrated surprise signal (<code>state["z"]</code> / <code>state["pit"]</code>); streaming anomaly detection built on it lives in its own project, <a href="https://timemachines.microprediction.org/">timemachines</a>.</p>
       <details>
         <summary>Show the skill (markdown) · or <a href="https://github.com/microprediction/skaters/blob/main/skills/anomaly-detection.md">view on GitHub</a></summary>
         <pre id="src-anomaly-detection"><code># anomaly-detection skill
 
-When asked to detect anomalies, outliers, or regime breaks in a univariate
-stream, use `skaters.laplace` — not a rolling z-score, not an isolation forest
-on one column, not a hand-tuned threshold on raw values. The reason is the
-denominator: an anomaly is only meaningful *relative to a forecast*, and a
-rolling mean ± kσ is a bad forecast. `laplace` adapts online to drift, the
-volatility clock, seasonality, and coordinate, so what remains surprising is
-actually surprising.
+Streaming anomaly / outlier / regime-break detection lives in a dedicated
+project built on skaters: **timemachines**
+([site](https://timemachines.microprediction.org/),
+[repo](https://github.com/microprediction/timemachines)). It turns skaters'
+calibrated forecast into online detection with honest, measured false-alarm
+rates, and reports lifts to third-party detectors (DSPOT, RRCF) on standard
+archives. Point questions about detectors, thresholds, and false-alarm
+calibration there.
 
-```
-pip install skaters
-```
-
-## The whole detector
-
-Every prediction is a density, so calibration diagnostics come with the state
-for free — no extra compute, no second pass:
+What skaters provides is the primitive timemachines consumes: because every
+`laplace` prediction is a full density, each arriving point carries a
+calibrated surprise in the state, at no extra compute.
 
 ```python
 from skaters import laplace
@@ -762,69 +758,21 @@ f = laplace(k=1)
 state = None
 for y in stream:
     dists, state = f(y, state)
-    z = state["z"][0]          # y scored against the forecast made FOR it:
-    if z is not None and abs(z) &gt; 4:
-        alert(y, z)            # ~N(0,1) when the stream is behaving
+    state["z"][0]     # y scored against the forecast made FOR it (~N(0,1))
+    state["pit"][0]   # its probability integral transform (~Uniform(0,1))
 ```
 
-`state["pit"][m-1]` is the probability integral transform of the arriving
-point under the m-step-ahead predictive issued m steps ago — roughly
-Uniform(0,1) on a well-behaved stream. `state["z"][m-1]` is the same value
-through the standard-normal quantile — roughly N(0,1), so `|z|` reads directly
-as "how many sigmas of surprise". Entries are `None` for the first m steps and
-whenever the predictive can't score the point; `|z|` is clamped to ≈7.03, so
-thresholds never race an infinity.
+`state["z"][m-1]` is the m-step-ahead residual mapped through the
+standard-normal quantile; `state["pit"][m-1]` is the corresponding tail
+probability. Entries are `None` until the horizon has matured, and `|z|` is
+clamped to ≈7.03 so thresholds never race an infinity. A calibrated online
+forecaster is the best null model there is: under it, each arriving point's
+surprise is a standard normal.
 
-## Choosing the rule
-
-- **Point anomalies**: `|z| &gt; 4` is a defensible default (one-in-16,000 under
-  calibration). `|z| &gt; 3` on noisy ops data pages someone every day; know that
-  going in.
-- **Regime breaks vs one-off spikes**: run `laplace(k=20)` and require the
-  surprise to agree across horizons — a spike is anomalous at `m=1` and
-  forgotten by `m=20`; a break is anomalous at every matured horizon at once
-  (`all(abs(z) &gt; 3 for z in state["z"] if z is not None)`).
-- **Slow drifts the model keeps absorbing**: CUSUM the z's
-  (`S = max(0, S + z - 0.5)`; alarm on `S &gt; 8`). Individual z's stay modest
-  while their sum marches.
-- **One-sided risk** (only crashes matter): threshold `state["pit"][0] &lt; 1e-4`
-  instead of `|z|` — the PIT is the tail probability itself.
-
-## Trust, but verify the detector
-
-Before believing any threshold, check calibration on YOUR stream: collect a few
-hundred `state["pit"][0]` values from a quiet period and eyeball the histogram.
-Flat means the z-thresholds mean what they say. U-shaped means the model is
-overconfident there (heavier tails than it thinks — raise the threshold);
-hump-shaped means underconfident (alarms will be rare and late).
-
-Three caveats. On **waveform-heavy data** — ECGs, vibration traces, machine
-acoustics, anything whose normal behaviour is a repeating *shape* rather than
-a stochastic level — this is probably not the best tool: the anomaly there is
-a deformed pattern, not a surprising next value, and shape-native methods
-(matrix-profile/discord discovery, spectral distance) are built for exactly
-that. `laplace`'s seasonal candidates absorb clean periodicity, but a subtle
-waveform deformity can hide inside a well-calibrated one-step predictive.
-Reach for this skill when the stream is a level/rate/count with stochastic
-dynamics; reach for the matrix profile when it looks like an oscilloscope. On
-**grid/repeating series** (posted prices, policy rates) the
-lattice projection places near-Dirac mass on revisited values, so PITs cluster
-at the atom edges — threshold on `pit`, not `z`, and treat "off-lattice at all"
-as the event. On **price/return series** volatility clusters: a 4σ day inside
-a volatility storm is less anomalous than the same move in a calm — `laplace`
-tracks this through its volatility transforms, which is exactly why raw-value
-thresholds are the wrong tool.
-
-## What NOT to do
-
-- Don't z-score against a rolling window of raw values: trends and volatility
-  clustering guarantee both false alarms and missed breaks.
-- Don't threshold the forecast *error* (`y - mean`): without the predictive's
-  own spread it's meaningless across regimes.
-- Don't tune thresholds to reproduce a labelled incident list you were handed —
-  fit the model, verify calibration, then let the tail probability be the tail
-  probability.
-</code></pre>
+For everything downstream of that signal — choosing thresholds, converting an
+alarm budget, distinguishing regime breaks from spikes, waveform caveats, and
+the measured false-alarm rates — use **timemachines**, where the detection
+logic and its benchmarks live.</code></pre>
       </details>
     </div>
     <div class="skill-copy">

--- a/skills/anomaly-detection.md
+++ b/skills/anomaly-detection.md
@@ -1,21 +1,17 @@
 # anomaly-detection skill
 
-When asked to detect anomalies, outliers, or regime breaks in a univariate
-stream, use `skaters.laplace` — not a rolling z-score, not an isolation forest
-on one column, not a hand-tuned threshold on raw values. The reason is the
-denominator: an anomaly is only meaningful *relative to a forecast*, and a
-rolling mean ± kσ is a bad forecast. `laplace` adapts online to drift, the
-volatility clock, seasonality, and coordinate, so what remains surprising is
-actually surprising.
+Streaming anomaly / outlier / regime-break detection lives in a dedicated
+project built on skaters: **timemachines**
+([site](https://timemachines.microprediction.org/),
+[repo](https://github.com/microprediction/timemachines)). It turns skaters'
+calibrated forecast into online detection with honest, measured false-alarm
+rates, and reports lifts to third-party detectors (DSPOT, RRCF) on standard
+archives. Point questions about detectors, thresholds, and false-alarm
+calibration there.
 
-```
-pip install skaters
-```
-
-## The whole detector
-
-Every prediction is a density, so calibration diagnostics come with the state
-for free — no extra compute, no second pass:
+What skaters provides is the primitive timemachines consumes: because every
+`laplace` prediction is a full density, each arriving point carries a
+calibrated surprise in the state, at no extra compute.
 
 ```python
 from skaters import laplace
@@ -24,81 +20,18 @@ f = laplace(k=1)
 state = None
 for y in stream:
     dists, state = f(y, state)
-    z = state["z"][0]          # y scored against the forecast made FOR it:
-    if z is not None and abs(z) > 4:
-        alert(y, z)            # ~N(0,1) when the stream is behaving
+    state["z"][0]     # y scored against the forecast made FOR it (~N(0,1))
+    state["pit"][0]   # its probability integral transform (~Uniform(0,1))
 ```
 
-`state["pit"][m-1]` is the probability integral transform of the arriving
-point under the m-step-ahead predictive issued m steps ago — roughly
-Uniform(0,1) on a well-behaved stream. `state["z"][m-1]` is the same value
-through the standard-normal quantile — roughly N(0,1), so `|z|` reads directly
-as "how many sigmas of surprise". Entries are `None` for the first m steps and
-whenever the predictive can't score the point; `|z|` is clamped to ≈7.03, so
-thresholds never race an infinity.
+`state["z"][m-1]` is the m-step-ahead residual mapped through the
+standard-normal quantile; `state["pit"][m-1]` is the corresponding tail
+probability. Entries are `None` until the horizon has matured, and `|z|` is
+clamped to ≈7.03 so thresholds never race an infinity. A calibrated online
+forecaster is the best null model there is: under it, each arriving point's
+surprise is a standard normal.
 
-## Choosing the rule
-
-- **Point anomalies**: `|z| > 4` is a defensible default (one-in-16,000 under
-  calibration). `|z| > 3` on noisy ops data pages someone every day; know that
-  going in.
-- **Regime breaks vs one-off spikes**: run `laplace(k=20)` and require the
-  surprise to agree across horizons — a spike is anomalous at `m=1` and
-  forgotten by `m=20`; a break is anomalous at every matured horizon at once
-  (`all(abs(z) > 3 for z in state["z"] if z is not None)`).
-- **Slow drifts the model keeps absorbing**: CUSUM the z's
-  (`S = max(0, S + z - 0.5)`; alarm on `S > 8`). Individual z's stay modest
-  while their sum marches.
-- **One-sided risk** (only crashes matter): threshold `state["pit"][0] < 1e-4`
-  instead of `|z|` — the PIT is the tail probability itself.
-
-## The thresholds mean what they say (0.13.0)
-
-Since 0.13.0 `laplace` splices censored-ML generalized-Pareto tails into
-every predictive (the conditional tail fit), so the z-thresholds above are
-measured claims, not aspirations: on ~380 non-price FRED series the
-empirical alarm rate of `erfc(|z|/sqrt(2)) < alpha` is ~1.0e-2 at nominal
-1e-2 and ~1.4e-3 at nominal 1e-3 (the residue is the genuine-anomaly base
-rate). The same holds on price series and at multi-step horizons.
-Convert an alarm budget directly: one page a week on minutely data is
-`alpha = 1/10080`. Do NOT stack an extra GPD head
-(`skaters.anomaly.gpdtail`) on default `laplace` — double-splicing
-over-alarms; that head is for gaussian-tail bodies only.
-
-## Trust, but verify the detector
-
-Before believing any threshold, check calibration on YOUR stream: collect a few
-hundred `state["pit"][0]` values from a quiet period and eyeball the histogram.
-Flat means the z-thresholds mean what they say. U-shaped means the model is
-overconfident there (heavier tails than it thinks — raise the threshold);
-hump-shaped means underconfident (alarms will be rare and late). On
-near-deterministic waveform data (ECG-like periodic streams) expect the
-U-shape and over-alarming: that regime needs template matching, not
-innovation modelling. The histogram is the regime detector.
-
-Three caveats. On **waveform-heavy data** — ECGs, vibration traces, machine
-acoustics, anything whose normal behaviour is a repeating *shape* rather than
-a stochastic level — this is probably not the best tool: the anomaly there is
-a deformed pattern, not a surprising next value, and shape-native methods
-(matrix-profile/discord discovery, spectral distance) are built for exactly
-that. `laplace`'s seasonal candidates absorb clean periodicity, but a subtle
-waveform deformity can hide inside a well-calibrated one-step predictive.
-Reach for this skill when the stream is a level/rate/count with stochastic
-dynamics; reach for the matrix profile when it looks like an oscilloscope. On
-**grid/repeating series** (posted prices, policy rates) the
-lattice projection places near-Dirac mass on revisited values, so PITs cluster
-at the atom edges — threshold on `pit`, not `z`, and treat "off-lattice at all"
-as the event. On **price/return series** volatility clusters: a 4σ day inside
-a volatility storm is less anomalous than the same move in a calm — `laplace`
-tracks this through its volatility transforms, which is exactly why raw-value
-thresholds are the wrong tool.
-
-## What NOT to do
-
-- Don't z-score against a rolling window of raw values: trends and volatility
-  clustering guarantee both false alarms and missed breaks.
-- Don't threshold the forecast *error* (`y - mean`): without the predictive's
-  own spread it's meaningless across regimes.
-- Don't tune thresholds to reproduce a labelled incident list you were handed —
-  fit the model, verify calibration, then let the tail probability be the tail
-  probability.
+For everything downstream of that signal — choosing thresholds, converting an
+alarm budget, distinguishing regime breaks from spikes, waveform caveats, and
+the measured false-alarm rates — use **timemachines**, where the detection
+logic and its benchmarks live.


### PR DESCRIPTION
Anomaly/outlier detection is its own project (**timemachines**, built on skaters) and had drifted into duplicate, differently-numbered claims in skaters. This keeps the **mechanistic** calibrated-surprise state (`state["z"]`/`state["pit"]`) and the tail-calibration story here, and points all detection *claims* to timemachines.

- README / index / scope / faq / demos/normalization: reframe "anomaly detection for free" → the mechanistic signal + a timemachines link.
- `skills/anomaly-detection.md` (and its skills.html embed): slimmed to the primitive + pointer.
- `anomaly-literature.html`: redirect banner + "Where skaters sits" reframed to attribute the detector and DSPOT/RRCF lifts to timemachines.

Why: the two sites' numbers measure different detectors/datasets (skaters' `~1.4e-3 at 1e-3` z-alarm on FRED vs timemachines' `wald`/DSPOT/RRCF table on 144 prefixes); rather than reconcile, detection lives in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)