### PR TITLE
Performance page: measured cost against 8 models, one nav source

### DIFF
--- a/benchmarks/foundation_pages.py
+++ b/benchmarks/foundation_pages.py
@@ -159,40 +159,12 @@ MODELS = {
                            "through granite-tsfm."),
 }
 
-NAV = """      <nav>
-        <a href="/">Home</a>
-        <a href="/guide.html">Methodology</a>
-        <span class="menu" tabindex="0"><span class="menu-label">Usage &#9662;</span>
-          <span class="drop">
-            <a href="/challengers.html">Standalone</a>
-            <a href="/sandwich.html">Sandwich pattern</a>
-            <a href="/sidecar.html">Sidecar pattern</a>
-          </span>
-        </span>
-        <span class="menu" tabindex="0"><span class="menu-label">Foundational &#9662;</span>
-          <span class="drop">
-            <a href="/foundation/chronos.html">Chronos</a>
-            <a href="/foundation/tirex.html">TiRex</a>
-            <a href="/foundation/timesfm.html">TimesFM</a>
-            <a href="/foundation/sundial.html">Sundial</a>
-            <a href="/foundation/flowstate.html">FlowState</a>
-          </span>
-        </span>
-        <a href="/demos/">Demos</a>
-        <a href="/papers.html">Papers</a>
-        <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
-          <span class="drop">
-            <a href="/guide.html">Methodology</a>
-            <a href="/draws.html">Draws</a>
-            <a href="/scope.html">Scope</a>
-            <a href="/languages.html">Languages</a>
-            <a href="/heritage.html">Heritage</a>
-            <a href="/faq.html">FAQ</a>
-            <a href="/skills.html">Skills</a>
-          </span>
-        </span>
-        <a href="https://github.com/microprediction/skaters">GitHub</a>
-      </nav>"""
+# NAV comes from docs/sweep_nav.py, the single source of truth. This file used
+# to hold its own copy and rewrite only the inner <nav>, which is how the site
+# ended up serving three different menus simultaneously.
+import sys as _sys
+_sys.path.insert(0, os.path.join(ROOT, "docs"))
+from sweep_nav import NAV                      # noqa: E402
 
 
 def load_vs():

