### PR TITLE
transform: exact=True pushforward inverse for yeo_johnson and power_transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,15 @@ from skaters.leaf import leaf
 from skaters.transform import ou_transform, yeo_johnson
 
 f = conjugate(leaf(k=10), ou_transform(kappa=0.1), k=10)                       # linear (spreads)
-f = conjugate(conjugate(leaf(k=10), ou_transform(0.1), k=10), yeo_johnson(0.5), k=10)  # positive (vol/rates)
+f = conjugate(conjugate(leaf(k=10), ou_transform(0.1), k=10), yeo_johnson(0.5, exact=True), k=10)  # positive (vol/rates)
 ```
+
+`exact=True` maps the predictive back through the exact change of variables
+instead of the component-wise delta method, which cannot carry the skew of the
+coordinate change. The difference grows with horizon: at `h=10` on strictly
+positive FRED levels it is worth a median +0.015 to +0.018 nats of held-out
+log-likelihood (72–78% of series), and at `h=1` the two agree. The candidate
+pool keeps the default (its one-step spreads are where they agree).
 
 `laplace(k>1)` already carries an OU group in its pool, so the general forecaster
 picks up reversion automatically at multi-step horizons. The OU-on-a-coordinate
@@ -230,9 +237,9 @@ Online bijective maps. Each has a `forward` (scalar in, scalar out) and an `inve
 | `standardize(`$\alpha$`)` | $y'_t = (y_t - \hat\mu_t) / \hat\sigma_t$ | $D \mapsto \hat\sigma_t \cdot D + \hat\mu_t$ | Remove scale |
 | `garch(`$\omega, \alpha, \beta$`)` | $y'_t = y_t / \hat\sigma_t$ | $D \mapsto \hat\sigma_t \cdot D$ | Volatility clustering |
 | `seasonal_difference(`$s$`)` | $y'_t = y_t - y_{t-s}$ | Shift by lagged value | Periodicity |
-| `power_transform(`$p$`)` | $y'_t = \text{sign}(y_t)\|y_t\|^p$ | Delta method | Tail compression |
+| `power_transform(`$p$`)` | $y'_t = \text{sign}(y_t)\|y_t\|^p$ | Delta method (`exact=True` for the pushforward) | Tail compression |
 | `theta(`$\alpha$`)` | $y'_t = y_t - \text{SES}_t$ | Shift by smoothed level + drift | Theta method (M3 winner) |
-| `yeo_johnson(`$\lambda$`)` | Signed Box–Cox to coordinate $\lambda$ | Component-wise delta method | Coordinate learning (log/root/linear) |
+| `yeo_johnson(`$\lambda$`)` | Signed Box–Cox to coordinate $\lambda$ | Delta method (`exact=True` for the pushforward) | Coordinate learning (log/root/linear) |
 | `ou_transform(`$\kappa$`)` | Deviation from running mean, OU speed $\kappa$ | Exact OU moments (scale + shift) | Mean reversion |
 
 ## Conjugation

