### PR TITLE
papers page: submission status and the gap companion paper

### DIFF
--- a/docs/papers.html
+++ b/docs/papers.html
@@ -81,6 +81,27 @@
       &nbsp;·&nbsp;
       <a href="https://github.com/microprediction/skaters/blob/main/papers/skaters.md">Markdown draft</a>
     </p>
+    <p>
+      A preprint is posted on SSRN (2026), and a short software paper is under review at the
+      <a href="https://joss.theoj.org/">Journal of Open Source Software</a>
+      (<a href="https://github.com/microprediction/skaters/blob/main/papers/joss/paper.md">paper.md</a>).
+    </p>
+
+    <h2>Companion paper &mdash; the conformal information gap</h2>
+    <p>
+      <strong>An Empirical Study of the Conformal Information Gap.</strong> P. Cotton.
+    </p>
+    <p>
+      The library serves as the measurement instrument for a study of what residual pooling
+      costs. Under logarithmic loss the irreducible cost of a retained representation is a
+      conditional mutual information, the information gap. A nested ladder of skaters
+      transforms prices each representation family prequentially on 701 FRED series:
+      conditional scale is the largest and most reliable component of the gain, and
+      scale-normalized empirical pooling beats raw pooling on 87 percent of series under
+      CRPS. The experiment scripts live in this repository's
+      <a href="https://github.com/microprediction/skaters/tree/main/benchmarks">benchmarks</a>
+      directory. Preprint on SSRN (2026).
+    </p>
 
     <h2>Benchmark 1 — the non-price universe</h2>
     <p>


### PR DESCRIPTION
The page predated today's submissions: adds the SSRN/JOSS status line to the skaters paper and a section for the conformal-information-gap companion study, whose experiment scripts live in benchmarks/. SSRN links get added when the abstract IDs arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)