### PR TITLE
challengers: drop the hedge in the featured-bouts lead

### DIFF
--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -120,8 +120,8 @@
 
     <h2>Featured bouts</h2>
     <p>
-      The above caveats notwithstanding, Laplace does seem to outperform as
-      a practical generalist model: fast, light, and with no dependencies.
+      Laplace also outperforms as a practical generalist model: fast, light,
+      and with no dependencies.
     </p>
     <div class="card-grid">
       <div class="card">


### PR DESCRIPTION
Removes "The above caveats notwithstanding, Laplace does seem to outperform" hedging; states it plainly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)