--- a/src/skaters/pushforward.py
+++ b/src/skaters/pushforward.py
@@ -1,0 +1,242 @@
+"""Exact pushforward of a predictive through a monotone coordinate map.
+
+The component-wise delta method used by the nonlinear transform inverses
+(``yeo_johnson``, ``power_transform``) maps each mixture component to
+``N(inv(m), s * dinv(m))``. That is cheap and stays a plain :class:`Dist`,
+and it has a structural blind spot: the inner components of a conjugated
+forecaster all sit near the same location, so the mapped mixture comes out
+location-symmetric about the mapped median. The skew that the coordinate
+change is supposed to express lives in the curvature of the map *within* a
+component's width, which the delta method linearizes away. The error grows
+with the predictive spread, hence with horizon: measured on 120 strictly
+positive FRED level series under the README's standalone composition
+(leaf under OU under Yeo-Johnson, k=10), exact mapping beats the delta
+method by a median +0.018 nats at h=10 (72% of series) for lambda=0 and
++0.015 (78%) for lambda=0.5, while h=1 is a wash.
+
+:class:`PushforwardDist` is the exact treatment, the same idiom as
+``SplicedDist``: keep the inner predictive in the transformed z-coordinate
+and answer queries through the change of variables
+
+    F_Y(y)      = F_Z(z(y))
+    log p_Y(y)  = log p_Z(z(y)) + log dz/dy
+    Q_Y(p)      = y(Q_Z(p))
+
+where y <-> z is a strictly increasing piecewise-linear table, so dz/dy is a
+segment slope and CRPS integrates in z-coordinates with a constant Jacobian
+per segment.
+
+Compatibility: consumers that need mixture components (``Dist.combine`` in
+ensemble warm-up, the sticky projection) get a ``components`` property that
+maps each inner component by 7-point Gauss-Hermite moment matching through
+the table. Moment matching is the KL(true || q) optimum among Gaussians, so
+the shim is the best answer the plain-``Dist`` representation admits; exact
+queries stay exact.
+
+Everything is stdlib-only and the state is pure data, as everywhere else.
+"""
+
+from __future__ import annotations
+import bisect
+import math
+from skaters.dist import Dist
+
+_SQRT2 = math.sqrt(2.0)
+_SQRTPI = math.sqrt(math.pi)
+
+# 7-point Gauss-Hermite nodes/weights (physicists'), for E[g(Z)], Z ~ N(0,1):
+# E[g(Z)] ~= sum w_i/sqrt(pi) * g(sqrt(2) x_i). Exact for polynomials to
+# degree 13, which pins pushforward means to ~1e-12 at practical spreads.
+_GH7 = (
+    (-2.6519613568352334, 9.717812450995192e-04),
+    (-1.6735516287674714, 5.451558281912703e-02),
+    (-0.8162878828589647, 4.256072526101278e-01),
+    (0.0, 8.102646175568073e-01),
+    (0.8162878828589647, 4.256072526101278e-01),
+    (1.6735516287674714, 5.451558281912703e-02),
+    (2.6519613568352334, 9.717812450995192e-04),
+)
+
+
+def interp_table(x: float, xs: list, fs: list) -> float:
+    """Piecewise-linear with linear extrapolation from the end segments."""
+    i = bisect.bisect_left(xs, x)
+    if i <= 0:
+        i = 1
+    elif i >= len(xs):
+        i = len(xs) - 1
+    x0, x1 = xs[i - 1], xs[i]
+    return fs[i - 1] + (fs[i] - fs[i - 1]) * (x - x0) / (x1 - x0)
+
+
+def table_from_map(inv_fn, z_lo: float, z_hi: float, nodes: int = 400):
+    """(ys, zs) knots of a monotone map y = inv_fn(z) on [z_lo, z_hi].
+
+    Knots where inv_fn fails to strictly increase (float ties on flat
+    stretches) are dropped so every segment has a positive, finite slope.
+    """
+    z_hi = max(z_hi, z_lo + 1e-9)
+    step = (z_hi - z_lo) / nodes
+    ys, zs = [], []
+    for j in range(nodes + 1):
+        z = z_lo + step * j
+        y = inv_fn(z)
+        if not ys or y > ys[-1]:
+            ys.append(y)
+            zs.append(z)
+    if len(ys) < 2:
+        y0 = inv_fn(z_lo)
+        ys, zs = [y0, y0 + 1e-9], [z_lo, z_lo + 1e-9]
+    return ys, zs
+
+
+class PushforwardDist:
+    """A z-space predictive pushed through a monotone y <-> z map.
+
+    The map is carried two ways: a piecewise-linear (ys, zs) table, always
+    present, used for the y -> z direction and the CRPS segment weights; and
+    an optional ``inv_fn`` (the exact z -> y map) which, when given, makes
+    the z -> y direction and the Jacobian exact instead of table-limited.
+    """
+
+    __slots__ = ("inner", "ys", "zs", "inv_fn", "_comps")
+
+    def __init__(self, inner, ys: list, zs: list, inv_fn=None):
+        self.inner = inner
+        self.ys = ys
+        self.zs = zs
+        self.inv_fn = inv_fn
+        self._comps = None
+
+    # --- the map -----------------------------------------------------------
+
+    def _z(self, y: float) -> float:
+        # clamp the linear extrapolation: past ~8 z-units beyond the table the
+        # density is negligible, and an extreme end-segment slope must not
+        # launch z to a magnitude whose finite logpdf poisons a study mean
+        z = interp_table(y, self.ys, self.zs)
+        return min(max(z, self.zs[0] - 8.0), self.zs[-1] + 8.0)
+
+    def _y(self, z: float) -> float:
+        if self.inv_fn is not None:
+            return self.inv_fn(z)
+        return interp_table(z, self.zs, self.ys)
+
+    def _slope(self, y: float) -> float:
+        """dz/dy at y (central difference of the exact map when available,
+        segment secant otherwise; end segments extend beyond the table)."""
+        if self.inv_fn is not None:
+            z = self._z(y)
+            h = 1e-5 * (1.0 + abs(z))
+            dy = self.inv_fn(z + h) - self.inv_fn(z - h)
+            if dy > 0.0:
+                return 2.0 * h / dy
+        ys, zs = self.ys, self.zs
+        i = bisect.bisect_left(ys, y)
+        i = min(max(i, 1), len(ys) - 1)
+        return (zs[i] - zs[i - 1]) / (ys[i] - ys[i - 1])
+
+    # --- queries (exact) ----------------------------------------------------
+
+    def logpdf(self, x: float) -> float:
+        return self.inner.logpdf(self._z(x)) + math.log(self._slope(x))
+
+    def pdf(self, x: float) -> float:
+        return self.inner.pdf(self._z(x)) * self._slope(x)
+
+    def cdf(self, x: float) -> float:
+        return self.inner.cdf(self._z(x))
+
+    def quantile(self, p: float, tol: float = 1e-9, max_iter: int = 100) -> float:
+        return self._y(self.inner.quantile(p, tol=tol, max_iter=max_iter))
+
+    def crps(self, x: float) -> float:
+        """CRPS by trapezoid in z-coordinates, where the Jacobian y'(z) is
+        constant per table segment. The realization's z is always inserted as
+        a node, and the indicator side is decided per segment, so the kink
+        costs no accuracy. Validated to ~0.2% against ``Dist.crps`` through an
+        identity table."""
+        zstar = self._z(x)
+        zs = self.zs
+        s_lo = 1.0 / self._slope(self.ys[0])
+        s_hi = 1.0 / self._slope(self.ys[-1])
+        base = [zs[0] - 8.0, zs[0] - 6.0, zs[0] - 4.0, zs[0] - 2.0, zs[0] - 1.0]
+        base += zs
+        base += [zs[-1] + 1.0, zs[-1] + 2.0, zs[-1] + 4.0, zs[-1] + 6.0, zs[-1] + 8.0]
+        base += [zstar - 1.0, zstar, zstar + 1.0]
+        base = sorted(set(base))
+        nodes = [base[0]]
+        for z in base[1:]:
+            lo = nodes[-1]
+            gap = z - lo
+            if gap > 0.1:
+                pieces = min(int(gap / 0.1) + 1, 40)
+                step = gap / pieces
+                nodes.extend(lo + step * (j + 1) for j in range(pieces - 1))
+            nodes.append(z)
+        cdf = self.inner.cdf
+        total = 0.0
+        prev_z = nodes[0]
+        c_prev = cdf(prev_z)
+        for z in nodes[1:]:
+            c = cdf(z)
+            ind = 1.0 if prev_z >= zstar else 0.0
+            g0 = (c_prev - ind) ** 2
+            g1 = (c - ind) ** 2
+            if z <= zs[0]:
+                yp = s_lo
+            elif prev_z >= zs[-1]:
+                yp = s_hi
+            else:
+                yp = (self._y(z) - self._y(prev_z)) / (z - prev_z)
+            total += 0.5 * (g0 + g1) * (z - prev_z) * yp
+            prev_z, c_prev = z, c
+        return total
+
+    # --- Dist-compatibility shim ---------------------------------------------
+
+    @property
+    def components(self) -> list:
+        """Moment-matched mixture components in y-space (lazy, cached).
+
+        Each inner component is mapped by Gauss-Hermite through the table:
+        the resulting (weight, mean, std) triple carries the pushforward's
+        exact first two moments per component. This is the KL-optimal single
+        Gaussian per component, so consumers that must have a plain mixture
+        (``Dist.combine``, the sticky projection) get the best answer the
+        representation admits. Exact queries do not use this path.
+        """
+        if self._comps is None:
+            comps = []
+            for w, m, s in self.inner.components:
+                mu = 0.0
+                m2 = 0.0
+                for x, wt in _GH7:
+                    y = self._y(m + s * _SQRT2 * x)
+                    g = wt / _SQRTPI
+                    mu += g * y
+                    m2 += g * y * y
+                sd = math.sqrt(max(m2 - mu * mu, 1e-24))
+                comps.append((w, mu, max(sd, 1e-15)))
+            self._comps = comps
+        return self._comps
+
+    @property
+    def mean(self) -> float:
+        return sum(w * m for w, m, _ in self.components)
+
+    @property
+    def var(self) -> float:
+        mu = self.mean
+        return sum(w * (s * s + (m - mu) ** 2) for w, m, s in self.components)
+
+    @property
+    def std(self) -> float:
+        return math.sqrt(max(self.var, 0.0))
+
+    def __repr__(self) -> str:
+        return (f"PushforwardDist(knots={len(self.ys)}, "
+                f"inner={self.inner!r})")
+
+    def __len__(self) -> int:
+        return len(self.inner)

