### PR TITLE
Bump version to 0.15.0

### DIFF
--- a/docs/js/skaters/package.json
+++ b/docs/js/skaters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skaters",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Fast univariate online distributional time-series forecasting: a zero-dependency JavaScript port of the Python skaters package, numerically identical to 1e-6.",
   "type": "module",
   "main": "./index.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skaters"
-version = "0.14.0"
+version = "0.15.0"
 description = "Fast univariate time series models that run in Pyodide"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
v0.14.0 was tagged before #160 merged. 0.15.0 is the JOSS-reviewable version containing the gaussianize transform, the empirical terminal leaves, the paper benchmarks, and papers/joss/paper.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)