### PR TITLE
Fix `Dist.quantile`: localize the search bracket and use a scale-relative tolerance

### DIFF
--- a/docs/js/skaters/dist.mjs
+++ b/docs/js/skaters/dist.mjs
@@ -186,17 +186,36 @@ export class Dist {
 
   quantile(p, tol = 1e-9, maxIter = 100) {
     if (!(p > 0 && p < 1)) throw new Error("quantile p must be in (0, 1)");
-    const mu = this.mean;
-    const sigma = Math.sqrt(this.var);
-    let lo = mu - 8 * sigma;
-    let hi = mu + 8 * sigma;
-    for (let i = 0; i < maxIter; i++) {
+    // Localize before bisecting: the sorted component +/-8 sigma endpoints
+    // are partition landmarks (not cdf change points), binary-searched for a
+    // gap containing p; then x-space tolerance at the smallest component
+    // sigma (parity with the Python reference fix).
+    const edgeSet = new Set();
+    let sMin = Infinity;
+    for (const [, m, s] of this.components) {
+      edgeSet.add(m - 8 * s);
+      edgeSet.add(m + 8 * s);
+      if (s > 0 && s < sMin) sMin = s;
+    }
+    const edges = Array.from(edgeSet).sort((a, b) => a - b);
+    let i = 0;
+    let j = edges.length - 1;
+    while (j - i > 1) {
+      const k = Math.floor((i + j) / 2);
+      if (this.cdf(edges[k]) < p) i = k;
+      else j = k;
+    }
+    let lo = edges[i];
+    let hi = edges[j];
+    const xTol = Number.isFinite(sMin) ? tol * sMin : 0;
+    for (let n = 0; n < maxIter; n++) {
       const mid = 0.5 * (lo + hi);
+      if (mid === lo || mid === hi) break; // machine resolution
       if (this.cdf(mid) < p) lo = mid;
       else hi = mid;
-      if (hi - lo < tol) break;
+      if (hi - lo <= xTol) break;
     }
-    return 0.5 * (lo + hi);
+    return hi;
   }
 
   get mean() {

--- a/parity/quantile_contract.mjs
+++ b/parity/quantile_contract.mjs
@@ -1,0 +1,95 @@
+// Inverse-CDF contract gate for the JS twin.
+//
+// `quantile` is documented as the inverse of `cdf`. Four mixture geometries
+// broke that round-trip before the localized-bracket fix, and each one killed
+// a different candidate repair:
+//
+//   1. tiny scale          — an ABSOLUTE stopping tolerance exceeds the whole
+//                            bracket, so bisection stops after one halving;
+//   2. far low-weight      — a mixture-moment bracket excludes the component
+//      component            that owns the quantile, so it returns its own edge;
+//   3. narrow inside wide  — a tolerance scaled to the MIXTURE sigma is too
+//                            coarse for the narrow component;
+//   4. astronomical        — bisecting the global span needs ~133 halvings
+//      separation           against max_iter = 100.
+//
+// Mirrors tests/test_quantile_inverse_contract.py and
+// rust/tests/quantile_contract.rs: the same numbers must hold in every port.
+//
+// Run: node parity/quantile_contract.mjs      (exits non-zero on any violation)
+
+import { Dist } from "../docs/js/skaters/dist.mjs";
+
+let failures = 0;
+
+function check(name, ok, detail) {
+  if (ok) {
+    console.log(`ok   ${name}`);
+  } else {
+    console.log(`FAIL ${name}: ${detail}`);
+    failures += 1;
+  }
+}
+
+function roundtripErr(d, p) {
+  return Math.abs(d.cdf(d.quantile(p)) - p);
+}
+
+// 1. tiny scale
+{
+  const d = new Dist([[1.0, 0.0, 1e-11]]);
+  for (const p of [0.01, 0.5, 0.99]) {
+    const e = roundtripErr(d, p);
+    check(`tiny_scale p=${p}`, e < 1e-6, `roundtrip err ${e}`);
+  }
+  const q = d.quantile(0.99);
+  check("tiny_scale value", Math.abs(q - 2.3263478740408408e-11) < 1e-13, `got ${q}`);
+}
+
+// 2. far low-weight component
+{
+  const d = new Dist([[0.9999, 0.0, 1.0], [1e-4, 1000.0, 1.0]]);
+  const p = 1 - 1e-6;
+  const q = d.quantile(p);
+  check("far_component reaches it", q > 990.0, `stuck at bracket edge: ${q}`);
+  check("far_component roundtrip", roundtripErr(d, p) < 1e-5, `err ${roundtripErr(d, p)}`);
+}
+
+// 3. narrow component inside a wide mixture
+{
+  const d = new Dist([[0.5, 0.0, 1e-11], [0.5, 1000.0, 1.0]]);
+  const q = d.quantile(0.25);
+  check("narrow_inside_wide roundtrip", roundtripErr(d, 0.25) < 1e-6, `err ${roundtripErr(d, 0.25)}`);
+  check("narrow_inside_wide value", Math.abs(q) < 1e-9, `p=0.25 sits at the narrow median, got ${q}`);
+}
+
+// 4. astronomical separation beside a narrow component
+for (const sep of [1e20, 1e40, 1e80]) {
+  const d = new Dist([[0.5, 0.0, 1e-11], [0.5, sep, 1.0]]);
+  for (const p of [0.25, 0.75]) {
+    const e = roundtripErr(d, p);
+    check(`astronomical sep=${sep} p=${p}`, e < 1e-6, `roundtrip err ${e}, q=${d.quantile(p)}`);
+  }
+}
+
+// 5. deep tail: parade derives z through this call, so termination stays in
+//    x-space. A probability-space exit blunts this from ~7.03 to ~6.0.
+{
+  const d = new Dist([[1.0, 0.0, 1.0]]);
+  const z = d.quantile(1 - 1e-12);
+  check("deep_tail diagnostic", Math.abs(z - 7.034481104929) < 1e-4, `got ${z}`);
+}
+
+// 6. unit scale must be untouched by the localization
+{
+  const d = new Dist([[0.6, 0.0, 1.0], [0.4, 3.0, 2.0]]);
+  for (const p of [0.1, 0.5, 0.9]) {
+    check(`unit_scale p=${p}`, roundtripErr(d, p) < 1e-6, `err ${roundtripErr(d, p)}`);
+  }
+}
+
+if (failures > 0) {
+  console.log(`\n${failures} inverse-CDF contract violation(s)`);
+  process.exit(1);
+}
+console.log("\nall inverse-CDF contract checks passed");

--- a/rust/src/dist.rs
+++ b/rust/src/dist.rs
@@ -111,22 +111,47 @@ impl Dist {
 
     pub fn quantile_tol(&self, p: f64, tol: f64, max_iter: usize) -> f64 {
         assert!(0.0 < p && p < 1.0);
-        let mu = self.mean();
-        let sigma = self.var().sqrt();
-        let mut lo = mu - 8.0 * sigma;
-        let mut hi = mu + 8.0 * sigma;
+        // Localize before bisecting: the sorted component +/-8 sigma
+        // endpoints are partition landmarks (not cdf change points),
+        // binary-searched for a gap containing p; then x-space tolerance at
+        // the smallest component sigma (parity with the Python fix).
+        let mut edges: Vec<f64> = Vec::with_capacity(self.components.len() * 2);
+        let mut s_min = f64::INFINITY;
+        for &(_, m, s) in &self.components {
+            edges.push(m - 8.0 * s);
+            edges.push(m + 8.0 * s);
+            if s > 0.0 && s < s_min {
+                s_min = s;
+            }
+        }
+        edges.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        edges.dedup();
+        let (mut i, mut j) = (0usize, edges.len() - 1);
+        while j - i > 1 {
+            let k = (i + j) / 2;
+            if self.cdf(edges[k]) < p {
+                i = k;
+            } else {
+                j = k;
+            }
+        }
+        let (mut lo, mut hi) = (edges[i], edges[j]);
+        let x_tol = if s_min.is_finite() { tol * s_min } else { 0.0 };
         for _ in 0..max_iter {
             let mid = 0.5 * (lo + hi);
+            if mid == lo || mid == hi {
+                break; // machine resolution
+            }
             if self.cdf(mid) < p {
                 lo = mid;
             } else {
                 hi = mid;
             }
-            if hi - lo < tol {
+            if hi - lo <= x_tol {
                 break;
             }
         }
-        0.5 * (lo + hi)
+        hi
     }
 
     pub fn mean(&self) -> f64 {

--- a/rust/tests/quantile_contract.rs
+++ b/rust/tests/quantile_contract.rs
@@ -1,0 +1,89 @@
+//! `quantile` must invert `cdf` at every scale and for uneven mixtures.
+//!
+//! Rust mirror of `tests/test_quantile_inverse_contract.py`. Three regimes
+//! broke the documented inverse-CDF contract:
+//!
+//! 1. tiny scales — the absolute tolerance exceeded the whole bracket, so
+//!    bisection stopped after one halving (median of N(0, 1e-11) resolved
+//!    to the ~0.003rd percentile);
+//! 2. tiny-weight far components — the mixture-moment bracket excluded the
+//!    answer, so bisection returned the bracket edge (~80 instead of
+//!    1002.3263);
+//! 3. astronomical separation beside a narrow component — bisecting the
+//!    whole span needs ~133 halvings against max_iter = 100.
+//!
+//! The fix localizes before bisecting: sorted component +/- 8 sigma
+//! endpoints are binary-searched for a gap containing p; the tolerance is
+//! `tol` times the SMALLEST component sigma (which the narrow-inside-wide
+//! case pins); termination stays in x-space (the deep-tail case pins this
+//! — parade derives its z diagnostic through this function); and the
+//! result is the `cdf >= p` endpoint rather than the midpoint.
+
+use skaters_core::dist::Dist;
+
+fn roundtrip_err(d: &Dist, p: f64) -> f64 {
+    (d.cdf(d.quantile(p)) - p).abs()
+}
+
+#[test]
+fn quantile_inverts_cdf_at_tiny_scale() {
+    let d = Dist::new(vec![(1.0, 0.0, 1e-11)]);
+    for p in [0.01, 0.5, 0.99] {
+        assert!(roundtrip_err(&d, p) < 1e-6, "p={p} err={}", roundtrip_err(&d, p));
+    }
+    assert!((d.quantile(0.99) - 2.3263478740408408e-11).abs() < 1e-13);
+}
+
+#[test]
+fn quantile_reaches_tiny_weight_far_component() {
+    let d = Dist::new(vec![(0.9999, 0.0, 1.0), (1e-4, 1000.0, 1.0)]);
+    let p = 1.0 - 1e-6;
+    let q = d.quantile(p);
+    assert!(q > 990.0, "quantile stuck at bracket edge: {q}");
+    assert!(roundtrip_err(&d, p) < 1e-5);
+}
+
+#[test]
+fn quantile_mixed_scales_narrow_inside_wide() {
+    let d = Dist::new(vec![(0.5, 0.0, 1e-11), (0.5, 1000.0, 1.0)]);
+    let q = d.quantile(0.25);
+    assert!(roundtrip_err(&d, 0.25) < 1e-6, "q={q} cdf={}", d.cdf(q));
+    assert!(q.abs() < 1e-9, "p=0.25 lives at the narrow component median, got {q}");
+}
+
+#[test]
+fn quantile_astronomical_separation_with_narrow_component() {
+    // Bisecting the GLOBAL span needs ~133 halvings to reach the narrow
+    // component's scale, against max_iter = 100. Localizing to the endpoint
+    // gap that contains p keeps the search where the tolerance can resolve.
+    for sep in [1e20_f64, 1e40, 1e80] {
+        let d = Dist::new(vec![(0.5, 0.0, 1e-11), (0.5, sep, 1.0)]);
+        for p in [0.25_f64, 0.75] {
+            let e = roundtrip_err(&d, p);
+            assert!(e < 1e-6, "sep={sep} p={p} err={e} q={}", d.quantile(p));
+        }
+    }
+}
+
+#[test]
+fn quantile_preserves_deep_tail_diagnostic() {
+    // parade derives z = Phi^-1(pit) through this call; the clamp lands at
+    // ~7.03 and a probability-space exit would blunt it to ~6.0 — that gap
+    // is what this pins. Tolerance is 1e-4, not 1e-6: the Rust erf differs
+    // from the Python reference by ~1.9e-6 in x at |z| ~ 7 (Python
+    // 7.034481104929, Rust 7.034483039286). That difference is inherited
+    // from erf and is IDENTICAL on pristine main — it is not introduced by
+    // the bracket/tolerance change.
+    let d = Dist::new(vec![(1.0, 0.0, 1.0)]);
+    let z = d.quantile(1.0 - 1e-12);
+    assert!((z - 7.034481104929).abs() < 1e-4, "deep-tail z was {z}");
+    assert!(z > 6.5, "probability-space exit would have blunted this to ~6.0");
+}
+
+#[test]
+fn quantile_unit_scale_unchanged() {
+    let d = Dist::new(vec![(0.6, 0.0, 1.0), (0.4, 3.0, 2.0)]);
+    for p in [0.1, 0.5, 0.9] {
+        assert!(roundtrip_err(&d, p) < 1e-6);
+    }
+}

--- a/src/skaters/dist.py
+++ b/src/skaters/dist.py
@@ -128,22 +128,57 @@ class Dist:
         return t1 - 0.5 * t2
 
     def quantile(self, p: float, tol: float = 1e-9, max_iter: int = 100) -> float:
-        """Inverse CDF via bisection."""
+        """Inverse CDF via bisection.
+
+        The bracket spans every component's +/-8 sigma range, and the
+        stopping tolerance is ``tol`` times the SMALLEST component sigma
+        (x-space, never probability-space), so tiny scales, distant
+        low-weight components, and narrow-inside-wide mixtures all resolve
+        while unit-scale behavior matches the historical tolerance exactly.
+        Terminates at machine resolution or ``max_iter`` otherwise.
+        """
         assert 0 < p < 1
-        # Initial bracket
-        mu = self.mean
-        sigma = math.sqrt(self.var)
-        lo = mu - 8 * sigma
-        hi = mu + 8 * sigma
+        # Localize before bisecting. The component +/-8 sigma endpoints are
+        # not change points of the mixture cdf (it is smooth), but they are
+        # useful partition landmarks: sorted, they bound the regions where
+        # each component carries essentially all of its mass, so binary
+        # searching them costs O(log n) cdf calls and lands on a gap that
+        # contains p and is no wider than the local structure. Bisecting the
+        # GLOBAL span instead cannot resolve a narrow component inside a
+        # hugely separated mixture: the width ratio can exceed what max_iter
+        # halvings can bridge.
+        edges = sorted({m - 8.0 * s for _, m, s in self.components}
+                       | {m + 8.0 * s for _, m, s in self.components})
+        i, j = 0, len(edges) - 1
+        while j - i > 1:
+            k = (i + j) // 2
+            if self.cdf(edges[k]) < p:
+                i = k
+            else:
+                j = k
+        lo, hi = edges[i], edges[j]
+        # x-space tolerance at the smallest component scale: resolves narrow
+        # components inside wide mixtures, and at unit scale reduces to the
+        # historical absolute tolerance (preserving deep-tail diagnostics).
+        sigmas = [s for _, _, s in self.components if s > 0.0]
+        x_tol = tol * min(sigmas) if sigmas else 0.0
         for _ in range(max_iter):
             mid = 0.5 * (lo + hi)
+            if mid == lo or mid == hi:
+                break  # bracket at machine resolution
             if self.cdf(mid) < p:
                 lo = mid
             else:
                 hi = mid
-            if hi - lo < tol:
+            if hi - lo <= x_tol:
                 break
-        return 0.5 * (lo + hi)
+        # `hi` is the tightest point known to satisfy cdf(x) >= p, which is
+        # the quantile's definition; the midpoint can fall on the cdf(x) < p
+        # side. They differ by at most half the final bracket (<= x_tol/2),
+        # except where float64 cannot resolve the component at all — there,
+        # returning `hi` lands on the one representable point that carries
+        # the mass instead of the neighbour just below it.
+        return hi
 
     @property
     def mean(self) -> float:

--- a/tests/test_js_parity.py
+++ b/tests/test_js_parity.py
@@ -42,6 +42,16 @@ def test_js_adversarial_gate():
         check=True, cwd=ROOT)
 
 
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_js_quantile_contract():
+    """The JS twin must invert its own cdf in every mixture geometry that
+    broke the shipped bisection — same numbers as
+    tests/test_quantile_inverse_contract.py and rust/tests/quantile_contract.rs."""
+    subprocess.run(
+        ["node", os.path.join(ROOT, "parity", "quantile_contract.mjs")],
+        check=True, cwd=ROOT)
+
+
 @pytest.mark.skipif(shutil.which("cargo") is None, reason="cargo not installed")
 def test_rust_parity():
     """The Rust core (rust/) must reproduce the Python numerics: regenerate

--- a/tests/test_quantile_inverse_contract.py
+++ b/tests/test_quantile_inverse_contract.py
@@ -1,0 +1,132 @@
+"""quantile must invert cdf at every scale and for uneven mixtures.
+
+The README contract is `quantile  # inverse CDF`. Two regimes broke it:
+
+1. Tiny scales: the bisection's ABSOLUTE tolerance (1e-9) exceeds the whole
+   initial bracket when the mixture std is small, so the loop stops after
+   one halving — the median of N(0, 1e-11) resolved to the ~0.003rd
+   percentile.
+2. Tiny-weight far components: the initial bracket is built from MIXTURE
+   moments (mu +/- 8*sigma), so quantiles owned by a low-weight distant
+   component lie outside the bracket and bisection returns the bracket
+   edge: quantile(1-1e-6) of 0.9999*N(0,1) + 1e-4*N(1000,1) returned ~80
+   (true 1002.3263).
+
+A third regime appears once those two are addressed: with a narrow
+component beside a hugely separated one, bisecting the whole span needs
+~133 halvings against max_iter=100, so the search never reaches the
+tolerance at all.
+
+The fix localizes before bisecting: the component +/- 8 sigma endpoints
+are sorted and binary-searched for a gap containing p, the stopping
+tolerance is `tol` times the SMALLEST component sigma (x-space, never
+probability-space, so parade's deep-tail z diagnostic survives), and the
+result is `hi` — the tightest point known to satisfy cdf(x) >= p, which
+is the quantile's definition and matters where float64 resolves a
+component to a single representable point. These tests pin the contract,
+including the float64 limit beyond which no algorithm can satisfy it.
+"""
+import math
+
+from skaters.dist import Dist
+
+
+def _roundtrip_err(d, p):
+    return abs(d.cdf(d.quantile(p)) - p)
+
+
+def test_quantile_inverts_cdf_at_tiny_scale():
+    d = Dist([(1.0, 0.0, 1e-11)])
+    assert _roundtrip_err(d, 0.5) < 1e-6
+    assert _roundtrip_err(d, 0.99) < 1e-6
+    assert _roundtrip_err(d, 0.01) < 1e-6
+    # and the values themselves are right (Phi^-1(0.99) ~ 2.3263)
+    assert abs(d.quantile(0.99) - 2.3263478740408408e-11) < 1e-13
+
+
+def test_quantile_inverts_cdf_at_huge_scale():
+    d = Dist([(1.0, 1e9, 1e7)])
+    for p in (0.01, 0.5, 0.99):
+        assert _roundtrip_err(d, p) < 1e-6
+
+
+def test_quantile_reaches_tiny_weight_far_component():
+    d = Dist([(0.9999, 0.0, 1.0), (1e-4, 1000.0, 1.0)])
+    p = 1.0 - 1e-6
+    q = d.quantile(p)
+    assert q > 990.0, f"quantile stuck at bracket edge: {q}"
+    assert _roundtrip_err(d, p) < 1e-5
+
+
+def test_quantile_far_component_low_side():
+    d = Dist([(1e-4, -1000.0, 1.0), (0.9999, 0.0, 1.0)])
+    p = 1e-6
+    q = d.quantile(p)
+    assert q < -990.0, f"quantile stuck at bracket edge: {q}"
+    assert _roundtrip_err(d, p) < 1e-5
+
+
+def test_quantile_unit_scale_unchanged():
+    # ordinary mixtures must keep inverting cdf tightly at unit scale
+    d = Dist([(0.6, 0.0, 1.0), (0.4, 3.0, 2.0)])
+    for p in (0.1, 0.5, 0.9):
+        assert _roundtrip_err(d, p) < 1e-6
+
+
+def test_quantile_monotone_across_levels_tiny_scale():
+    d = Dist([(0.5, 0.0, 1e-11), (0.5, 5e-11, 2e-11)])
+    ps = [0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999]
+    qs = [d.quantile(p) for p in ps]
+    assert all(b >= a for a, b in zip(qs, qs[1:])), qs
+    for p, q in zip(ps, qs):
+        assert abs(d.cdf(q) - p) < 1e-5
+
+
+def test_quantile_mixed_scales_narrow_inside_wide():
+    # reviewer counterexample: narrow component inside a wide mixture —
+    # a mixture-scale-relative tolerance stalls before resolving it
+    d = Dist([(0.5, 0.0, 1e-11), (0.5, 1000.0, 1.0)])
+    q = d.quantile(0.25)
+    assert _roundtrip_err(d, 0.25) < 1e-6, (q, d.cdf(q))
+    assert abs(q) < 1e-9, f"p=0.25 lives at the narrow component median, got {q}"
+
+
+def test_quantile_mixed_scales_dominant_narrow():
+    d = Dist([(0.9999, 0.0, 1e-11), (1e-4, 1000.0, 1.0)])
+    q = d.quantile(0.5)
+    assert _roundtrip_err(d, 0.5) < 1e-6, (q, d.cdf(q))
+    assert abs(q) < 1e-9
+
+
+def test_quantile_mixed_scales_mirrored():
+    d = Dist([(0.5, -1000.0, 1.0), (0.5, 0.0, 1e-11)])
+    for p in (0.75, 0.9):
+        assert _roundtrip_err(d, p) < 1e-6
+
+
+def test_quantile_astronomical_separation_with_narrow_component():
+    # A narrow component beside a hugely separated one: bisecting the GLOBAL
+    # span needs ~133 halvings to reach the narrow scale, but max_iter is 100.
+    # Localizing the bracket to the component endpoints that contain p keeps
+    # the search inside a region the tolerance can actually resolve.
+    for sep in (1e20, 1e40, 1e80):
+        d = Dist([(0.5, 0.0, 1e-11), (0.5, sep, 1.0)])
+        assert _roundtrip_err(d, 0.25) < 1e-6, (sep, d.quantile(0.25))
+        assert _roundtrip_err(d, 0.75) < 1e-6, (sep, d.quantile(0.75))
+
+
+def test_quantile_localization_costs_no_precision_at_unit_scale():
+    # Localization must not change well-conditioned answers.
+    d = Dist([(0.5, -2.0, 1.0), (0.5, 2.0, 1.0)])
+    for p in (0.05, 0.25, 0.5, 0.75, 0.95):
+        assert _roundtrip_err(d, p) < 1e-9
+
+
+def test_quantile_representation_limit_is_documented_not_silent():
+    # KNOWN LIMIT, not a defect: when ulp(mean) exceeds the component scale,
+    # float64 has no representable point between the mean and mean +/- sigma,
+    # so every quantile collapses to the mean. No algorithm can do better;
+    # this test exists so the boundary is explicit rather than surprising.
+    d = Dist([(1.0, 8.386e41, 3.853e6)])
+    assert math.ulp(8.386e41) > 8.0 * 3.853e6
+    assert d.quantile(0.25) == d.quantile(0.75) == 8.386e41


### PR DESCRIPTION
`Dist.quantile` is documented as the inverse of `cdf` (README: `d.quantile(0.975)  # inverse CDF`), but it doesn't invert for tiny-scale or widely separated mixtures. Both reproduce on current `main` and on PyPI 0.14.0 — the function is byte-identical in the two.

```python
from skaters.dist import Dist

d = Dist([(1.0, 0.0, 1e-11)])
d.quantile(0.5)         # -4e-11
d.cdf(d.quantile(0.5))  # 3.17e-05  — asked for the median, got the 0.003rd percentile

d = Dist([(0.9999, 0.0, 1.0), (1e-4, 1000.0, 1.0)])
d.quantile(1 - 1e-6)         # 80.5  — the bracket edge; the answer is ~1002.33
d.cdf(d.quantile(1 - 1e-6))  # 0.9999
```

Two causes, both in the bisection setup:

1. **The stopping tolerance is absolute** (`tol=1e-9`). When the mixture is
   narrower than that, the initial bracket is already inside tolerance and
   the loop exits after one halving.
2. **The bracket comes from mixture moments** (`mu ± 8*sigma`), so a
   quantile owned by a low-weight distant component lies outside the search
   region and bisection returns its own edge.

**The fix**

- Localize before bisecting: sort the component `m ± 8s` endpoints and
  binary-search them (O(log n) cdf calls) for a gap containing `p`, then
  bisect inside it. Bisecting the global span also can't resolve a narrow
  component beside a hugely separated one —
  `Dist([(0.5,0,1e-11),(0.5,1e20,1)]).quantile(0.25)` needs ~133 halvings
  against `max_iter=100`.
- Stop at `hi - lo <= tol * min_i(s_i)` — the tolerance scaled to the
  smallest component sigma, in x-space. Keeping it in x-space matters
  because `parade` derives its `z` diagnostic through this function; a
  probability-space exit blunts `quantile(1-1e-12)` from ~7.03 to ~6.0.
- Return `hi`, the tightest point known to satisfy `cdf(x) >= p`.

At unit scale the stopping rule reduces to the historical absolute
tolerance, so ordinary-scale behavior is unchanged
(`quantile(1-1e-12)` = 7.0344811, within 5e-10 of before).

**Tests**

New `tests/test_quantile_inverse_contract.py` (12 tests) — 8 fail on
0.14.0/`main`, all pass patched. The same geometries are pinned in the other
two ports: `rust/tests/quantile_contract.rs` (6 tests) and
`parity/quantile_contract.mjs`, wired into the suite as
`test_js_quantile_contract` alongside the existing adversarial gate. Against
pristine `main` that JS gate reports 12 failures; against the patch, none.

**Not broken by this**

`bench_core.roll_dist_scores` output is bit-identical old-vs-new on six
stress series (BURN=300). I have *not* verified every published benchmark
and don't want to imply otherwise: `SplicedDist.mean/var/crps` are computed
on a 65-node quantile grid, so tail-spliced numbers can change at the scales
where the old quantiles were wrong. That's the intended effect, but it is a
change, and you may want to re-run the affected arms.

Parity is unaffected: the JS and Rust mismatch sets are identical with and
without this patch (I checked both against pristine `893d3ea3` — the
`pol_laplace` failures are pre-existing). Runtime is unchanged for ordinary
mixtures (~10 µs/call).

Happy to split this, or to hand over the property harness if you'd rather
take the fix in a different direction.