--- a/src/skaters/transform.py
+++ b/src/skaters/transform.py
@@ -759,7 +759,29 @@ def seasonal_scale(period: int, alpha: float = 0.05, center: bool = False,
 # Signed power transform (works on any real value)
 # ---------------------------------------------------------------------------
 
-def power_transform(p: float = 0.5):
+def _exact_inverse_k(inv_fn):
+    """Build an inverse_k that emits the exact pushforward.
+
+    The table window adapts to each predictive: [m - 10s, m + 10s] over the
+    mixture. A fixed window fails in level coordinates (positive levels live
+    at z ~ 2 sqrt(y) under lambda = 0.5, far from any static range) and
+    everything beyond a table extrapolates with the wrong curvature.
+    """
+    from skaters.pushforward import PushforwardDist, table_from_map
+
+    def inverse_k(dists: list, state: dict) -> list:
+        out = []
+        for d in dists:
+            lo = min(m - 10.0 * s for _, m, s in d.components)
+            hi = max(m + 10.0 * s for _, m, s in d.components)
+            ys, zs = table_from_map(inv_fn, lo, hi)
+            out.append(PushforwardDist(d, ys, zs, inv_fn=inv_fn))
+        return out
+
+    return inverse_k
+
+
+def power_transform(p: float = 0.5, exact: bool = False):
     """Signed power transform: compresses large values, handles negatives.
 
     Forward:   y'_t = sign(y_t) * |y_t|^p
@@ -768,15 +790,20 @@ def power_transform(p: float = 0.5):
     For 0 < p < 1, this compresses the tails (like log) but works on
     all reals — no explosion on negatives.
 
-    The inverse is nonlinear, so we linearize around the Dist mean
-    for each component: if y' ~ N(mu, sigma^2) in transformed space,
-    the inverse is approximately:
+    By default the inverse linearizes around each component's mean
+    (delta method):
         mean_orig = sign(mu) * |mu|^(1/p)
-        std_orig  = sigma * (1/p) * |mu|^(1/p - 1)   (delta method)
+        std_orig  = sigma * (1/p) * |mu|^(1/p - 1)
+
+    ``exact=True`` emits the exact pushforward instead (see
+    :mod:`skaters.pushforward` and :func:`yeo_johnson` for when the delta
+    method's missing skew becomes material).
 
     Args:
         p: power in (0, 1). Smaller = more compression.
            p=0.5 is the signed square root.
+        exact: emit :class:`PushforwardDist` (exact change of variables)
+            instead of delta-method component mapping.
     """
     assert 0 < p < 1
     inv_p = 1.0 / p
@@ -807,10 +834,10 @@ def power_transform(p: float = 0.5):
             result.append(Dist(components))
         return result
 
-    return forward, inverse_k
+    return forward, (_exact_inverse_k(_inv) if exact else inverse_k)
 
 
-def yeo_johnson(lmbda: float = 0.0):
+def yeo_johnson(lmbda: float = 0.0, exact: bool = False):
     """Yeo-Johnson coordinate transform — the signed Box-Cox family.
 
     A one-parameter family that picks the *coordinate in which the series is
@@ -824,8 +851,18 @@ def yeo_johnson(lmbda: float = 0.0):
         y >= 0:  ((y+1)**L - 1) / L            (L != 0);   log(y+1)      (L == 0)
         y <  0:  -(((-y+1)**(2-L) - 1)/(2-L))  (L != 2);  -log(-y+1)     (L == 2)
 
-    The inverse is nonlinear, so each Dist component is mapped by the exact
-    inverse on the mean and the delta method on the std (deriv = d inv / dy').
+    By default each Dist component is mapped by the exact inverse on the mean
+    and the delta method on the std (deriv = d inv / dy'). The delta method
+    cannot carry the skew of the coordinate change (the mapped mixture is
+    location-symmetric about the mapped median) and its error grows with the
+    predictive spread, hence with horizon. ``exact=True`` emits the exact
+    pushforward (:class:`skaters.pushforward.PushforwardDist`) instead: on
+    120 strictly positive FRED level series under the standalone composition
+    from the README (leaf under OU under Yeo-Johnson, k=10), exact beats
+    delta by a median +0.018 nats at h=10 (72% of series) at lmbda=0, and
+    +0.015 (78%) at lmbda=0.5, with h=1 a wash. Inside the candidate pool the
+    trunk consumes means, one-step likelihoods and warm-up mixtures, all at
+    small spreads where the two agree, so the pool keeps the default.
 
     Fit the *family* the NFL-safe way: put a coarse grid of lmbda in the
     candidate pool (see :func:`skaters.api._build_candidates`) and let the
@@ -834,6 +871,9 @@ def yeo_johnson(lmbda: float = 0.0):
     Args:
         lmbda: the transform parameter. 0 = log1p (multiplicative / non-negative),
             1 = identity, 0.5 = signed-sqrt-ish compression.
+        exact: emit :class:`PushforwardDist` (exact change of variables)
+            instead of delta-method component mapping. Prefer it for
+            standalone conjugation at multi-step horizons.
     """
     L = float(lmbda)
 
@@ -881,7 +921,7 @@ def yeo_johnson(lmbda: float = 0.0):
             result.append(Dist(comps))
         return result
 
-    return forward, inverse_k
+    return forward, (_exact_inverse_k(_inv) if exact else inverse_k)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pushforward.py
+++ b/tests/test_pushforward.py
@@ -1,0 +1,136 @@
+"""Tests for the exact pushforward inverse (skaters.pushforward)."""
+
+import math
+import random
+from skaters.dist import Dist
+from skaters.pushforward import PushforwardDist, table_from_map
+from skaters.transform import yeo_johnson, power_transform
+from skaters.conjugate import conjugate
+from skaters.leaf import leaf
+
+SQRT2PI = math.sqrt(2.0 * math.pi)
+
+
+def _identity_table(lo=-8.0, hi=8.0, step=0.125):
+    grid = []
+    x = lo
+    while x <= hi + 1e-12:
+        grid.append(x)
+        x += step
+    return grid, list(grid)
+
+
+class TestIdentityTable:
+    """Through the identity map the pushforward IS the inner Dist."""
+
+    def test_logpdf_exact(self):
+        ys, zs = _identity_table()
+        inner = Dist([(0.6, -0.3, 0.5), (0.3, 0.4, 1.2), (0.1, 0.0, 3.0)])
+        pf = PushforwardDist(inner, ys, zs)
+        for x in (-2.7, -1.0, 0.0, 0.4, 3.1):
+            assert abs(pf.logpdf(x) - inner.logpdf(x)) < 1e-9
+
+    def test_crps_close(self):
+        ys, zs = _identity_table()
+        inner = Dist.gaussian(0.0, 1.0)
+        pf = PushforwardDist(inner, ys, zs)
+        for x in (-2.7, -1.0, 0.0, 1.3, 3.1):
+            exact = inner.crps(x)
+            assert abs(pf.crps(x) - exact) < 0.01 * max(exact, 0.05)
+
+    def test_cdf_quantile_roundtrip(self):
+        ys, zs = _identity_table()
+        pf = PushforwardDist(Dist.gaussian(0.5, 2.0), ys, zs)
+        for p in (0.05, 0.3, 0.5, 0.9):
+            assert abs(pf.cdf(pf.quantile(p)) - p) < 1e-6
+
+    def test_moments_match(self):
+        ys, zs = _identity_table()
+        inner = Dist([(0.7, 0.2, 0.8), (0.3, -0.5, 1.5)])
+        pf = PushforwardDist(inner, ys, zs)
+        assert abs(pf.mean - inner.mean) < 1e-6
+        assert abs(pf.std - inner.std) < 1e-3
+
+
+class TestLognormalClosedForm:
+    """yeo_johnson(0) is log1p on the POSITIVE branch, so a component whose
+    z-mass stays positive pushes to a shifted lognormal exactly. (The
+    negative branch is quadratic, a detail the first version of this test
+    got wrong.)"""
+
+    def _pf(self, m, s):
+        _, inverse_k = yeo_johnson(0.0, exact=True)
+        return inverse_k([Dist.gaussian(m, s)], {})[0]
+
+    def test_logpdf_matches_lognormal(self):
+        m, s = 0.3, 0.5
+        pf = self._pf(m, s)
+        for y in (0.1, 0.5, 1.0, 2.0, 5.0):    # z = log1p(y) > 0: log branch
+            z = math.log1p(y)
+            want = (-0.5 * ((z - m) / s) ** 2 - math.log(s * SQRT2PI)
+                    - math.log1p(y))          # -log dinv = -z
+            assert abs(pf.logpdf(y) - want) < 2e-3
+
+    def test_mean_matches_lognormal(self):
+        m, s = 3.0, 0.3                        # z-mass entirely positive
+        pf = self._pf(m, s)
+        want = math.exp(m + 0.5 * s * s) - 1.0
+        assert abs(pf.mean - want) < 1e-3 * (1.0 + abs(want))
+
+    def test_exact_carries_skew_delta_does_not(self):
+        m, s = 0.0, 0.5
+        pf = self._pf(m, s)
+        up = pf.quantile(0.9) - pf.quantile(0.5)
+        dn = pf.quantile(0.5) - pf.quantile(0.1)
+        assert up > 1.2 * dn                      # right-skewed in y
+        _, inv_delta = yeo_johnson(0.0)
+        d = inv_delta([Dist.gaussian(m, s)], {})[0]
+        up_d = d.quantile(0.9) - d.quantile(0.5)
+        dn_d = d.quantile(0.5) - d.quantile(0.1)
+        assert abs(up_d - dn_d) < 1e-6 * max(up_d, 1.0)   # symmetric
+
+
+class TestDefaultUnchanged:
+
+    def test_delta_path_is_default(self):
+        _, inv_default = yeo_johnson(0.5)
+        _, inv_exact = yeo_johnson(0.5, exact=True)
+        d = Dist.gaussian(1.0, 0.3)
+        out_default = inv_default([d], {})[0]
+        out_exact = inv_exact([d], {})[0]
+        assert isinstance(out_default, Dist)
+        assert isinstance(out_exact, PushforwardDist)
+
+    def test_power_transform_exact_smoke(self):
+        _, inverse_k = power_transform(0.5, exact=True)
+        pf = inverse_k([Dist.gaussian(2.0, 0.4)], {})[0]
+        assert math.isfinite(pf.logpdf(pf.mean))
+        assert pf.std > 0
+
+
+class TestComposition:
+
+    def test_conjugated_skater_runs_and_scores(self):
+        random.seed(3)
+        f = conjugate(leaf(k=3), yeo_johnson(0.0, exact=True), k=3)
+        state = None
+        level = 5.0
+        pend = None
+        lps = []
+        for _ in range(200):
+            level = max(level * math.exp(random.gauss(0, 0.1)), 1e-3)
+            if pend is not None:
+                lps.append(pend[0].logpdf(level))
+            pend, state = f(level, state)
+        assert all(math.isfinite(v) for v in lps[10:])
+
+    def test_components_shim_supports_combine(self):
+        _, inverse_k = yeo_johnson(0.0, exact=True)
+        pf = inverse_k([Dist.gaussian(0.5, 0.3)], {})[0]
+        mixed = Dist.combine([Dist(pf.components), Dist.gaussian(0.0, 1.0)])
+        assert math.isfinite(mixed.logpdf(0.2))
+
+    def test_table_from_map_monotone(self):
+        ys, zs = table_from_map(lambda z: math.expm1(min(z, 350.0)), -3.0, 3.0)
+        assert all(b > a for a, b in zip(ys, ys[1:]))
+        assert all(b > a for a, b in zip(zs, zs[1:]))


### PR DESCRIPTION
Follow-up from the #80 work, scrutinizing a defect the nonparanormal ablation surfaced in src itself.

## The defect

The nonlinear transform inverses map each mixture component by the delta method, `N(inv(m), s*dinv(m))`. The inner components of a conjugated forecaster all sit near the same z-location, so the mapped mixture comes out location-symmetric about the mapped median. The skew the coordinate change exists to express lives in the curvature of the map within a component's width, and the delta method linearizes it away. Inside the candidate pool this is harmless (the trunk consumes means, one-step likelihoods and warm-up mixtures at small spreads). It bites the composition the README itself recommends: standalone `conjugate(..., yeo_johnson(0.5), k=10)` on positive levels, where the emitted predictive is consumed directly and the h=10 spread makes curvature material.

## Size of the effect

Analytic (pushforward of N(m,s) through log1p vs its delta Gaussian): KL 0.008 nats at s=0.1, 0.036 at 0.2, 0.26 at 0.5; 90% intervals cover 87.5% at s=0.5; mean biased by 0.24 sd. Empirical, on 120 strictly positive FRED level series under the README composition (leaf under OU under Yeo-Johnson, k=10):

| | h=1 | h=5 | h=10 |
|---|---|---|---|
| lambda=0, exact - delta, median LL | -0.001 | +0.004 | **+0.018 (72% win)** |
| lambda=0.5 | -0.000 | +0.005 | **+0.015 (78% win)** |

The gain grows with horizon and with realized z-spread, as the curvature analysis predicts. Alternatives measured and rejected: equal-mass quantile splitting has a ~0.06-nat lumpiness floor (a slice mixture is a poor stand-in for a smooth density) and Gauss-Hermite moment matching captures only 15-25% of the gap (the loss is mostly skew, and moment matching is already the KL-optimal single Gaussian).

## The change

- New `skaters/pushforward.py` with `PushforwardDist`, the `SplicedDist` idiom: exact `logpdf/pdf/cdf/quantile` through the change of variables, CRPS by trapezoid in z-coordinates (constant Jacobian per table segment, validated to 0.2% against `Dist.crps` through an identity table), and a lazy `.components` shim (per-component Gauss-Hermite moment matching) so `Dist.combine` and sticky keep working.
- `yeo_johnson(lmbda, exact=True)` and `power_transform(p, exact=True)` emit it, building the table on an adaptive window (a fixed window fails: positive levels live at z ~ 2*sqrt(y) under lambda=0.5).
- README: the standalone composition now shows `exact=True`; transform table rows note the option.

## Compatibility

Defaults are byte-identical (`exact=False` everywhere; the pool is untouched), so JS parity vectors do not move. The JS twin needs a port only if/when it grows the `exact=` option; flagging rather than coupling the release train. Full suite: 697 passed. `tests/test_fast_backend.py::test_cross_backend_logpdf_parity` fails on clean main on this machine and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)