### PR TITLE
Restore five-port parity: uncap standardize, define missing observations (0.16.0)

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,71 @@
+name: Publish Rust port to crates.io
+
+# Publishes rust/ (the Rust port, crate name `skaters`) to crates.io when a
+# GitHub Release is published, after re-checking Python<->Rust numeric parity.
+# Bump the version in rust/Cargo.toml before tagging the release.
+#
+# Requires a repo secret CARGO_REGISTRY_TOKEN, scoped publish-new +
+# publish-update. Mirrors publish.yml (npm), including the discipline that the
+# parity vectors are REGENERATED from the Python reference before the gate runs:
+# parity/vectors.json is generated and untracked, so a stale copy reports
+# PARITY OK against a reference that no longer exists.
+#
+# `cargo publish` is irreversible: a version can be yanked but never deleted and
+# never reused. Use the workflow_dispatch dry run to rehearse the whole job
+# without uploading.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Package and verify without uploading"
+        type: boolean
+        default: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python (parity reference)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install the Python package
+        run: pip install -e .
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # The crate version is the thing being claimed forever, so refuse to
+      # publish one that disagrees with the tag that triggered this run.
+      - name: Crate version must match the release tag
+        if: github.event_name == 'release'
+        run: |
+          crate=$(sed -n 's/^version = "\(.*\)"/\1/p' rust/Cargo.toml | head -1)
+          tag="${GITHUB_REF_NAME#v}"
+          echo "crate=$crate tag=$tag"
+          if [ "$crate" != "$tag" ]; then
+            echo "::error::rust/Cargo.toml is $crate but the release tag is $tag"
+            exit 1
+          fi
+
+      - name: Parity gate (regenerate vectors from Python, then check the Rust port)
+        env:
+          PYTHONPATH: src
+        run: |
+          python parity/gen_vectors.py
+          cargo test --release --manifest-path rust/Cargo.toml
+
+      - name: Publish to crates.io
+        working-directory: rust
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+            cargo publish --dry-run
+          else
+            cargo publish
+          fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,14 @@ jobs:
     needs: vectors
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+        # macos-13 removed: GitHub retired those hosted runners, so the job sat
+        # QUEUED forever and never started, and `digests-agree` needs `core` —
+        # one dead matrix entry blocked every PR indefinitely. Its purpose was
+        # x86 macOS, and the portable-math claim still gets an x86-vs-arm64
+        # comparison from ubuntu-latest and windows-latest (x86) against
+        # macos-latest (arm64), plus wasm. To restore x86 macOS specifically,
+        # `macos-15-intel` is the current label.
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+## 0.16.0
+
+Two user-visible behavior changes, and the first release in which the Python,
+JavaScript, Rust, R and Julia ports actually agree.
+
+### The residual cap (all five ports)
+
+`standardize` divided the residual by the **post-update** EWMA variance, which
+made the emission self-normalized:
+
+    z = d / sqrt((1-a) v + a d^2)   =>   |z| < 1/sqrt(alpha) = 4.4721
+
+No input could produce a residual past 4.4721. Measured on the old code, `y=100`,
+`y=1000` and `y=1e6` all emitted exactly 4.4721, so a million-sigma move was
+indistinguishable from a hundred-sigma one. The affine inverse was also not the
+forward map's inverse, because the forward scale depended on the value being
+predicted: round-tripping `y=7.5` recovered `5.996`.
+
+It now emits against the prior variance, and the cold start scales by the first
+nonzero residual so the first informative emission is ±1.
+
+This changes every predictive. Expect small movements in both directions on
+aggregate point metrics (on the GIFT-Eval leaderboard protocol at k=13,
+`m4_monthly` MASE improved 1.0716 → 1.0619 while `m4_weekly` worsened
+3.2377 → 3.3229). Tail and coverage results are the ones most affected, since
+the cap is precisely what distorted them.
+
+The Python fix landed on main in #169 but **after** the v0.15.0 tag, so this is
+the first release to carry it in any language.
+
+### Missing observations are now a skipped tick
+
+A non-finite `y` (NaN or infinity) means "no observation", not a value and not an
+error. Previously the outcome depended on the horizon: at `k=1` laplace returned
+`mean=nan, std=0.0` and never recovered, because an EWMA fed NaN is poisoned
+permanently (`mu + alpha*(nan - mu) = nan`); at `k>1` it tripped a bare
+`assert w_total > 0` inside `Dist`.
+
+Now the value never reaches the tree, the fitted state is not advanced, and the
+fan is shifted so the previous tick's horizon `h+1` is returned as this tick's
+`h` — the forecast ages by one step rather than relabelling a stale predictive.
+After `k` consecutive gaps the longest horizon is held. `state["pit"]` and
+`state["z"]` are all `None` for the tick, so a gap cannot look like a zero
+residual to the anomaly layer, and `state["skipped"]` counts them.
+
+Callers wanting loud failure should check finiteness before calling. The reverse
+is not available: nothing can recover a silently corrupted state.
+
+See the "Missing observations" section of `skaters.conventions`.
+
+### Port parity restored
+
+CI was red from #169 (2026-08-04) to this release: the `standardize` repair
+reached Python only. The JS twin, the Rust port, the R package (published on
+r-universe) and the Julia package all kept the capped version. R and Julia were
+further behind still, each missing four things:
+
+- `garch` had no mean tracking, modelling the variance of the raw value rather
+  than of the deviation from a running mean, with a pure-scale inverse instead of
+  an affine one
+- `_ar_spectral_radius` / `_ar_stationary` were absent entirely, so an explosive
+  online fit had no damping and its multi-step forecast could diverge
+- `ar` and `grouped_ar` accumulated multi-step variance as `sum phi_j^2 var_{h-j}`
+  instead of `sigma^2 sum psi_i^2`; successive horizons share one innovation, so
+  the old form both mis-weighted and double counted it
+- `seasonal_anchor` was absent entirely, leaving the candidate pool at 57 against
+  Python's 60
+
+All five ports now pass at 1e-6.
+
+### Parity gate: two instrument fixes
+
+The drift was invisible because the gates were lying, and both faults are fixed.
+
+**The gates reported `ok` for failing scenarios.** The R and Julia parity scripts
+printed `ok <name>` per scenario unconditionally, with the failure detail capped
+at 7 lines *globally*, so a port four features behind displayed 59 `ok` lines and
+one failure. The budget is now per scenario and the summary reflects the tally.
+
+**Nothing checked the component inventory.** 105,798 numeric probes could not see
+three missing candidates, because every individual transform matched to 1e-6 and
+only the composed `laplace` drifted. `parity/vectors.json` now carries a
+`structure` block (candidate count and full depth vector per k), asserted in all
+four ports. The depth vector also pins ordering, since the ensemble aligns weights
+by candidate index.
+
+Note that `parity/vectors.json` is generated and untracked: a stale local copy
+will report `PARITY OK` against a reference that no longer exists. Regenerate with
+`PYTHONPATH=src python parity/gen_vectors.py` before trusting the gate. The
+pytest wrapper does this for you.
+
+### Added
+
+- `tests/test_standardize_no_cap.py` — pins the emission contract, the
+  forward/inverse pairing, and the cold-start unit emission
+- `tests/test_missing_observations.py` — 11 tests covering state preservation,
+  fan ageing, the leading-gap case, PIT/z reporting and an all-missing stream
+- Gap scenarios in the parity vectors, so the missing-observation rule is held
+  identically across ports (gaps travel as the `"nan"` sentinel, since JSON has
+  no NaN literal)

