### PR TITLE
JOSS paper: state-of-the-field comparison and compile-check action

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,0 +1,27 @@
+name: Draft PDF
+# JOSS pre-submission compile check: builds papers/joss/paper.md with the
+# official openjournals action and uploads the PDF as an artifact.
+on:
+  push:
+    paths:
+      - papers/joss/**
+      - .github/workflows/draft-pdf.yml
+  workflow_dispatch:
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    name: Paper Draft
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build draft PDF
+        uses: openjournals/openjournals-draft-action@master
+        with:
+          journal: joss
+          paper-path: papers/joss/paper.md
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: paper
+          path: papers/joss/paper.pdf

--- a/papers/joss/paper.bib
+++ b/papers/joss/paper.bib
@@ -41,3 +41,53 @@
   year    = {2023},
   doi     = {10.1109/TKDE.2021.3112126}
 }
+
+@inproceedings{seabold2010statsmodels,
+  author    = {Seabold, Skipper and Perktold, Josef},
+  title     = {statsmodels: Econometric and Statistical Modeling with Python},
+  booktitle = {Proceedings of the 9th Python in Science Conference},
+  year      = {2010},
+  pages     = {92--96},
+  doi       = {10.25080/Majora-92bf1922-011}
+}
+
+@article{alexandrov2020gluonts,
+  author  = {Alexandrov, Alexander and Benidis, Konstantinos and Bohlke-Schneider, Michael and Flunkert, Valentin and Gasthaus, Jan and Januschowski, Tim and Maddix, Danielle C. and Rangapuram, Syama and Salinas, David and Schulz, Jasper and Stella, Lorenzo and T{\"u}rkmen, Ali Caner and Wang, Yuyang},
+  title   = {{GluonTS}: Probabilistic and Neural Time Series Modeling in {Python}},
+  journal = {Journal of Machine Learning Research},
+  volume  = {21},
+  number  = {116},
+  pages   = {1--6},
+  year    = {2020}
+}
+
+@article{montiel2021river,
+  author  = {Montiel, Jacob and Halford, Max and Mastelini, Saulo Martiello and Bolmier, Geoffrey and Sourty, Raphael and Vaysse, Robin and Zouitine, Adil and Gomes, Heitor Murilo and Read, Jesse and Abdessalem, Talel and Bifet, Albert},
+  title   = {River: Machine Learning for Streaming Data in {Python}},
+  journal = {Journal of Machine Learning Research},
+  volume  = {22},
+  number  = {110},
+  pages   = {1--8},
+  year    = {2021}
+}
+
+@article{herzen2022darts,
+  author  = {Herzen, Julien and L{\"a}ssig, Francesco and Piazzetta, Samuele Giuliano and Neuer, Thomas and Tafti, L{\'e}o and Raille, Guillaume and Van Pottelbergh, Tomas and Pasieka, Marek and Skrodzki, Andrzej and Huguenin, Nicolas and Dumonal, Maxime and Ko{\'s}cisz, Jan and Bader, Dennis and Gusset, Fr{\'e}d{\'e}rick and Benheddi, Mounir and Williamson, Camila and Kosinski, Michal and Petrik, Matej and Grosch, Ga{\"e}l},
+  title   = {Darts: User-Friendly Modern Machine Learning for Time Series},
+  journal = {Journal of Machine Learning Research},
+  volume  = {23},
+  number  = {124},
+  pages   = {1--6},
+  year    = {2022}
+}
+
+@article{taylor2018forecasting,
+  author  = {Taylor, Sean J. and Letham, Benjamin},
+  title   = {Forecasting at Scale},
+  journal = {The American Statistician},
+  volume  = {72},
+  number  = {1},
+  pages   = {37--45},
+  year    = {2018},
+  doi     = {10.1080/00031305.2017.1380080}
+}

--- a/papers/joss/paper.md
+++ b/papers/joss/paper.md
@@ -54,6 +54,14 @@ forecasting software returns point forecasts or intervals, refits in
 batch, or requires a scientific-computing stack. Practitioners who need a
 predictive *distribution* per tick, updated online at microsecond-to-second
 cadence, on a server or in a browser, have had to assemble one from parts.
+Established open-source forecasters occupy different corners: `statsmodels`
+[@seabold2010statsmodels] and `darts` [@herzen2022darts] are batch-refit and
+largely point- or interval-oriented, Prophet [@taylor2018forecasting] targets
+batch seasonal decomposition, `GluonTS` [@alexandrov2020gluonts] is
+distributional but assumes a deep-learning stack and offline training, and
+`river` [@montiel2021river] is natively online but centred on point
+prediction. None provides an online predictive density as a single
+dependency-free function.
 
 `skaters` fills that gap with a single dependency-free function. On 894
 continuous non-price FRED series it leads classical, neural, and
@@ -64,7 +72,10 @@ forecaster into an anomaly detector with stated false-alarm rates: alarm
 when $\mathrm{erfc}(|z|/\sqrt{2}) < \alpha$, with measured rates near
 nominal on economic series. Methods, benchmarks, and the tail-calibration
 studies are documented in a companion methods paper in the repository and
-at https://skaters.microprediction.org.
+at https://skaters.microprediction.org. The package also serves as the
+measurement instrument in an ongoing empirical study of representation
+value in conformal prediction, whose experiment scripts live in this
+repository's `benchmarks` directory.
 
 The design distills ideas from the author's earlier `timemachines`
 package [@cotton2021timemachines] and from live distributional-prediction


### PR DESCRIPTION
Adds the related-software comparison JOSS reviewers check for (statsmodels, darts, Prophet, GluonTS, river), a research-use note, and the official openjournals draft-pdf Action as the pre-submission compile test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)