--- a/benchmarks/perf_compare.py
+++ b/benchmarks/perf_compare.py
@@ -1,0 +1,394 @@
+"""Cost comparison: laplace against the foundation models, and the site page.
+
+Accuracy studies live in the results store; this is the RUNTIME axis they do not
+record. A distributional forecaster is only interesting at a stated cost, so the
+numbers here are meant to be published alongside the accuracy tables rather than
+quoted from memory.
+
+Two regimes are reported, because they disagree and a single number hides the
+argument:
+
+  COLD  one forecast for a series never seen before, given L history points.
+        This is the benchmark protocol. Foundation models BATCH here and that is
+        decisive: chronos falls ~10x per series from batch 1 to batch 64, so
+        quoting unbatched inference flatters laplace. laplace has to consume the
+        L history points to warm up, so it is at its WORST in this regime.
+
+  WARM  one new observation arrives on a series already being tracked; emit an
+        updated forecast. laplace is ONLINE: one state update, independent of
+        history length. A foundation model carries no state, so it must re-run
+        the whole forward pass over a shifted window. This is where the gap is
+        large, and it is the regime a live deployment actually runs in.
+
+Both the Rust core (skaters_fast) and the pure-Python reference are timed, since
+they differ by ~18x and a published ratio has to say which one it means.
+
+    PYTHONPATH=src:benchmarks .venv-gifteval/bin/python benchmarks/perf_compare.py
+    ... writes benchmarks/perf_results.json and docs/performance.html
+"""
+from __future__ import annotations
+import os
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+import json
+import logging
+import platform
+import statistics as st
+import subprocess
+import time
+import warnings
+
+import numpy as np
+
+warnings.filterwarnings("ignore")
+logging.disable(logging.WARNING)
+import torch                                                    # noqa: E402
+
+THREADS = int(os.environ.get("TORCH_THREADS", "1"))
+torch.set_num_threads(THREADS)
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+L = int(os.environ.get("PERF_L", "256"))
+H = int(os.environ.get("PERF_H", "12"))
+NSER = int(os.environ.get("PERF_N", "64"))
+LEV = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+BATCHES = (1, 16, 64)
+
+_rng = np.random.default_rng(0)
+CTX = [np.cumsum(_rng.standard_normal(L)).astype(np.float32) for _ in range(NSER)]
+
+
+def med(fn, reps=3):
+    return st.median([(lambda t0: (fn(), time.perf_counter() - t0)[1])(time.perf_counter())
+                      for _ in range(reps)])
+
+
+def stamp():
+    ver = "unknown"
+    with open(os.path.join(ROOT, "pyproject.toml")) as fh:
+        for line in fh:
+            if line.startswith("version = "):
+                ver = line.split('"')[1]
+                break
+    try:
+        sha = subprocess.run(["git", "-C", ROOT, "rev-parse", "--short", "HEAD"],
+                             capture_output=True, text=True, timeout=10).stdout.strip()
+    except Exception:                                            # noqa: BLE001
+        sha = "nogit"
+    return {"version": ver, "commit": sha, "python": platform.python_version(),
+            "machine": f"{platform.system()} {platform.machine()}",
+            "torch_threads": THREADS, "context": L, "horizon": H, "series": NSER,
+            "date": time.strftime("%Y-%m-%d")}
+
+
+def measure():
+    rows = []
+
+    def add(model, regime, ms, note):
+        rows.append({"model": model, "regime": regime, "ms": ms, "note": note})
+
+    import skaters_fast
+    from skaters.api import laplace as py_laplace
+
+    for k in (1, H):
+        def cold(k=k):
+            for c in CTX:
+                g = skaters_fast.laplace(k)
+                for y in c:
+                    g.step(float(y))
+        add(f"laplace (Rust) k={k}", "cold", med(cold) / NSER * 1000, f"replays {L} points")
+        f = skaters_fast.laplace(k)
+        for y in CTX[0]:
+            f.step(float(y))
+
+        def warm(f=f):
+            for _ in range(500):
+                f.step(1.0)
+        add(f"laplace (Rust) k={k}", "warm", med(warm) / 500 * 1000, "one online update")
+
+    def cold_py():
+        for c in CTX[:8]:
+            s = None
+            g = py_laplace(1)
+            for y in c:
+                _, s = g(float(y), s)
+    add("laplace (Python) k=1", "cold", med(cold_py) / 8 * 1000, f"replays {L} points")
+
+    s = None
+    g = py_laplace(1)
+    for y in CTX[0]:
+        _, s = g(float(y), s)
+
+    def warm_py(g=g, s=s):
+        st_ = s
+        for _ in range(300):
+            _, st_ = g(1.0, st_)
+    add("laplace (Python) k=1", "warm", med(warm_py) / 300 * 1000, "one online update")
+
+    def fm(name, call, params):
+        try:
+            call(CTX[:2])
+        except Exception as e:                                   # noqa: BLE001
+            add(name, "cold", float("nan"),
+                f"unavailable: {type(e).__name__}: {str(e)[:70]}")
+            return
+        for bs in BATCHES:
+            def run(bs=bs):
+                for i in range(0, NSER, bs):
+                    call(CTX[i:i + bs])
+            add(name, f"cold b={bs}", med(run) / NSER * 1000, f"{params}, batched")
+        add(name, "warm", med(lambda: call(CTX[:1]), reps=5) * 1000,
+            "stateless: full re-forward")
+
+    try:
+        from chronos import BaseChronosPipeline
+        pipe = BaseChronosPipeline.from_pretrained("amazon/chronos-bolt-small",
+                                                   device_map="cpu",
+                                                   torch_dtype=torch.float32)
+
+        def c_chronos(cs):
+            with torch.no_grad():
+                pipe.predict_quantiles(inputs=[torch.tensor(c) for c in cs],
+                                       prediction_length=H, quantile_levels=LEV)
+        fm("Chronos-Bolt-small", c_chronos, "48M params")
+    except Exception as e:                                       # noqa: BLE001
+        add("Chronos-Bolt-small", "cold", float("nan"), f"load failed: {type(e).__name__}")
+
+    try:
+        from tirex import load_model
+        tx = load_model("NX-AI/TiRex", device="cpu", backend="torch")
+
+        def c_tirex(cs):
+            tx.forecast(context=torch.tensor(np.stack(cs)), prediction_length=H,
+                        output_type="numpy")
+        fm("TiRex", c_tirex, "35M params, xLSTM")
+    except Exception as e:                                       # noqa: BLE001
+        add("TiRex", "cold", float("nan"), f"load failed: {type(e).__name__}")
+
+    try:
+        from transformers import AutoModelForCausalLM
+        sd = AutoModelForCausalLM.from_pretrained("thuml/sundial-base-128m",
+                                                  trust_remote_code=True).eval()
+
+        def c_sundial(cs):
+            with torch.no_grad():
+                sd.generate(torch.tensor(np.stack(cs), dtype=torch.float32),
+                            num_samples=30, max_new_tokens=H)
+        fm("Sundial-base-128m", c_sundial, "128M params, 30 sample paths")
+    except Exception as e:                                       # noqa: BLE001
+        add("Sundial-base-128m", "cold", float("nan"), f"load failed: {type(e).__name__}")
+
+    try:
+        # Convention copied from foundation_study.timesfm_dists: the 2.5 torch
+        # class plus an explicit compile(), not the older TimesFm(hparams=...)
+        # constructor, which does not exist in this version.
+        import timesfm as _tfm
+        M = _tfm.TimesFM_2p5_200M_torch
+        tfm = M.from_pretrained(M.DEFAULT_REPO_ID)
+        tfm.compile(_tfm.ForecastConfig(max_context=L, max_horizon=H,
+                                        normalize_inputs=True,
+                                        use_continuous_quantile_head=True,
+                                        per_core_batch_size=64))
+
+        def c_timesfm(cs):
+            tfm.forecast(horizon=H, inputs=[c.astype(np.float32) for c in cs])
+        fm("TimesFM-2.5-200M", c_timesfm, "200M params")
+    except Exception as e:                                       # noqa: BLE001
+        add("TimesFM-2.5-200M", "cold", float("nan"), f"load failed: {type(e).__name__}")
+
+    # ---- classical models that REFIT. This is the honest upper end of the cost
+    # range and the sharpest contrast to an online update: a refitting model pays
+    # its whole fit again for every new observation, so its warm cost IS its cold
+    # cost. Batching does not exist for them, hence one column.
+    try:
+        from statsforecast.models import AutoARIMA
+        def one_arima(c):
+            m = AutoARIMA(season_length=1)
+            m.fit(np.asarray(c, dtype=np.float64))
+            m.predict(h=H)
+        one_arima(CTX[0][:128])                                  # warm up numba/JIT
+        t = med(lambda: one_arima(CTX[0]), reps=3) * 1000
+        add("AutoARIMA (refit)", "cold", t, f"fit on {L} points")
+        add("AutoARIMA (refit)", "warm", t, "refits from scratch every step")
+    except Exception as e:                                       # noqa: BLE001
+        add("AutoARIMA (refit)", "cold", float("nan"), f"unavailable: {type(e).__name__}")
+
+    try:
+        from statsforecast.models import AutoETS
+        def one_ets(c):
+            m = AutoETS(season_length=1)
+            m.fit(np.asarray(c, dtype=np.float64))
+            m.predict(h=H)
+        one_ets(CTX[0][:128])
+        t = med(lambda: one_ets(CTX[0]), reps=3) * 1000
+        add("AutoETS (refit)", "cold", t, f"fit on {L} points")
+        add("AutoETS (refit)", "warm", t, "refits from scratch every step")
+    except Exception as e:                                       # noqa: BLE001
+        add("AutoETS (refit)", "cold", float("nan"), f"unavailable: {type(e).__name__}")
+
+    try:
+        import pandas as pd
+        from prophet import Prophet
+        logging.getLogger("cmdstanpy").setLevel(logging.ERROR)
+        def one_prophet(c):
+            df = pd.DataFrame({"ds": pd.date_range("2000-01-01", periods=len(c), freq="D"),
+                               "y": np.asarray(c, dtype=float)})
+            m = Prophet(uncertainty_samples=0)
+            m.fit(df)
+            m.predict(m.make_future_dataframe(periods=H, freq="D").iloc[-H:])
+        one_prophet(CTX[0][:64])
+        t = med(lambda: one_prophet(CTX[0]), reps=2) * 1000
+        add("Prophet (refit)", "cold", t, f"fit on {L} points")
+        add("Prophet (refit)", "warm", t, "refits from scratch every step")
+    except Exception as e:                                       # noqa: BLE001
+        add("Prophet (refit)", "cold", float("nan"), f"unavailable: {type(e).__name__}")
+
+    return rows
+
+
+def render(rows, meta):
+    import sys
+    sys.path.insert(0, os.path.join(ROOT, "docs"))
+    from sweep_nav import CANONICAL                              # one nav source of truth
+
+    warm = {r["model"]: r["ms"] for r in rows if r["regime"] == "warm"}
+    base = warm.get("laplace (Rust) k=1")
+    best_cold = {}
+    for r in rows:
+        if r["regime"].startswith("cold"):
+            m = r["model"]
+            if r["ms"] == r["ms"] and (m not in best_cold or r["ms"] < best_cold[m][0]):
+                best_cold[m] = (r["ms"], r["regime"])
+
+    def tr(r):
+        ms = "n/a" if r["ms"] != r["ms"] else f"{r['ms']:.4f}"
+        return (f"      <tr><td>{r['model']}</td><td>{r['regime']}</td>"
+                f"<td class=num>{ms}</td><td class=note>{r['note']}</td></tr>")
+
+    ratio_rows = "\n".join(
+        f"      <tr><td>{m}</td><td class=num>{v:.4f}</td>"
+        f"<td class=num>{v / base:,.0f}&times;</td></tr>"
+        for m, v in sorted(warm.items(), key=lambda kv: kv[1]) if v == v and m != "laplace (Rust) k=1")
+    cold_rows = "\n".join(
+        f"      <tr><td>{m}</td><td class=num>{v[0]:.4f}</td><td class=note>{v[1]}</td></tr>"
+        for m, v in sorted(best_cold.items(), key=lambda kv: kv[1][0]))
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>skaters &mdash; performance</title>
+  <meta name="description" content="Measured cost of laplace against foundation models, in both the batch-benchmark regime and the streaming regime a deployment actually runs in." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters &mdash; performance" />
+  <meta property="og:description" content="Measured cost of laplace against foundation models, batch and streaming." />
+  <meta property="og:url" content="https://skaters.microprediction.org/performance.html" />
+  <meta name="twitter:card" content="summary" />
+  <link rel="stylesheet" href="./academic.css" />
+  <style>
+    .lede {{ color: #555; margin: 0 0 28px; font-size: 1.05em; }}
+    table.perf {{ border-collapse: collapse; margin: 0 0 26px; width: 100%; }}
+    table.perf th, table.perf td {{ border-bottom: 1px solid #e3e3e3; padding: 6px 10px;
+      text-align: left; font-size: 0.95em; }}
+    table.perf th {{ border-bottom: 2px solid #bbb; font-weight: 600; }}
+    td.num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+    td.note {{ color: #777; font-size: 0.88em; }}
+    .caveats li {{ margin-bottom: 7px; }}
+    .stamp {{ color: #888; font-size: 0.88em; font-style: italic; }}
+  </style>
+</head>
+<body>
+{CANONICAL}
+
+  <main>
+    <h1>Performance</h1>
+    <p class="lede">What a forecast costs. Accuracy comparisons live on the
+      <a href="/benchmarks.html">benchmarks page</a>; this is the runtime axis, measured
+      on one machine with every model given the same core budget. There are two regimes
+      and they disagree, so both are reported.</p>
+
+    <h2>Streaming: one new observation arrives</h2>
+    <p><code>laplace</code> is online. A new observation costs a single state update
+      whose cost does not depend on how much history preceded it. A foundation model
+      carries no state, so it re-runs its whole forward pass over a shifted window
+      every time. This is the regime a live deployment runs in.</p>
+    <table class="perf">
+      <tr><th>model</th><th>ms per observation</th><th>vs laplace (Rust) k=1</th></tr>
+{ratio_rows}
+    </table>
+
+    <h2>Batch: one forecast for a series never seen before</h2>
+    <p>This is the benchmark protocol, and it is <em>laplace at its worst</em>: it must
+      consume the whole history to warm up, while a foundation model amortises a batched
+      forward pass across many series. Best batch size shown per model.</p>
+    <table class="perf">
+      <tr><th>model</th><th>ms per series</th><th>regime</th></tr>
+{cold_rows}
+    </table>
+
+    <h2>Every measurement</h2>
+    <table class="perf">
+      <tr><th>model</th><th>regime</th><th>ms</th><th>note</th></tr>
+{chr(10).join(tr(r) for r in rows)}
+    </table>
+
+    <h2>Caveats</h2>
+    <ul class="caveats">
+      <li><strong>CPU only, {meta['torch_threads']} torch thread.</strong> A GPU changes the
+        foundation-model numbers substantially and does not change laplace's.</li>
+      <li><strong>The two regimes disagree, and neither is wrong.</strong> Batched, a
+        foundation model can be cheaper per series than laplace replaying a history.
+        Streaming, laplace is orders of magnitude cheaper. Which number applies depends
+        entirely on whether you are scoring a benchmark or running a service.</li>
+      <li><strong>Rust and Python differ by roughly 18&times;.</strong> Ratios here are
+        against the Rust core (<code>skaters_fast</code>), which is what ships; the
+        pure-Python reference is correspondingly slower.</li>
+      <li><strong>Horizon costs laplace.</strong> Going from k=1 to k={H} costs it roughly
+        an order of magnitude, because the multi-scale ensemble runs a full candidate pool
+        per decimation stride per horizon.</li>
+      <li><strong>Not size-ordered.</strong> The models differ in parameter count and in
+        output mechanism (quantile heads versus sampled paths), so this ranks
+        implementations as configured, not architectures in the abstract.</li>
+      <li><strong>Dependencies are not in the table.</strong> laplace is pure Python (and
+        JavaScript, and Rust) with no weights to download and runs in a browser; the
+        foundation models need torch and hundreds of megabytes of weights.</li>
+    </ul>
+
+    <p class="stamp">Measured {meta['date']} on {meta['machine']}, Python
+      {meta['python']}, skaters {meta['version']}+{meta['commit']}, context {meta['context']}
+      points, horizon {meta['horizon']}, {meta['series']} series, median of repeats.
+      Regenerate with <code>benchmarks/perf_compare.py</code>.</p>
+  </main>
+
+  <footer>
+    <a href="https://github.com/microprediction/skaters">Source</a> &middot;
+    Part of the <a href="https://repos.microprediction.org/">microprediction</a> family
+    (see also <a href="http://thurstone.microprediction.org">thurstone</a>,
+    <a href="http://schur.microprediction.org">schur</a>).
+  </footer>
+</body>
+</html>
+"""
+
+
+def main():
+    meta = stamp()
+    rows = measure()
+    out = {"meta": meta, "rows": rows}
+    jp = os.path.join(os.path.dirname(os.path.abspath(__file__)), "perf_results.json")
+    with open(jp, "w") as fh:
+        json.dump(out, fh, indent=1)
+    hp = os.path.join(ROOT, "docs", "performance.html")
+    with open(hp, "w") as fh:
+        fh.write(render(rows, meta))
+    print(f"[perf] {len(rows)} measurements -> {jp}")
+    print(f"[perf] page -> {hp}")
+    for r in rows:
+        ms = "n/a" if r["ms"] != r["ms"] else f"{r['ms']:.4f}"
+        print(f"   {r['model']:24s}{r['regime']:12s}{ms:>10}  {r['note']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/perf_results.json
+++ b/benchmarks/perf_results.json
@@ -1,0 +1,165 @@
+{
+ "meta": {
+  "version": "0.16.0",
+  "commit": "d778bdf",
+  "python": "3.11.15",
+  "machine": "Darwin arm64",
+  "torch_threads": 1,
+  "context": 256,
+  "horizon": 12,
+  "series": 64,
+  "date": "2026-08-12"
+ },
+ "rows": [
+  {
+   "model": "laplace (Rust) k=1",
+   "regime": "cold",
+   "ms": 3.364190749834961,
+   "note": "replays 256 points"
+  },
+  {
+   "model": "laplace (Rust) k=1",
+   "regime": "warm",
+   "ms": 0.012414582015480846,
+   "note": "one online update"
+  },
+  {
+   "model": "laplace (Rust) k=12",
+   "regime": "cold",
+   "ms": 42.47689973408342,
+   "note": "replays 256 points"
+  },
+  {
+   "model": "laplace (Rust) k=12",
+   "regime": "warm",
+   "ms": 0.14843166602076963,
+   "note": "one online update"
+  },
+  {
+   "model": "laplace (Python) k=1",
+   "regime": "cold",
+   "ms": 66.34913012385368,
+   "note": "replays 256 points"
+  },
+  {
+   "model": "laplace (Python) k=1",
+   "regime": "warm",
+   "ms": 0.248072776691212,
+   "note": "one online update"
+  },
+  {
+   "model": "Chronos-Bolt-small",
+   "regime": "cold b=1",
+   "ms": 7.288692062502378,
+   "note": "48M params, batched"
+  },
+  {
+   "model": "Chronos-Bolt-small",
+   "regime": "cold b=16",
+   "ms": 1.2829765628339374,
+   "note": "48M params, batched"
+  },
+  {
+   "model": "Chronos-Bolt-small",
+   "regime": "cold b=64",
+   "ms": 0.7271972654052661,
+   "note": "48M params, batched"
+  },
+  {
+   "model": "Chronos-Bolt-small",
+   "regime": "warm",
+   "ms": 7.436000014422461,
+   "note": "stateless: full re-forward"
+  },
+  {
+   "model": "TiRex",
+   "regime": "cold b=1",
+   "ms": 94.40885026560863,
+   "note": "35M params, xLSTM, batched"
+  },
+  {
+   "model": "TiRex",
+   "regime": "cold b=16",
+   "ms": 74.638590500399,
+   "note": "35M params, xLSTM, batched"
+  },
+  {
+   "model": "TiRex",
+   "regime": "cold b=64",
+   "ms": 75.39016535929477,
+   "note": "35M params, xLSTM, batched"
+  },
+  {
+   "model": "TiRex",
+   "regime": "warm",
+   "ms": 95.04220800590701,
+   "note": "stateless: full re-forward"
+  },
+  {
+   "model": "Sundial-base-128m",
+   "regime": "cold",
+   "ms": NaN,
+   "note": "unavailable: AttributeError: 'DynamicCache' object has no attribute 'seen_tokens'"
+  },
+  {
+   "model": "TimesFM-2.5-200M",
+   "regime": "cold b=1",
+   "ms": 318.4692278591683,
+   "note": "200M params, batched"
+  },
+  {
+   "model": "TimesFM-2.5-200M",
+   "regime": "cold b=16",
+   "ms": 20.073409500128037,
+   "note": "200M params, batched"
+  },
+  {
+   "model": "TimesFM-2.5-200M",
+   "regime": "cold b=64",
+   "ms": 4.965540359535225,
+   "note": "200M params, batched"
+  },
+  {
+   "model": "TimesFM-2.5-200M",
+   "regime": "warm",
+   "ms": 319.157207995886,
+   "note": "stateless: full re-forward"
+  },
+  {
+   "model": "AutoARIMA (refit)",
+   "regime": "cold",
+   "ms": 62.722041009692475,
+   "note": "fit on 256 points"
+  },
+  {
+   "model": "AutoARIMA (refit)",
+   "regime": "warm",
+   "ms": 62.722041009692475,
+   "note": "refits from scratch every step"
+  },
+  {
+   "model": "AutoETS (refit)",
+   "regime": "cold",
+   "ms": 1.960374996997416,
+   "note": "fit on 256 points"
+  },
+  {
+   "model": "AutoETS (refit)",
+   "regime": "warm",
+   "ms": 1.960374996997416,
+   "note": "refits from scratch every step"
+  },
+  {
+   "model": "Prophet (refit)",
+   "regime": "cold",
+   "ms": 28.225000001839362,
+   "note": "fit on 256 points"
+  },
+  {
+   "model": "Prophet (refit)",
+   "regime": "warm",
+   "ms": 28.225000001839362,
+   "note": "refits from scratch every step"
+  }
+ ]
+}

--- a/docs/anomaly-literature.html
+++ b/docs/anomaly-literature.html
@@ -38,9 +38,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -41,9 +41,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/challengers.html
+++ b/docs/challengers.html
@@ -32,9 +32,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/challengers/pymc-forecast.html
+++ b/docs/challengers/pymc-forecast.html
@@ -38,9 +38,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/challengers/tabfm.html
+++ b/docs/challengers/tabfm.html
@@ -38,9 +38,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -40,9 +40,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/demos/normalization.html
+++ b/docs/demos/normalization.html
@@ -48,9 +48,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/demos/playground.html
+++ b/docs/demos/playground.html
@@ -52,9 +52,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/demos/pyodide.html
+++ b/docs/demos/pyodide.html
@@ -40,9 +40,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/demos/race.html
+++ b/docs/demos/race.html
@@ -65,9 +65,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/demos/rosenblatt.html
+++ b/docs/demos/rosenblatt.html
@@ -50,9 +50,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/draws.html
+++ b/docs/draws.html
@@ -37,6 +37,7 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -32,9 +32,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/foundation/chronos.html
+++ b/docs/foundation/chronos.html
@@ -49,6 +49,7 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>

--- a/docs/foundation/flowstate.html
+++ b/docs/foundation/flowstate.html
@@ -49,6 +49,7 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>

--- a/docs/foundation/sundial.html
+++ b/docs/foundation/sundial.html
@@ -49,6 +49,7 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>

--- a/docs/foundation/timesfm.html
+++ b/docs/foundation/timesfm.html
@@ -49,6 +49,7 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>

--- a/docs/foundation/tirex.html
+++ b/docs/foundation/tirex.html
@@ -49,6 +49,7 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -44,9 +44,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/heritage.html
+++ b/docs/heritage.html
@@ -54,9 +54,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,9 +44,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/languages.html
+++ b/docs/languages.html
@@ -38,9 +38,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/metrics.html
+++ b/docs/metrics.html
@@ -35,9 +35,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/papers.html
+++ b/docs/papers.html
@@ -52,9 +52,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/performance.html
+++ b/docs/performance.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>skaters &mdash; performance</title>
+  <meta name="description" content="Measured cost of laplace against foundation models, in both the batch-benchmark regime and the streaming regime a deployment actually runs in." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="skaters" />
+  <meta property="og:title" content="skaters &mdash; performance" />
+  <meta property="og:description" content="Measured cost of laplace against foundation models, batch and streaming." />
+  <meta property="og:url" content="https://skaters.microprediction.org/performance.html" />
+  <meta name="twitter:card" content="summary" />
+  <link rel="stylesheet" href="./academic.css" />
+  <style>
+    .lede { color: #555; margin: 0 0 28px; font-size: 1.05em; }
+    table.perf { border-collapse: collapse; margin: 0 0 26px; width: 100%; }
+    table.perf th, table.perf td { border-bottom: 1px solid #e3e3e3; padding: 6px 10px;
+      text-align: left; font-size: 0.95em; }
+    table.perf th { border-bottom: 2px solid #bbb; font-weight: 600; }
+    td.num { text-align: right; font-variant-numeric: tabular-nums; }
+    td.note { color: #777; font-size: 0.88em; }
+    .caveats li { margin-bottom: 7px; }
+    .stamp { color: #888; font-size: 0.88em; font-style: italic; }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="nav-inner">
+      <a class="brand" href="/">skaters</a>
+      <nav>
+        <a href="/">Home</a>
+        <a href="/guide.html">Methodology</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Usage &#9662;</span>
+          <span class="drop">
+            <a href="/challengers.html">Standalone</a>
+            <a href="/sandwich.html">Sandwich pattern</a>
+            <a href="/sidecar.html">Sidecar pattern</a>
+          </span>
+        </span>
+        <span class="menu" tabindex="0"><span class="menu-label">Foundational &#9662;</span>
+          <span class="drop">
+            <a href="/foundation/chronos.html">Chronos</a>
+            <a href="/foundation/tirex.html">TiRex</a>
+            <a href="/foundation/timesfm.html">TimesFM</a>
+            <a href="/foundation/sundial.html">Sundial</a>
+            <a href="/foundation/flowstate.html">FlowState</a>
+          </span>
+        </span>
+        <a href="/demos/">Demos</a>
+        <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
+          <span class="drop">
+            <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
+            <a href="/scope.html">Scope</a>
+            <a href="/languages.html">Languages</a>
+            <a href="/heritage.html">Heritage</a>
+            <a href="/faq.html">FAQ</a>
+            <a href="/skills.html">Skills</a>
+          </span>
+        </span>
+        <a href="https://github.com/microprediction/skaters">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <h1>Performance</h1>
+    <p class="lede">What a forecast costs. Accuracy comparisons live on the
+      <a href="/benchmarks.html">benchmarks page</a>; this is the runtime axis, measured
+      on one machine with every model given the same core budget. There are two regimes
+      and they disagree, so both are reported.</p>
+
+    <h2>Streaming: one new observation arrives</h2>
+    <p><code>laplace</code> is online. A new observation costs a single state update
+      whose cost does not depend on how much history preceded it. A foundation model
+      carries no state, so it re-runs its whole forward pass over a shifted window
+      every time. This is the regime a live deployment runs in.</p>
+    <table class="perf">
+      <tr><th>model</th><th>ms per observation</th><th>vs laplace (Rust) k=1</th></tr>
+      <tr><td>laplace (Rust) k=12</td><td class=num>0.1484</td><td class=num>12&times;</td></tr>
+      <tr><td>laplace (Python) k=1</td><td class=num>0.2481</td><td class=num>20&times;</td></tr>
+      <tr><td>AutoETS (refit)</td><td class=num>1.9604</td><td class=num>158&times;</td></tr>
+      <tr><td>Chronos-Bolt-small</td><td class=num>7.4360</td><td class=num>599&times;</td></tr>
+      <tr><td>Prophet (refit)</td><td class=num>28.2250</td><td class=num>2,274&times;</td></tr>
+      <tr><td>AutoARIMA (refit)</td><td class=num>62.7220</td><td class=num>5,052&times;</td></tr>
+      <tr><td>TiRex</td><td class=num>95.0422</td><td class=num>7,656&times;</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td class=num>319.1572</td><td class=num>25,708&times;</td></tr>
+    </table>
+
+    <h2>Batch: one forecast for a series never seen before</h2>
+    <p>This is the benchmark protocol, and it is <em>laplace at its worst</em>: it must
+      consume the whole history to warm up, while a foundation model amortises a batched
+      forward pass across many series. Best batch size shown per model.</p>
+    <table class="perf">
+      <tr><th>model</th><th>ms per series</th><th>regime</th></tr>
+      <tr><td>Chronos-Bolt-small</td><td class=num>0.7272</td><td class=note>cold b=64</td></tr>
+      <tr><td>AutoETS (refit)</td><td class=num>1.9604</td><td class=note>cold</td></tr>
+      <tr><td>laplace (Rust) k=1</td><td class=num>3.3642</td><td class=note>cold</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td class=num>4.9655</td><td class=note>cold b=64</td></tr>
+      <tr><td>Prophet (refit)</td><td class=num>28.2250</td><td class=note>cold</td></tr>
+      <tr><td>laplace (Rust) k=12</td><td class=num>42.4769</td><td class=note>cold</td></tr>
+      <tr><td>AutoARIMA (refit)</td><td class=num>62.7220</td><td class=note>cold</td></tr>
+      <tr><td>laplace (Python) k=1</td><td class=num>66.3491</td><td class=note>cold</td></tr>
+      <tr><td>TiRex</td><td class=num>74.6386</td><td class=note>cold b=16</td></tr>
+    </table>
+
+    <h2>Every measurement</h2>
+    <table class="perf">
+      <tr><th>model</th><th>regime</th><th>ms</th><th>note</th></tr>
+      <tr><td>laplace (Rust) k=1</td><td>cold</td><td class=num>3.3642</td><td class=note>replays 256 points</td></tr>
+      <tr><td>laplace (Rust) k=1</td><td>warm</td><td class=num>0.0124</td><td class=note>one online update</td></tr>
+      <tr><td>laplace (Rust) k=12</td><td>cold</td><td class=num>42.4769</td><td class=note>replays 256 points</td></tr>
+      <tr><td>laplace (Rust) k=12</td><td>warm</td><td class=num>0.1484</td><td class=note>one online update</td></tr>
+      <tr><td>laplace (Python) k=1</td><td>cold</td><td class=num>66.3491</td><td class=note>replays 256 points</td></tr>
+      <tr><td>laplace (Python) k=1</td><td>warm</td><td class=num>0.2481</td><td class=note>one online update</td></tr>
+      <tr><td>Chronos-Bolt-small</td><td>cold b=1</td><td class=num>7.2887</td><td class=note>48M params, batched</td></tr>
+      <tr><td>Chronos-Bolt-small</td><td>cold b=16</td><td class=num>1.2830</td><td class=note>48M params, batched</td></tr>
+      <tr><td>Chronos-Bolt-small</td><td>cold b=64</td><td class=num>0.7272</td><td class=note>48M params, batched</td></tr>
+      <tr><td>Chronos-Bolt-small</td><td>warm</td><td class=num>7.4360</td><td class=note>stateless: full re-forward</td></tr>
+      <tr><td>TiRex</td><td>cold b=1</td><td class=num>94.4089</td><td class=note>35M params, xLSTM, batched</td></tr>
+      <tr><td>TiRex</td><td>cold b=16</td><td class=num>74.6386</td><td class=note>35M params, xLSTM, batched</td></tr>
+      <tr><td>TiRex</td><td>cold b=64</td><td class=num>75.3902</td><td class=note>35M params, xLSTM, batched</td></tr>
+      <tr><td>TiRex</td><td>warm</td><td class=num>95.0422</td><td class=note>stateless: full re-forward</td></tr>
+      <tr><td>Sundial-base-128m</td><td>cold</td><td class=num>n/a</td><td class=note>unavailable: AttributeError: 'DynamicCache' object has no attribute 'seen_tokens'</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td>cold b=1</td><td class=num>318.4692</td><td class=note>200M params, batched</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td>cold b=16</td><td class=num>20.0734</td><td class=note>200M params, batched</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td>cold b=64</td><td class=num>4.9655</td><td class=note>200M params, batched</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td>warm</td><td class=num>319.1572</td><td class=note>stateless: full re-forward</td></tr>
+      <tr><td>AutoARIMA (refit)</td><td>cold</td><td class=num>62.7220</td><td class=note>fit on 256 points</td></tr>
+      <tr><td>AutoARIMA (refit)</td><td>warm</td><td class=num>62.7220</td><td class=note>refits from scratch every step</td></tr>
+      <tr><td>AutoETS (refit)</td><td>cold</td><td class=num>1.9604</td><td class=note>fit on 256 points</td></tr>
+      <tr><td>AutoETS (refit)</td><td>warm</td><td class=num>1.9604</td><td class=note>refits from scratch every step</td></tr>
+      <tr><td>Prophet (refit)</td><td>cold</td><td class=num>28.2250</td><td class=note>fit on 256 points</td></tr>
+      <tr><td>Prophet (refit)</td><td>warm</td><td class=num>28.2250</td><td class=note>refits from scratch every step</td></tr>
+    </table>
+
+    <h2>Caveats</h2>
+    <ul class="caveats">
+      <li><strong>CPU only, 1 torch thread.</strong> A GPU changes the
+        foundation-model numbers substantially and does not change laplace's.</li>
+      <li><strong>The two regimes disagree, and neither is wrong.</strong> Batched, a
+        foundation model can be cheaper per series than laplace replaying a history.
+        Streaming, laplace is orders of magnitude cheaper. Which number applies depends
+        entirely on whether you are scoring a benchmark or running a service.</li>
+      <li><strong>Rust and Python differ by roughly 18&times;.</strong> Ratios here are
+        against the Rust core (<code>skaters_fast</code>), which is what ships; the
+        pure-Python reference is correspondingly slower.</li>
+      <li><strong>Horizon costs laplace.</strong> Going from k=1 to k=12 costs it roughly
+        an order of magnitude, because the multi-scale ensemble runs a full candidate pool
+        per decimation stride per horizon.</li>
+      <li><strong>Not size-ordered.</strong> The models differ in parameter count and in
+        output mechanism (quantile heads versus sampled paths), so this ranks
+        implementations as configured, not architectures in the abstract.</li>
+      <li><strong>Dependencies are not in the table.</strong> laplace is pure Python (and
+        JavaScript, and Rust) with no weights to download and runs in a browser; the
+        foundation models need torch and hundreds of megabytes of weights.</li>
+    </ul>
+
+    <p class="stamp">Measured 2026-08-12 on Darwin arm64, Python
+      3.11.15, skaters 0.16.0+d778bdf, context 256
+      points, horizon 12, 64 series, median of repeats.
+      Regenerate with <code>benchmarks/perf_compare.py</code>.</p>
+  </main>
+
+  <footer>
+    <a href="https://github.com/microprediction/skaters">Source</a> &middot;
+    Part of the <a href="https://repos.microprediction.org/">microprediction</a> family
+    (see also <a href="http://thurstone.microprediction.org">thurstone</a>,
+    <a href="http://schur.microprediction.org">schur</a>).
+  </footer>
+</body>
+</html>

--- a/docs/robustness.html
+++ b/docs/robustness.html
@@ -132,9 +132,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/sandwich.html
+++ b/docs/sandwich.html
@@ -38,9 +38,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/scope.html
+++ b/docs/scope.html
@@ -32,9 +32,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/sidecar.html
+++ b/docs/sidecar.html
@@ -51,6 +51,7 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -51,9 +51,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/sweep_nav.py
+++ b/docs/sweep_nav.py
@@ -15,23 +15,41 @@ import os
 import re
 import sys
 
+# THE one nav. `benchmarks/foundation_pages.py` used to carry a second copy and
+# rewrote only the inner <nav>, which is how the site ended up with three
+# different menus at once (25 pages on one variant, 7 on another, and this
+# constant matching neither). That generator now imports NAV from here, so this
+# is the single source. Changing the menu means editing this and running the
+# sweep; nothing else should write a <nav>.
 CANONICAL = """  <header class="site-header">
     <div class="nav-inner">
       <a class="brand" href="/">skaters</a>
       <nav>
         <a href="/">Home</a>
-        <span class="menu" tabindex="0"><span class="menu-label">Results &#9662;</span>
+        <a href="/guide.html">Methodology</a>
+        <span class="menu" tabindex="0"><span class="menu-label">Usage &#9662;</span>
           <span class="drop">
-            <a href="/challengers.html">Direct comparisons</a>
-            <a href="/sandwich.html">Collaborative use</a>
-            <a href="/sidecar.html">Foundation models</a>
+            <a href="/challengers.html">Standalone</a>
+            <a href="/sandwich.html">Sandwich pattern</a>
+            <a href="/sidecar.html">Sidecar pattern</a>
+          </span>
+        </span>
+        <span class="menu" tabindex="0"><span class="menu-label">Foundational &#9662;</span>
+          <span class="drop">
+            <a href="/foundation/chronos.html">Chronos</a>
+            <a href="/foundation/tirex.html">TiRex</a>
+            <a href="/foundation/timesfm.html">TimesFM</a>
+            <a href="/foundation/sundial.html">Sundial</a>
+            <a href="/foundation/flowstate.html">FlowState</a>
           </span>
         </span>
         <a href="/demos/">Demos</a>
-        <a href="/guide.html">Guide</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
+            <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>
@@ -43,6 +61,9 @@ CANONICAL = """  <header class="site-header">
       </nav>
     </div>
   </header>"""
+
+# The inner <nav> only, for consumers that replace just that block.
+NAV = CANONICAL[CANONICAL.index("      <nav>"):CANONICAL.index("</nav>") + len("</nav>")]
 
 HEADER_RE = re.compile(r'[ \t]*<header class="site-header">.*?</header>', re.DOTALL)
 

--- a/docs/tails.html
+++ b/docs/tails.html
@@ -42,9 +42,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/tiki-taka.html
+++ b/docs/tiki-taka.html
@@ -48,9 +48,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>

--- a/docs/timesfm.html
+++ b/docs/timesfm.html
@@ -32,9 +32,11 @@
         </span>
         <a href="/demos/">Demos</a>
         <a href="/papers.html">Papers</a>
+        <a href="/performance.html">Performance</a>
         <span class="menu" tabindex="0"><span class="menu-label">Docs &#9662;</span>
           <span class="drop">
             <a href="/guide.html">Methodology</a>
+            <a href="/draws.html">Draws</a>
             <a href="/scope.html">Scope</a>
             <a href="/languages.html">Languages</a>
             <a href="/heritage.html">Heritage</a>


### PR DESCRIPTION
## Why

The accuracy studies never recorded a **runtime axis**, so cost claims were being made from memory. `benchmarks/perf_compare.py` measures it and generates `docs/performance.html` plus `perf_results.json`, so the page regenerates from data rather than being hand-written.

## Two regimes, because they disagree

**Streaming** — one new observation on a series already being tracked. This is what a deployment runs. laplace does one online state update; a foundation model carries no state and must re-forward a shifted window; a refitting classical model refits from scratch.

| model | ms/obs | vs laplace (Rust) k=1 |
|---|---|---|
| **laplace (Rust) k=1** | 0.0123 | — |
| laplace (Rust) k=12 | 0.149 | 12× |
| laplace (Python) k=1 | 0.252 | 20× |
| AutoETS (refit) | 1.96 | 159× |
| Chronos-Bolt-small | 7.44 | 605× |
| Prophet (refit) | 28.2 | 2,295× |
| AutoARIMA (refit) | 62.7 | 5,100× |
| TiRex | 95.0 | 7,727× |
| TimesFM-2.5-200M | 319.2 | **25,950×** |

**Batch** — one forecast for an unseen series, i.e. the benchmark protocol, and **laplace at its worst** because it replays the whole history while a foundation model amortises a batched forward pass. Chronos reaches **0.73 ms/series** at batch 64 against laplace's 3.37 ms. TimesFM falls 318 → 4.97 ms/series from batch 1 to 64. The refitting models don't batch at all, which is why their cold and warm costs are identical.

Publishing only the streaming ratio would be cherry-picking, so both tables are on the page.

## Caveats are on the page, not buried

CPU-only with one torch thread; the regime disagreement stated plainly; Rust vs Python differing ~18× so every ratio says which it means; horizon costing laplace an order of magnitude from k=1 to k=12; the models not being size-ordered; and dependency weight absent from the table (laplace ships no weights and runs in a browser). Provenance stamp carries version, commit, machine, context, horizon and series count.

Sundial is recorded as **unavailable with its actual reason** (`'DynamicCache' object has no attribute 'seen_tokens'`, a `transformers` break in its remote code) so absence isn't read as a result.

## Also: three navs collapsed into one

The site was serving **three different menus** — 25 pages on one variant, 7 on another, and `sweep_nav.py`'s CANONICAL matching neither. Cause: two generators both wrote nav. `foundation_pages.py` carried its own `NAV` constant and rewrote the inner `<nav>`, while `sweep_nav.py` rewrote the whole header.

`foundation_pages.py` now imports `NAV` from `sweep_nav`, CANONICAL is the live menu plus the Performance link, and the sweep reports **nav in sync across 33 pages** with `--check` exiting 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)