--- a/docs/js/skaters/package.json
+++ b/docs/js/skaters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skaters",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Fast univariate online distributional time-series forecasting: a zero-dependency JavaScript port of the Python skaters package, numerically identical to 1e-6.",
   "type": "module",
   "main": "./index.mjs",

--- a/docs/js/skaters/parade.mjs
+++ b/docs/js/skaters/parade.mjs
@@ -14,14 +14,42 @@ const STD_NORMAL = Dist.gaussian(0.0, 1.0);
 // bisection in Dist.quantile stays inside its +-8 sigma bracket. No input can
 // produce an infinite z. Non-finite CDF values leave the entry null.
 const EPS = 1e-12;
+// A leading missing tick has no prior forecast to age and no observation has
+// fixed the series' scale yet, so emit a deliberately wide zero-centred
+// Gaussian rather than a confident guess. The tree is left untouched, so the
+// first finite value initializes it exactly as a true first observation would.
+const NO_INFO_STD = 1e6;
 
 export function parade(base, k) {
   return function skater(y, state) {
     if (state === null || state === undefined) {
-      state = { base: null, pending: [], pit: new Array(k).fill(null), z: new Array(k).fill(null) };
+      state = { base: null, pending: [], pit: new Array(k).fill(null), z: new Array(k).fill(null), skipped: 0 };
     }
     const pend = state.pending;
     const n = pend.length;
+    // Missing observation — port of the Python parade's missing-tick rule. A
+    // non-finite y must never reach the tree: an EWMA fed NaN is poisoned
+    // permanently (mu + alpha*(nan - mu) = nan) and no later clean data
+    // recovers it. Treat the tick as "no observation": time advanced,
+    // information did not. Leave the base state untouched and SHIFT the fan,
+    // so the previous tick's horizon h+1 becomes this tick's horizon h and the
+    // forecast ages by one step. After k consecutive gaps h=k is held.
+    if (!Number.isFinite(y)) {
+      state.skipped = (state.skipped ?? 0) + 1;
+      state.pit = new Array(k).fill(null);
+      state.z = new Array(k).fill(null);
+      if (!n) {
+        const wide = [];
+        for (let h = 0; h < k; h++) wide.push(Dist.gaussian(0.0, NO_INFO_STD));
+        return [wide, state];
+      }
+      const prev = pend[n - 1];
+      const shifted = [];
+      for (let h = 1; h <= k; h++) shifted.push(prev[Math.min(h, prev.length - 1)]);
+      pend.push(shifted);
+      if (pend.length > k) pend.shift();
+      return [shifted, state];
+    }
     const pit = new Array(k).fill(null);
     const z = new Array(k).fill(null);
     for (let m = 1; m <= k; m++) {

--- a/docs/js/skaters/transform.mjs
+++ b/docs/js/skaters/transform.mjs
@@ -113,15 +113,24 @@ export function standardize(alpha = 0.05, eps = 1e-8) {
   function forward(y, state) {
     if (state === null || state === undefined) return [0.0, { mu: y, var: 0.0 }];
     const mu = state.mu;
-    let varr = state.var;
+    const varr = state.var;
     const diff = y - mu;
-    // Center against the PRIOR mean (post-update centering shrinks the residual
-    // by (1-alpha) -> overconfident intervals); standard EWMA variance recursion.
-    const muNew = mu + alpha * diff;
-    varr = (1 - alpha) * varr + alpha * diff * diff;
-    const sigma = varr > eps * eps ? Math.sqrt(varr) : eps;
+    // Emit against the PRIOR state, so the forward map is the affine change
+    // of coordinates z = (y - mu) / sigma that the inverse applies. Scaling
+    // by the post-update std makes the emission self-normalized (bounded by
+    // 1/sqrt(alpha)) and the affine inverse is then not its inverse.
+    // Cold start: before the variance is informative, scale by the first
+    // nonzero residual, so the first informative emission is +-1.
+    let sigma;
+    if (varr > eps * eps) {
+      sigma = Math.sqrt(varr);
+    } else {
+      sigma = Math.abs(diff) > eps ? Math.abs(diff) : eps;
+    }
     const yPrime = diff / sigma;
-    return [yPrime, { mu: muNew, var: varr }];
+    const muNew = mu + alpha * diff;
+    const varNew = (1 - alpha) * varr + alpha * diff * diff;
+    return [yPrime, { mu: muNew, var: varNew }];
   }
   function inverseK(dists, state) {
     const varr = state.var;

--- a/parity/check.mjs
+++ b/parity/check.mjs
@@ -4,8 +4,9 @@
 // Exits non-zero if any scenario diverges beyond tolerance.
 
 import { readFileSync } from "fs";
-import { buildScenarios, buildRepeatScenarios } from "./scenarios.mjs";
+import { buildScenarios, buildRepeatScenarios, buildGapScenarios } from "./scenarios.mjs";
 import { periodDetector } from "../docs/js/skaters/periodicity.mjs";
+import { buildCandidates } from "../docs/js/skaters/api.mjs";
 import { runningCov, emaCov, ledoitWolfCov } from "../docs/js/skaters/cov.mjs";
 
 const ATOL = 1e-6;
@@ -105,6 +106,54 @@ function main() {
       }
       if (f > 0) { failures += f; console.error(`FAIL ${name}: ${f} mismatches`); }
       else console.log(`ok   ${name}`);
+    }
+  }
+
+  // Missing observations on the gap series. The series is transported with the
+  // same "nan" sentinel the outputs use, since JSON has no NaN literal.
+  if (vectors.gap_scenarios) {
+    const gaps = vectors.gap_series.map((v) => (v === "nan" ? NaN : decode(v)));
+    const gapScen = new Map(buildGapScenarios().map(([n, k, sk]) => [n, sk]));
+    for (const [name, expected] of Object.entries(vectors.gap_scenarios)) {
+      const sk = gapScen.get(name);
+      if (!sk) { missing.push(`gap:${name}`); continue; }
+      const got = runScenario(sk, gaps, burn, probe, qLo, qHi);
+      let f = 0;
+      for (let step = 0; step < expected.out.length; step++) {
+        for (let h = 0; h < expected.out[step].length; h++) {
+          for (let j = 0; j < 7; j++) {
+            checked++;
+            if (!close(got[step][h][j], expected.out[step][h][j])) {
+              f++;
+              if (f <= 3) console.error(`  MISMATCH gap:${name} step=${step + burn} h=${h} ${LABELS[j]}: js=${got[step][h][j]} py=${decode(expected.out[step][h][j])}`);
+            }
+          }
+        }
+      }
+      if (f > 0) { failures += f; console.error(`FAIL gap:${name}: ${f} mismatches`); }
+      else console.log(`ok   gap:${name}`);
+    }
+  }
+
+  // Structure: the candidate population itself, not its numbers. Numeric probes
+  // cannot see a port that is missing a candidate -- the R port ran 57 against
+  // Python's 60 while every individual transform still matched to 1e-6. The
+  // depth histogram also pins ORDER, since the ensemble aligns depths by index.
+  if (vectors.structure) {
+    for (const [kname, want] of Object.entries(vectors.structure)) {
+      const kk = Number(kname);
+      const [cands, depths] = buildCandidates(kk);
+      let bad = 0;
+      if (cands.length !== want.n_candidates) {
+        console.error(`FAIL structure k=${kk}: ${cands.length} candidates, want ${want.n_candidates}`);
+        bad++;
+      }
+      if (depths.length !== want.depths.length || depths.some((d, i) => d !== want.depths[i])) {
+        console.error(`FAIL structure k=${kk}: depth vector differs`);
+        bad++;
+      }
+      if (bad) failures += bad;
+      else console.log(`ok   structure k=${kk}   ${cands.length} candidates`);
     }
   }
 

--- a/parity/gen_vectors.py
+++ b/parity/gen_vectors.py
@@ -137,6 +137,27 @@ def make_repeat_series(n=150, seed=99):
     return out
 
 
+def make_gap_series(n=150, seed=4242):
+    """A stream with MISSING observations, to pin the missing-tick rule across
+    ports: a non-finite y never reaches the tree, the base state is not
+    advanced, and the fan is shifted so the forecast ages by one step.
+
+    Gaps cover all three branches: a leading gap (no prior forecast, so the
+    wide no-information predictive), isolated gaps, and a run longer than k
+    (so the h=k hold is reached). Encoded in JSON with the same "nan" sentinel
+    clean() uses for outputs, since JSON has no NaN literal.
+    """
+    random.seed(seed)
+    out = []
+    lvl = 0.0
+    for t in range(n):
+        lvl += random.gauss(0, 0.3)
+        out.append(lvl + 2.0 * math.sin(2 * math.pi * t / 7) + random.gauss(0, 1.0))
+    for i in (0, 12, 13, 41, 77, 78, 79, 80, 81, 121):
+        out[i] = float("nan")
+    return out
+
+
 def clean(x):
     # JS JSON.parse rejects Infinity/NaN; encode them as string sentinels.
     if x != x:
@@ -207,6 +228,33 @@ def main():
     vectors["repeat_scenarios"] = {
         name: {"k": k, "out": run_scenario(sk, rep)} for name, (k, sk) in rep_scen.items()
     }
+
+    # Missing observations: the parade's non-finite tick rule. Both k=1 (hold
+    # the previous predictive, there is no h+1 to age into) and k>1 (shift the
+    # fan) are covered.
+    gaps = make_gap_series()
+    vectors["gap_series"] = [clean(v) for v in gaps]
+    gap_scen = {
+        "pol_laplace": (1, laplace(k=1)),
+        "pol_laplace_k3": (3, laplace(k=3)),
+    }
+    vectors["gap_scenarios"] = {
+        name: {"k": k, "out": run_scenario(sk, gaps)} for name, (k, sk) in gap_scen.items()
+    }
+
+    # STRUCTURE: the candidate population itself, not its numbers. 105,798
+    # numeric probes cannot see a port that is missing a candidate -- the R port
+    # sat at 57 candidates against Python's 60 (no `seasonal_anchor`) and every
+    # individual transform still matched to 1e-6, so only the composed laplace
+    # drifted. Count and depth histogram are language-agnostic and decisive, and
+    # they also pin ORDER-sensitivity: the ensemble aligns depths and weights by
+    # candidate index, so a candidate inserted in the wrong place shows up here.
+    from skaters.api import _build_candidates
+    structure = {}
+    for kk in (1, 3):
+        cands, depths, _ = _build_candidates(kk)
+        structure[str(kk)] = {"n_candidates": len(cands), "depths": list(depths)}
+    vectors["structure"] = structure
 
     here = os.path.dirname(os.path.abspath(__file__))
     path = os.path.join(here, "vectors.json")

--- a/parity/scenarios.mjs
+++ b/parity/scenarios.mjs
@@ -80,3 +80,13 @@ export function buildRepeatScenarios() {
     ["sticky_ema", 1, sticky(conjugate(leaf(1), emaTransform(0.1), 1), 1)],
   ];
 }
+
+// Missing-observation scenarios run on the gap series: a non-finite tick must
+// not reach the tree, must not advance the base state, and must age the fan by
+// one horizon. k=1 holds the previous predictive; k=3 shifts.
+export function buildGapScenarios() {
+  return [
+    ["pol_laplace", 1, laplace(1)],
+    ["pol_laplace_k3", 3, laplace(3)],
+  ];
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skaters"
-version = "0.15.0"
+version = "0.16.0"
 description = "Fast univariate time series models that run in Pyodide"
 readme = "README.md"
 license = "MIT"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,8 +5,8 @@ members = ["python"]
 default-members = ["."]
 
 [package]
-name = "skaters-core"
-version = "0.1.0"
+name = "skaters"
+version = "0.16.0"
 edition = "2021"
 # MSRV. Conservative: the deps (pyo3 0.22 -> 1.63, serde_json 1 -> 1.56, edition
 # 2021 -> 1.56) all admit older toolchains, but only stable 1.96 is available in
@@ -15,6 +15,12 @@ edition = "2021"
 rust-version = "1.74"
 description = "Rust port of the skaters online distributional forecasting core, parity-gated against the Python reference."
 license = "MIT"
+repository = "https://github.com/microprediction/skaters"
+homepage = "https://skaters.microprediction.org"
+documentation = "https://docs.rs/skaters"
+readme = "README.md"
+keywords = ["forecasting", "time-series", "probabilistic", "online", "quantile"]
+categories = ["science", "mathematics"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,4 +1,4 @@
-# skaters-core
+# skaters
 
 Rust port of the [skaters](https://github.com/microprediction/skaters) online
 distributional forecasting core. Every forecaster is a struct with
@@ -44,7 +44,7 @@ bit-deterministic.
 ## Usage
 
 ```rust
-use skaters_core::laplace;
+use skaters::laplace;
 
 let mut f = laplace(1);
 for y in observations {

--- a/rust/python/Cargo.toml
+++ b/rust/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skaters-fast"
-version = "0.1.0"
+version = "0.16.0"
 edition = "2021"
 # pyo3 0.29 requires Rust 1.83. This binding is built by maturin on stable and
 # is not part of skaters-core's MSRV promise (the workspace default build stays
@@ -14,7 +14,7 @@ name = "skaters_fast"
 crate-type = ["cdylib"]
 
 [dependencies]
-skaters-core = { path = ".." }
+skaters = { version = "0.16", path = ".." }
 serde_json = { version = "1", features = ["float_roundtrip"] }
 
 [dependencies.pyo3]

--- a/rust/python/README.md
+++ b/rust/python/README.md
@@ -2,7 +2,7 @@
 
 An opt-in accelerated backend for [skaters](https://github.com/microprediction/skaters):
 a thin [PyO3](https://pyo3.rs) skin over the parity-gated Rust core
-(`skaters-core`).
+(`skaters`).
 
 The pure Python package is the reference implementation. This backend runs the
 identical model faster.

--- a/rust/python/src/lib.rs
+++ b/rust/python/src/lib.rs
@@ -1,6 +1,6 @@
 //! skaters-fast: an opt-in accelerated backend for skaters.
 //!
-//! This is a thin PyO3 skin over the `skaters-core` Rust crate. The pure
+//! This is a thin PyO3 skin over the `skaters` Rust crate. The pure
 //! Python package remains the reference implementation; this backend exists
 //! only to run the identical model faster.
 //!
@@ -17,8 +17,8 @@
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use skaters_core::api::{laplace as core_laplace, Forecaster};
-use skaters_core::tails::PDist;
+use skaters::api::{laplace as core_laplace, Forecaster};
+use skaters::tails::PDist;
 
 /// A single-horizon distributional prediction handle.
 ///

--- a/rust/src/bin/bench.rs
+++ b/rust/src/bin/bench.rs
@@ -2,7 +2,7 @@
 //! The input series is the parity vectors' embedded series, tiled — fully
 //! deterministic, no RNG dependency.
 
-use skaters_core::api::laplace;
+use skaters::api::laplace;
 use std::time::Instant;
 
 fn main() {

--- a/rust/src/parade.rs
+++ b/rust/src/parade.rs
@@ -8,6 +8,11 @@ use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 
 const EPS: f64 = 1e-12;
+/// A leading missing tick has no prior forecast to age and no observation has
+/// fixed the series' scale yet, so emit a deliberately wide zero-centred
+/// Gaussian rather than a confident guess. The tree is left untouched, so the
+/// first finite value initializes it exactly as a true first observation would.
+const NO_INFO_STD: f64 = 1e6;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ParadeBase {
@@ -31,6 +36,10 @@ pub struct Parade {
     pub pending: VecDeque<Vec<PDist>>,
     pub pit: Vec<Option<f64>>,
     pub z: Vec<Option<f64>>,
+    /// Count of missing (non-finite) ticks skipped. `serde(default)` so state
+    /// checkpointed before this field existed still deserializes.
+    #[serde(default)]
+    pub skipped: u64,
 }
 
 pub fn parade(base: ParadeBase, k: usize) -> Parade {
@@ -40,6 +49,7 @@ pub fn parade(base: ParadeBase, k: usize) -> Parade {
         pending: VecDeque::new(),
         pit: vec![None; k],
         z: vec![None; k],
+        skipped: 0,
     }
 }
 
@@ -47,6 +57,30 @@ impl Parade {
     pub fn step(&mut self, y: f64) -> Vec<PDist> {
         let k = self.k;
         let n = self.pending.len();
+        // Missing observation — port of the Python parade's missing-tick rule.
+        // A non-finite y must never reach the tree: an EWMA fed NaN is poisoned
+        // permanently and no later clean data recovers it. Treat the tick as
+        // "no observation": time advanced, information did not. Leave the base
+        // state untouched and SHIFT the fan, so the previous tick's horizon
+        // h+1 becomes this tick's horizon h and the forecast ages by one step.
+        // After k consecutive gaps h=k is held.
+        if !y.is_finite() {
+            self.skipped += 1;
+            self.pit = vec![None; k];
+            self.z = vec![None; k];
+            if n == 0 {
+                return vec![PDist::Mix(Dist::gaussian(0.0, NO_INFO_STD)); k];
+            }
+            let prev = &self.pending[n - 1];
+            let shifted: Vec<PDist> = (1..=k)
+                .map(|h| prev[h.min(prev.len() - 1)].clone())
+                .collect();
+            self.pending.push_back(shifted.clone());
+            while self.pending.len() > k {
+                self.pending.pop_front();
+            }
+            return shifted;
+        }
         let std_normal = Dist::gaussian(0.0, 1.0);
         let mut pit: Vec<Option<f64>> = vec![None; k];
         let mut z: Vec<Option<f64>> = vec![None; k];

--- a/rust/src/transform.rs
+++ b/rust/src/transform.rs
@@ -1060,7 +1060,14 @@ fn ar_spectral_radius(phi: &[f64]) -> f64 {
             let r = disc.sqrt();
             return ((a + r) / 2.0).abs().max(((a - r) / 2.0).abs());
         }
-        return (a / 2.0).hypot((-disc).sqrt() / 2.0);
+        // libm::hypot, not f64::hypot: the std method calls the platform's own
+        // libm (MSVC's differs from glibc's and Apple's) and is not guaranteed
+        // bit-identical, which broke the cross-platform digest on Windows while
+        // Linux, macOS and wasm agreed. Every other transcendental here already
+        // routes through the libm crate for exactly this reason. Python's
+        // math.hypot is also platform libm, so the 1e-6 parity tolerance covers
+        // the reference comparison; bit-identity is a Rust-to-Rust claim.
+        return libm::hypot(a / 2.0, (-disc).sqrt() / 2.0);
     }
     let mut v = vec![1.0_f64; p];
     let mut rho = 0.0;
@@ -1097,8 +1104,12 @@ fn ar_stationary(phi: &[f64]) -> Vec<f64> {
         return phi.to_vec();
     }
     let g = margin / rho;
+    // libm::pow, not f64::powi: powi lowers to the llvm.powi intrinsic, whose
+    // expansion is target dependent, so it is not bit-stable across platforms.
+    // pow also matches the reference more closely, since Python's `g ** (j + 1)`
+    // calls C pow rather than doing repeated multiplication.
     (0..phi.len())
-        .map(|j| phi[j] * g.powi((j + 1) as i32))
+        .map(|j| phi[j] * libm::pow(g, (j + 1) as f64))
         .collect()
 }
 

--- a/rust/src/transform.rs
+++ b/rust/src/transform.rs
@@ -210,16 +210,23 @@ impl Standardize {
         }
         let mu = self.mu;
         let diff = y - mu;
-        let mu_new = mu + self.alpha * diff;
-        let var = (1.0 - self.alpha) * self.var + self.alpha * diff * diff;
-        let sigma = if var > self.eps * self.eps {
-            var.sqrt()
+        // Emit against the PRIOR state, so the forward map is the affine change
+        // of coordinates z = (y - mu) / sigma that the inverse applies. Scaling
+        // by the post-update std makes the emission self-normalized (bounded by
+        // 1/sqrt(alpha)) and the affine inverse is then not its inverse.
+        // Cold start: before the variance is informative, scale by the first
+        // nonzero residual, so the first informative emission is +-1.
+        let sigma = if self.var > self.eps * self.eps {
+            self.var.sqrt()
+        } else if diff.abs() > self.eps {
+            diff.abs()
         } else {
             self.eps
         };
-        self.mu = mu_new;
-        self.var = var;
-        diff / sigma
+        let y_prime = diff / sigma;
+        self.mu = mu + self.alpha * diff;
+        self.var = (1.0 - self.alpha) * self.var + self.alpha * diff * diff;
+        y_prime
     }
 
     fn inverse_k(&self, dists: &[Dist]) -> Vec<Dist> {

--- a/rust/tests/parity.rs
+++ b/rust/tests/parity.rs
@@ -302,6 +302,32 @@ fn parity_vectors() {
         n_scenarios += 1;
     }
 
+    // Missing observations: the parade's non-finite tick rule (skip the update,
+    // age the fan). The series carries the same "nan" sentinel the outputs use,
+    // since JSON has no NaN literal.
+    if let Some(gap) = v["gap_scenarios"].as_object() {
+        let gap_series: Vec<f64> = v["gap_series"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(parse_val)
+            .collect();
+        for (full, sc) in gap {
+            let k = sc["k"].as_u64().unwrap() as usize;
+            let (base, kk) = scenario_name(full).unwrap_or((full.as_str(), k));
+            run_scenario(
+                &format!("gap:{full}"),
+                build(base, kk),
+                &gap_series,
+                burn,
+                &sc["out"],
+                &mut checked,
+                &mut failures,
+            );
+            n_scenarios += 1;
+        }
+    }
+
     // Covariance estimators on the fixed multivariate series (cov block).
     let vec_series: Vec<Vec<f64>> = v["vec_series"]
         .as_array()
@@ -397,6 +423,36 @@ fn parity_vectors() {
         }
         assert_eq!(oi, out.len(), "periodicity: scored-step count mismatch");
         n_scenarios += 1;
+    }
+
+    // Structure: the candidate population itself, not its numbers. Numeric
+    // probes cannot see a port missing a candidate -- the R port ran 57 against
+    // Python's 60 while every individual transform still matched to 1e-6. The
+    // depth vector also pins ORDER, since the ensemble aligns depths by index.
+    if let Some(structure) = v["structure"].as_object() {
+        for (kname, want) in structure {
+            let kk: usize = kname.parse().expect("structure key must be an integer k");
+            let (cands, depths) = skaters_core::api::build_candidates(kk);
+            let want_n = want["n_candidates"].as_u64().unwrap() as usize;
+            if cands.len() != want_n {
+                failures.push(format!(
+                    "structure k={kk}: {} candidates, want {want_n}",
+                    cands.len()
+                ));
+            }
+            let want_d: Vec<f64> = want["depths"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|x| x.as_f64().unwrap())
+                .collect();
+            if depths != want_d {
+                failures.push(format!("structure k={kk}: depth vector differs"));
+            }
+            if cands.len() == want_n && depths == want_d {
+                println!("ok   structure k={kk}   {} candidates", cands.len());
+            }
+        }
     }
 
     println!("parity: {n_scenarios} scenarios, {checked} values checked");

--- a/rust/tests/parity.rs
+++ b/rust/tests/parity.rs
@@ -17,17 +17,17 @@ fn digest_push(v: f64) {
     );
 }
 
-use skaters_core::api::{laplace, Forecaster};
-use skaters_core::cov::{EmaCov, LedoitWolfCov, RunningCov};
-use skaters_core::periodicity::PeriodDetector;
-use skaters_core::search::search;
-use skaters_core::spec;
-use skaters_core::leaf::{CrpsLeaf, GarchLeaf, Leaf, ScaleMixLeaf};
-use skaters_core::skater::{
+use skaters::api::{laplace, Forecaster};
+use skaters::cov::{EmaCov, LedoitWolfCov, RunningCov};
+use skaters::periodicity::PeriodDetector;
+use skaters::search::search;
+use skaters::spec;
+use skaters::leaf::{CrpsLeaf, GarchLeaf, Leaf, ScaleMixLeaf};
+use skaters::skater::{
     bayesian_ensemble, conjugate, ema, multiscale, precision_weighted_ensemble, sticky, Sk,
 };
-use skaters_core::tails::gpdtails;
-use skaters_core::transform::{
+use skaters::tails::gpdtails;
+use skaters::transform::{
     ar, ar_default, difference, drift, ema_transform, fractional_difference, garch_default,
     grouped_ar, holt_linear, ou_transform, power_transform, seasonal_difference, standardize,
     theta, yeo_johnson,
@@ -247,7 +247,22 @@ fn parity_vectors() {
             concat!(env!("CARGO_MANIFEST_DIR"), "/parity/vectors.json").to_string()
         }
     });
-    let raw = std::fs::read_to_string(&path).expect("vectors.json");
+    // The vectors are GENERATED, not shipped: they are absent from the
+    // published crate, so a consumer running `cargo test` has nothing to check
+    // against. Skip rather than fail -- this gate is meaningful only against a
+    // reference regenerated from the Python source of truth, and a stale or
+    // missing copy must never read as a pass or as a spurious failure.
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(_) => {
+            println!(
+                "SKIP parity: no vectors at {path}. Regenerate in the skaters repo with\n  \
+                 PYTHONPATH=src python parity/gen_vectors.py\n\
+                 or point SKATERS_VECTORS at a copy."
+            );
+            return;
+        }
+    };
     let v: Value = serde_json::from_str(&raw).unwrap();
     let series: Vec<f64> = v["series"]
         .as_array()
@@ -432,7 +447,7 @@ fn parity_vectors() {
     if let Some(structure) = v["structure"].as_object() {
         for (kname, want) in structure {
             let kk: usize = kname.parse().expect("structure key must be an integer k");
-            let (cands, depths) = skaters_core::api::build_candidates(kk);
+            let (cands, depths) = skaters::api::build_candidates(kk);
             let want_n = want["n_candidates"].as_u64().unwrap() as usize;
             if cands.len() != want_n {
                 failures.push(format!(

--- a/rust/tests/parity.rs
+++ b/rust/tests/parity.rs
@@ -9,10 +9,23 @@ static DIGEST: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0xcbf2_9ce4_8422_2325);
 
 /// Fold one computed value into the FNV-1a bit digest.
+///
+/// NaN is canonicalized first. IEEE-754 fixes the bits of zeros, normals and
+/// both infinities, but leaves a NaN's sign and payload unspecified, and
+/// platforms differ: x86 and aarch64 propagate different payloads, and wasm
+/// canonicalizes its own way. Probes can legitimately be NaN (gen_vectors.py has
+/// a "nan" sentinel for exactly that), so folding raw NaN bits made this digest
+/// report a platform divergence that is not one. Presence of a NaN is still
+/// recorded, since every NaN maps to one fixed pattern.
 fn digest_push(v: f64) {
+    let bits = if v.is_nan() {
+        0x7ff8_0000_0000_0000
+    } else {
+        v.to_bits()
+    };
     let cur = DIGEST.load(std::sync::atomic::Ordering::Relaxed);
     DIGEST.store(
-        (cur ^ v.to_bits()).wrapping_mul(0x0000_0100_0000_01b3),
+        (cur ^ bits).wrapping_mul(0x0000_0100_0000_01b3),
         std::sync::atomic::Ordering::Relaxed,
     );
 }

--- a/rust/tests/robustness.rs
+++ b/rust/tests/robustness.rs
@@ -4,8 +4,8 @@
 //! contracts a backend must keep: bitwise determinism and serde
 //! checkpoint-resume equivalence.
 
-use skaters_core::api::{laplace, Forecaster};
-use skaters_core::tails::PDist;
+use skaters::api::{laplace, Forecaster};
+use skaters::tails::PDist;
 
 // Deterministic LCG + Box-Muller-free gaussian via sum of uniforms is NOT
 // used; mirror adversarial.mjs exactly: LCG + Box-Muller with libm.
@@ -170,8 +170,8 @@ fn search_checkpoint_resume_bit_exact() {
     // The search state (pool of live Sk values plus recipes) is plain data:
     // checkpoint past an expansion (n_obs 100) and resume bit-exactly, with
     // the infinite cost budget surviving the JSON round trip.
-    use skaters_core::search::search;
-    use skaters_core::skater::Sk;
+    use skaters::search::search;
+    use skaters::skater::Sk;
     let mut r = Lcg(19);
     let ys: Vec<f64> = (0..300).map(|_| r.gauss()).collect();
     let mut straight = Sk::Search(Box::new(search(1)));

--- a/src/skaters/conventions.py
+++ b/src/skaters/conventions.py
@@ -15,6 +15,35 @@ Log-likelihood is dist.logpdf(y_actual).
 A skater is always a tree of transforms with a distributional leaf
 at the bottom. The leaf estimates the residual distribution; the
 transforms propagate it back to the original space.
+
+Missing observations
+--------------------
+A non-finite ``y`` (NaN or infinity) means "no observation this tick", not a
+value and not an error. Streams gap, and a forecaster deployed in a browser or
+a streaming sidecar must not crash or corrupt itself when they do.
+
+The tick advances time but carries no information, so:
+
+  * the value never reaches the tree, and the fitted state is not advanced
+    (an EWMA fed NaN is poisoned permanently: mu + alpha*(nan - mu) = nan,
+    and no amount of clean data afterwards recovers it);
+  * the forecast AGES by one horizon — the previous tick's h+1 predictive is
+    returned as this tick's h — so what you get is the predictive that
+    genuinely targets the point being forecast. After k consecutive gaps the
+    longest available horizon (h=k) is held;
+  * ``state["pit"]`` and ``state["z"]`` are all ``None``, since nothing was
+    resolved. Anomaly detection reads these, so a gap must not look like a
+    residual of zero;
+  * ``state["skipped"]`` counts them, so gaps are auditable rather than
+    invisible;
+  * a gap before any observation has no forecast to age and no scale
+    information, so it emits a wide zero-centred Gaussian and leaves the tree
+    untouched. The first finite value then initializes it exactly as a true
+    first observation would.
+
+Callers who prefer to fail loudly on missing data should check finiteness
+before calling. The reverse is not available: nothing can recover a state that
+has already been silently corrupted.
 """
 
 from __future__ import annotations

--- a/src/skaters/parade.py
+++ b/src/skaters/parade.py
@@ -29,6 +29,19 @@ _STD_NORMAL = Dist.gaussian(0.0, 1.0)
 # quantile at 1e-12, about 7.03, and the bisection in Dist.quantile stays
 # inside its +-8 sigma bracket. No input can produce an infinite z.
 _EPS = 1e-12
+# A leading missing tick has no prior forecast to age and no observation has
+# fixed the series' scale yet, so emit a deliberately wide zero-centred
+# Gaussian rather than a confident guess. The tree is left untouched, so the
+# first finite value initializes it exactly as a true first observation would.
+_NO_INFO_STD = 1e6
+
+
+def _missing(y) -> bool:
+    """True for a tick carrying no observation (NaN, inf, or non-numeric)."""
+    try:
+        return not math.isfinite(y)
+    except (TypeError, ValueError):
+        return True
 
 
 def parade(base, k: int):
@@ -37,9 +50,34 @@ def parade(base, k: int):
     def _skater(y: float, state: dict | None) -> tuple[list[Dist], dict]:
         if state is None:
             state = {"base": None, "pending": deque(maxlen=k),
-                     "pit": [None] * k, "z": [None] * k}
+                     "pit": [None] * k, "z": [None] * k, "skipped": 0}
         pend = state["pending"]
         n = len(pend)
+        # Missing observation. A non-finite y must never reach the tree: an EWMA
+        # fed NaN is poisoned permanently (mu + alpha*(nan - mu) = nan) and no
+        # amount of clean data afterwards recovers it — measured as
+        # mean=nan/std=0.0 forever at k=1, and an opaque `assert w_total > 0`
+        # inside Dist at k>1. So treat the tick as "no observation": time
+        # advanced, information did not. The base state is left exactly as it
+        # was and the fan is SHIFTED — the previous tick's horizon h+1 is this
+        # tick's horizon h — so the forecast AGES by one step instead of
+        # relabelling a stale h+1 predictive as h. Ageing is not the same as
+        # widening: on a periodic series the h=k predictive is legitimately
+        # sharper than h=1, and the shift keeps whichever predictive genuinely
+        # targets the stream position being forecast. It also keeps the
+        # parade's own bookkeeping aligned, so the next finite y is resolved
+        # against the predictive that actually aimed at it. After k consecutive
+        # gaps the longest available horizon (h=k) is held.
+        if _missing(y):
+            state["skipped"] = state.get("skipped", 0) + 1
+            state["pit"] = [None] * k
+            state["z"] = [None] * k
+            if not n:
+                return [Dist.gaussian(0.0, _NO_INFO_STD) for _ in range(k)], state
+            prev = pend[-1]
+            shifted = [prev[min(h, len(prev) - 1)] for h in range(1, k + 1)]
+            pend.append(shifted)
+            return shifted, state
         pit = [None] * k
         z = [None] * k
         for m in range(1, k + 1):

--- a/tests/test_missing_observations.py
+++ b/tests/test_missing_observations.py
@@ -1,0 +1,112 @@
+"""The missing-observation contract: a non-finite tick carries no information.
+
+Before this rule, a single NaN was unrecoverable. At k=1 laplace returned
+mean=nan, std=0.0 and stayed there through any amount of clean data (an EWMA
+fed NaN is poisoned permanently, since mu + alpha*(nan - mu) = nan). At k>1 it
+tripped a bare ``assert w_total > 0`` deep inside ``Dist``. Which failure you
+got depended on the horizon.
+
+The rule: time advanced, information did not. The tree never sees the value,
+the base state is not advanced, and the fan is shifted so the forecast ages by
+one horizon. The JS twin and the Rust port are held to the same behavior
+through the gap scenario in parity/gen_vectors.py.
+"""
+import math
+
+import pytest
+
+from skaters.api import laplace
+
+NAN = float("nan")
+CLEAN = [1.0, 2.0, 1.5, 3.0, 2.0] * 12
+
+
+def _run(f, ys, state=None):
+    dists = None
+    for y in ys:
+        dists, state = f(y, state)
+    return dists, state
+
+
+@pytest.mark.parametrize("k", [1, 2, 3, 8])
+def test_missing_tick_leaves_the_forecast_usable(k):
+    f = laplace(k)
+    dists, state = _run(f, CLEAN)
+    dists, state = f(NAN, state)
+    assert len(dists) == k
+    for h, d in enumerate(dists, 1):
+        assert math.isfinite(d.mean), f"k={k} h={h}: mean not finite after a gap"
+        assert d.std > 0.0 and math.isfinite(d.std), f"k={k} h={h}: std={d.std}"
+        assert math.isfinite(d.logpdf(2.0))
+    assert state["skipped"] == 1
+
+
+@pytest.mark.parametrize("bad", [NAN, float("inf"), float("-inf")])
+def test_state_is_not_poisoned_and_clean_data_still_moves_it(bad):
+    """The decisive property: the model must be as good after a gap as before,
+    and must keep learning. Previously mean went nan and never came back."""
+    f = laplace(1)
+    before, state = _run(f, CLEAN)
+    after_gap, state = f(bad, state)
+    assert after_gap[0].mean == pytest.approx(before[0].mean)
+    assert after_gap[0].std == pytest.approx(before[0].std)
+    recovered, state = _run(f, [2.0] * 10, state)
+    assert math.isfinite(recovered[0].mean)
+    assert recovered[0].std > 0.0
+    assert state["skipped"] == 1
+
+
+def test_gap_run_ages_the_fan_then_holds_the_longest_horizon():
+    """Each gap shifts horizon h+1 into h. After k gaps the h=k predictive is
+    held, so the forecast stops changing rather than degenerating."""
+    k = 4
+    f = laplace(k)
+    pre, state = _run(f, CLEAN)
+    pre_fan = [(d.mean, d.std) for d in pre]
+    seq = []
+    for _ in range(k + 3):
+        dists, state = f(NAN, state)
+        seq.append((dists[0].mean, dists[0].std))
+    # Gap g puts the pre-gap horizon g+1 at h=1, until h=k runs out.
+    assert seq[0] == pytest.approx(pre_fan[1]), "first gap: h=1 becomes pre-gap h=2"
+    assert seq[1] == pytest.approx(pre_fan[2]), "second gap: h=1 becomes pre-gap h=3"
+    assert seq[2] == pytest.approx(pre_fan[3]), "third gap: h=1 becomes pre-gap h=4"
+    for later in seq[3:]:
+        assert later == pytest.approx(pre_fan[k - 1]), (
+            f"past k-1 gaps the longest horizon should be held, got {later}")
+    for m, s in seq:
+        assert math.isfinite(m) and s > 0.0
+
+
+def test_leading_gap_is_ignored_and_next_value_initializes_normally():
+    """A gap before any observation has no forecast to age and no scale
+    information, so it emits a deliberately wide predictive and leaves the tree
+    untouched: the first finite value must behave exactly like a first call."""
+    fresh, _ = laplace(2)(5.0, None)
+    f = laplace(2)
+    wide, state = f(NAN, None)
+    assert wide[0].mean == 0.0
+    assert wide[0].std >= 1e5, "a leading gap must not imply a confident scale"
+    assert state["skipped"] == 1
+    after, _ = f(5.0, state)
+    assert after[0].mean == pytest.approx(fresh[0].mean)
+    assert after[0].std == pytest.approx(fresh[0].std)
+
+
+def test_pit_and_z_report_no_resolution_for_a_missing_tick():
+    """The calibration diagnostics must not invent a residual for a value that
+    was never observed; anomaly detection reads these."""
+    f = laplace(3)
+    _, state = _run(f, CLEAN)
+    _, state = f(NAN, state)
+    assert state["pit"] == [None, None, None]
+    assert state["z"] == [None, None, None]
+
+
+def test_all_missing_stream_never_crashes():
+    f = laplace(3)
+    state = None
+    for _ in range(50):
+        dists, state = f(NAN, state)
+    assert state["skipped"] == 50
+    assert all(d.std > 0.0 for d in dists)

--- a/tests/test_standardize_no_cap.py
+++ b/tests/test_standardize_no_cap.py
@@ -1,0 +1,49 @@
+"""Pin the ``standardize`` emission contract, which shipped broken until #169.
+
+``standardize`` must emit against the PRIOR variance. Dividing by the
+post-update EWMA std makes the emission self-normalized: with
+var_new = (1-a) var + a d^2, the emitted z = d / sqrt(var_new) is bounded by
+1/sqrt(alpha) for ANY input, so a million-sigma move is indistinguishable from
+a five-sigma one and the affine inverse is not the forward map's inverse. The
+bound is ~4.47 at the default alpha=0.05.
+
+The fix landed in Python only; the JS twin and the Rust port kept the capped
+version for six days (CI red from 1f70895 to fc475d6) because the parity suite
+compares against vectors regenerated from Python and nobody read the failure.
+These assertions are cheap and language-independent in spirit -- the ports are
+held to them through parity/gen_vectors.py.
+"""
+import math
+
+from skaters.transform import standardize
+
+
+def test_standardize_emits_beyond_the_self_normalized_bound():
+    alpha = 0.05
+    forward, _ = standardize(alpha)
+    bound = 1.0 / math.sqrt(alpha)          # 4.4721: the old code's hard ceiling
+    z, _ = forward(1000.0, {"mu": 0.0, "var": 1.0})
+    assert z == 1000.0, f"a 1000-sigma move must emit z=1000, got {z}"
+    assert z > bound
+
+
+def test_standardize_forward_matches_the_inverse_it_is_paired_with():
+    """inverse_k must undo forward: the sigma it applies has to be the one the
+    next forward call divides by, which is only true for the prior state."""
+    forward, inverse_k = standardize(0.05)
+    state = {"mu": 0.3, "var": 4.0}
+    y = 7.5
+    z, _ = forward(y, dict(state))
+    from skaters.dist import Dist
+    back = inverse_k([Dist.gaussian(z, 1e-9)], state)[0].mean
+    assert abs(back - y) < 1e-6, f"inverse did not recover y: {back} vs {y}"
+
+
+def test_standardize_cold_start_first_informative_emission_is_unit():
+    """With var still uninformative, scale by the first nonzero residual so the
+    emission is +-1 rather than diff/eps (which was ~1e8 and swamped the leaf)."""
+    forward, _ = standardize(0.05)
+    z, state = forward(5.0, {"mu": 3.0, "var": 0.0})
+    assert z == 1.0, f"first informative emission must be +1, got {z}"
+    z2, _ = forward(1.0, {"mu": 3.0, "var": 0.0})
+    assert z2 == -1.0, f"downward first emission must be -1, got {z2}"


### PR DESCRIPTION
## Why

`standardize` divided the residual by the **post-update** EWMA variance, making the emission self-normalized:

```
z = d / sqrt((1-a)v + a d^2)   =>   |z| < 1/sqrt(alpha) = 4.4721
```

No input could produce a residual past 4.4721. Measured on the old code, `y=100`, `y=1000` and `y=1e6` all emitted exactly **4.4721**, so a million-sigma move was indistinguishable from a hundred-sigma one. The affine inverse was also not the forward map's inverse, since the forward scale depended on the value being predicted: round-tripping `y=7.5` recovered **5.996**.

The Python repair landed in #169 on 2026-08-04, **after** the v0.15.0 tag (2026-08-02), so no release ever carried it — and the JS twin, Rust port, R package (published on r-universe) and Julia package never received it at all. CI has been red since #169.

## What changed

**Residual cap removed in every port.** Emission is now against the prior variance; cold start scales by the first nonzero residual so the first informative emission is ±1. This moves every predictive slightly, in both directions on aggregate point metrics — tail and coverage results are the ones the cap actually distorted.

**Missing observations are defined.** A non-finite `y` was previously horizon-dependent corruption: at `k=1` laplace returned `mean=nan, std=0.0` and never recovered (an EWMA fed NaN is poisoned permanently), at `k>1` it tripped a bare `assert w_total > 0` inside `Dist`. It is now a skipped tick — the value never reaches the tree, state is not advanced, and the fan shifts so the previous tick's `h+1` becomes this tick's `h`, ageing the forecast by one step. `pit`/`z` go all-`None` so a gap cannot look like a zero residual to the anomaly layer; `state["skipped"]` counts them.

**R and Julia were four features behind**, not one (fixes ship in their own repos): `garch` lacked mean tracking with a pure-scale rather than affine inverse; `_ar_spectral_radius`/`_ar_stationary` were absent entirely; `ar`/`grouped_ar` accumulated multi-step variance as `sum phi_j^2 var_{h-j}` instead of `sigma^2 sum psi_i^2`; and `seasonal_anchor` was missing, leaving the pool at 57 candidates against Python's 60.

## The gate was lying, in two ways

**`ok` was printed for failing scenarios.** The R and Julia scripts printed `ok <name>` per scenario unconditionally, with the failure budget capped at 7 lines *globally*. A port four features behind displayed 59 `ok` lines and one failure. Budget is now per scenario and the summary reflects the tally.

**Nothing checked the component inventory.** 105,798 numeric probes could not see three missing candidates, because every individual transform matched to 1e-6 and only the composed `laplace` drifted. `vectors.json` now carries a `structure` block — candidate count plus the full depth vector per k — asserted in all four ports. The depth vector also pins ordering, since the ensemble aligns weights by candidate index. Verified to bite: removing the candidates again yields `FAIL structure k=1: 57 candidates, want 60` and `depth vector differs (got 1/20/36 want 1/23/36)`.

Also worth knowing: `parity/vectors.json` is generated and untracked, so a stale local copy reports `PARITY OK` against a reference that no longer exists. The pytest wrapper regenerates first; a bare `node parity/check.mjs` does not.

## Verification

| port | result |
|---|---|
| Python | 1,227 tests pass |
| JavaScript | 109,578 parity values, structure check green |
| Rust | 109,578 parity values + robustness, structure check green |
| R | 105,798 parity values, plus contract and robustness |
| Julia | 105,798 parity values, plus contract and robustness |

New regression tests are verified to fail against the pre-fix sources, not merely to pass against the current ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)