### PR TITLE
Performance page: link the reproduction script and raw results

### DIFF
--- a/benchmarks/perf_compare.py
+++ b/benchmarks/perf_compare.py
@@ -296,6 +296,9 @@ def render(rows, meta):
     td.num {{ text-align: right; font-variant-numeric: tabular-nums; }}
     td.note {{ color: #777; font-size: 0.88em; }}
     .caveats li {{ margin-bottom: 7px; }}
+    .links a {{ text-decoration: none; }}
+    .links a:hover {{ text-decoration: underline; }}
+    pre code {{ font-size: 0.9em; }}
     .stamp {{ color: #888; font-size: 0.88em; font-style: italic; }}
   </style>
 </head>
@@ -356,10 +359,24 @@ def render(rows, meta):
         foundation models need torch and hundreds of megabytes of weights.</li>
     </ul>
 
+    <h2>Reproducing this</h2>
+    <p>Every number on this page is generated, not typed. The script measures each
+      model and writes both this page and the machine-readable results beside it, so
+      re-running it refreshes the page and nothing here can drift from the data.</p>
+<pre><code>PYTHONPATH=src:benchmarks python benchmarks/perf_compare.py</code></pre>
+    <p class="links">
+      <a href="https://github.com/microprediction/skaters/blob/main/benchmarks/perf_compare.py">perf_compare.py</a> &mdash; the measurement script
+      &middot;
+      <a href="https://github.com/microprediction/skaters/blob/main/benchmarks/perf_results.json">perf_results.json</a> &mdash; these numbers as data
+    </p>
+    <p>Knobs, as environment variables: <code>PERF_L</code> context length,
+      <code>PERF_H</code> horizon, <code>PERF_N</code> series count,
+      <code>TORCH_THREADS</code> core budget for the neural models. Each model is warmed
+      up before timing and reported as the median of repeats.</p>
+
     <p class="stamp">Measured {meta['date']} on {meta['machine']}, Python
       {meta['python']}, skaters {meta['version']}+{meta['commit']}, context {meta['context']}
-      points, horizon {meta['horizon']}, {meta['series']} series, median of repeats.
-      Regenerate with <code>benchmarks/perf_compare.py</code>.</p>
+      points, horizon {meta['horizon']}, {meta['series']} series, median of repeats.</p>
   </main>
 
   <footer>

--- a/benchmarks/perf_results.json
+++ b/benchmarks/perf_results.json
@@ -1,7 +1,7 @@
 {
  "meta": {
   "version": "0.16.0",
-  "commit": "d778bdf",
+  "commit": "8ddc8d5",
   "python": "3.11.15",
   "machine": "Darwin arm64",
   "torch_threads": 1,
@@ -14,85 +14,85 @@
   {
    "model": "laplace (Rust) k=1",
    "regime": "cold",
-   "ms": 3.364190749834961,
+   "ms": 3.389684250123537,
    "note": "replays 256 points"
   },
   {
    "model": "laplace (Rust) k=1",
    "regime": "warm",
-   "ms": 0.012414582015480846,
+   "ms": 0.012310668011195958,
    "note": "one online update"
   },
   {
    "model": "laplace (Rust) k=12",
    "regime": "cold",
-   "ms": 42.47689973408342,
+   "ms": 42.61712239076587,
    "note": "replays 256 points"
   },
   {
    "model": "laplace (Rust) k=12",
    "regime": "warm",
-   "ms": 0.14843166602076963,
+   "ms": 0.1510795839712955,
    "note": "one online update"
   },
   {
    "model": "laplace (Python) k=1",
    "regime": "cold",
-   "ms": 66.34913012385368,
+   "ms": 67.08088549930835,
    "note": "replays 256 points"
   },
   {
    "model": "laplace (Python) k=1",
    "regime": "warm",
-   "ms": 0.248072776691212,
+   "ms": 0.2505761099746451,
    "note": "one online update"
   },
   {
    "model": "Chronos-Bolt-small",
    "regime": "cold b=1",
-   "ms": 7.288692062502378,
+   "ms": 7.440869781476067,
    "note": "48M params, batched"
   },
   {
    "model": "Chronos-Bolt-small",
    "regime": "cold b=16",
-   "ms": 1.2829765628339374,
+   "ms": 1.292375640332466,
    "note": "48M params, batched"
   },
   {
    "model": "Chronos-Bolt-small",
    "regime": "cold b=64",
-   "ms": 0.7271972654052661,
+   "ms": 0.7214869842755434,
    "note": "48M params, batched"
   },
   {
    "model": "Chronos-Bolt-small",
    "regime": "warm",
-   "ms": 7.436000014422461,
+   "ms": 7.439749984769151,
    "note": "stateless: full re-forward"
   },
   {
    "model": "TiRex",
    "regime": "cold b=1",
-   "ms": 94.40885026560863,
+   "ms": 96.47288345286142,
    "note": "35M params, xLSTM, batched"
   },
   {
    "model": "TiRex",
    "regime": "cold b=16",
-   "ms": 74.638590500399,
+   "ms": 74.94859895314221,
    "note": "35M params, xLSTM, batched"
   },
   {
    "model": "TiRex",
    "regime": "cold b=64",
-   "ms": 75.39016535929477,
+   "ms": 76.33774023406659,
    "note": "35M params, xLSTM, batched"
   },
   {
    "model": "TiRex",
    "regime": "warm",
-   "ms": 95.04220800590701,
+   "ms": 95.68308299640194,
    "note": "stateless: full re-forward"
   },
   {
@@ -104,61 +104,61 @@
   {
    "model": "TimesFM-2.5-200M",
    "regime": "cold b=1",
-   "ms": 318.4692278591683,
+   "ms": 323.44013217198153,
    "note": "200M params, batched"
   },
   {
    "model": "TimesFM-2.5-200M",
    "regime": "cold b=16",
-   "ms": 20.073409500128037,
+   "ms": 20.263938156404038,
    "note": "200M params, batched"
   },
   {
    "model": "TimesFM-2.5-200M",
    "regime": "cold b=64",
-   "ms": 4.965540359535225,
+   "ms": 5.099649094063352,
    "note": "200M params, batched"
   },
   {
    "model": "TimesFM-2.5-200M",
    "regime": "warm",
-   "ms": 319.157207995886,
+   "ms": 329.82900002389215,
    "note": "stateless: full re-forward"
   },
   {
    "model": "AutoARIMA (refit)",
    "regime": "cold",
-   "ms": 62.722041009692475,
+   "ms": 62.13358402601443,
    "note": "fit on 256 points"
   },
   {
    "model": "AutoARIMA (refit)",
    "regime": "warm",
-   "ms": 62.722041009692475,
+   "ms": 62.13358402601443,
    "note": "refits from scratch every step"
   },
   {
    "model": "AutoETS (refit)",
    "regime": "cold",
-   "ms": 1.960374996997416,
+   "ms": 1.9309580093249679,
    "note": "fit on 256 points"
   },
   {
    "model": "AutoETS (refit)",
    "regime": "warm",
-   "ms": 1.960374996997416,
+   "ms": 1.9309580093249679,
    "note": "refits from scratch every step"
   },
   {
    "model": "Prophet (refit)",
    "regime": "cold",
-   "ms": 28.225000001839362,
+   "ms": 29.965979483677074,
    "note": "fit on 256 points"
   },
   {
    "model": "Prophet (refit)",
    "regime": "warm",
-   "ms": 28.225000001839362,
+   "ms": 29.965979483677074,
    "note": "refits from scratch every step"
   }
  ]

--- a/docs/performance.html
+++ b/docs/performance.html
@@ -21,6 +21,9 @@
     td.num { text-align: right; font-variant-numeric: tabular-nums; }
     td.note { color: #777; font-size: 0.88em; }
     .caveats li { margin-bottom: 7px; }
+    .links a { text-decoration: none; }
+    .links a:hover { text-decoration: underline; }
+    pre code { font-size: 0.9em; }
     .stamp { color: #888; font-size: 0.88em; font-style: italic; }
   </style>
 </head>
@@ -80,14 +83,14 @@
       every time. This is the regime a live deployment runs in.</p>
     <table class="perf">
       <tr><th>model</th><th>ms per observation</th><th>vs laplace (Rust) k=1</th></tr>
-      <tr><td>laplace (Rust) k=12</td><td class=num>0.1484</td><td class=num>12&times;</td></tr>
-      <tr><td>laplace (Python) k=1</td><td class=num>0.2481</td><td class=num>20&times;</td></tr>
-      <tr><td>AutoETS (refit)</td><td class=num>1.9604</td><td class=num>158&times;</td></tr>
-      <tr><td>Chronos-Bolt-small</td><td class=num>7.4360</td><td class=num>599&times;</td></tr>
-      <tr><td>Prophet (refit)</td><td class=num>28.2250</td><td class=num>2,274&times;</td></tr>
-      <tr><td>AutoARIMA (refit)</td><td class=num>62.7220</td><td class=num>5,052&times;</td></tr>
-      <tr><td>TiRex</td><td class=num>95.0422</td><td class=num>7,656&times;</td></tr>
-      <tr><td>TimesFM-2.5-200M</td><td class=num>319.1572</td><td class=num>25,708&times;</td></tr>
+      <tr><td>laplace (Rust) k=12</td><td class=num>0.1511</td><td class=num>12&times;</td></tr>
+      <tr><td>laplace (Python) k=1</td><td class=num>0.2506</td><td class=num>20&times;</td></tr>
+      <tr><td>AutoETS (refit)</td><td class=num>1.9310</td><td class=num>157&times;</td></tr>
+      <tr><td>Chronos-Bolt-small</td><td class=num>7.4397</td><td class=num>604&times;</td></tr>
+      <tr><td>Prophet (refit)</td><td class=num>29.9660</td><td class=num>2,434&times;</td></tr>
+      <tr><td>AutoARIMA (refit)</td><td class=num>62.1336</td><td class=num>5,047&times;</td></tr>
+      <tr><td>TiRex</td><td class=num>95.6831</td><td class=num>7,772&times;</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td class=num>329.8290</td><td class=num>26,792&times;</td></tr>
     </table>
 
     <h2>Batch: one forecast for a series never seen before</h2>
@@ -96,45 +99,45 @@
       forward pass across many series. Best batch size shown per model.</p>
     <table class="perf">
       <tr><th>model</th><th>ms per series</th><th>regime</th></tr>
-      <tr><td>Chronos-Bolt-small</td><td class=num>0.7272</td><td class=note>cold b=64</td></tr>
-      <tr><td>AutoETS (refit)</td><td class=num>1.9604</td><td class=note>cold</td></tr>
-      <tr><td>laplace (Rust) k=1</td><td class=num>3.3642</td><td class=note>cold</td></tr>
-      <tr><td>TimesFM-2.5-200M</td><td class=num>4.9655</td><td class=note>cold b=64</td></tr>
-      <tr><td>Prophet (refit)</td><td class=num>28.2250</td><td class=note>cold</td></tr>
-      <tr><td>laplace (Rust) k=12</td><td class=num>42.4769</td><td class=note>cold</td></tr>
-      <tr><td>AutoARIMA (refit)</td><td class=num>62.7220</td><td class=note>cold</td></tr>
-      <tr><td>laplace (Python) k=1</td><td class=num>66.3491</td><td class=note>cold</td></tr>
-      <tr><td>TiRex</td><td class=num>74.6386</td><td class=note>cold b=16</td></tr>
+      <tr><td>Chronos-Bolt-small</td><td class=num>0.7215</td><td class=note>cold b=64</td></tr>
+      <tr><td>AutoETS (refit)</td><td class=num>1.9310</td><td class=note>cold</td></tr>
+      <tr><td>laplace (Rust) k=1</td><td class=num>3.3897</td><td class=note>cold</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td class=num>5.0996</td><td class=note>cold b=64</td></tr>
+      <tr><td>Prophet (refit)</td><td class=num>29.9660</td><td class=note>cold</td></tr>
+      <tr><td>laplace (Rust) k=12</td><td class=num>42.6171</td><td class=note>cold</td></tr>
+      <tr><td>AutoARIMA (refit)</td><td class=num>62.1336</td><td class=note>cold</td></tr>
+      <tr><td>laplace (Python) k=1</td><td class=num>67.0809</td><td class=note>cold</td></tr>
+      <tr><td>TiRex</td><td class=num>74.9486</td><td class=note>cold b=16</td></tr>
     </table>
 
     <h2>Every measurement</h2>
     <table class="perf">
       <tr><th>model</th><th>regime</th><th>ms</th><th>note</th></tr>
-      <tr><td>laplace (Rust) k=1</td><td>cold</td><td class=num>3.3642</td><td class=note>replays 256 points</td></tr>
-      <tr><td>laplace (Rust) k=1</td><td>warm</td><td class=num>0.0124</td><td class=note>one online update</td></tr>
-      <tr><td>laplace (Rust) k=12</td><td>cold</td><td class=num>42.4769</td><td class=note>replays 256 points</td></tr>
-      <tr><td>laplace (Rust) k=12</td><td>warm</td><td class=num>0.1484</td><td class=note>one online update</td></tr>
-      <tr><td>laplace (Python) k=1</td><td>cold</td><td class=num>66.3491</td><td class=note>replays 256 points</td></tr>
-      <tr><td>laplace (Python) k=1</td><td>warm</td><td class=num>0.2481</td><td class=note>one online update</td></tr>
-      <tr><td>Chronos-Bolt-small</td><td>cold b=1</td><td class=num>7.2887</td><td class=note>48M params, batched</td></tr>
-      <tr><td>Chronos-Bolt-small</td><td>cold b=16</td><td class=num>1.2830</td><td class=note>48M params, batched</td></tr>
-      <tr><td>Chronos-Bolt-small</td><td>cold b=64</td><td class=num>0.7272</td><td class=note>48M params, batched</td></tr>
-      <tr><td>Chronos-Bolt-small</td><td>warm</td><td class=num>7.4360</td><td class=note>stateless: full re-forward</td></tr>
-      <tr><td>TiRex</td><td>cold b=1</td><td class=num>94.4089</td><td class=note>35M params, xLSTM, batched</td></tr>
-      <tr><td>TiRex</td><td>cold b=16</td><td class=num>74.6386</td><td class=note>35M params, xLSTM, batched</td></tr>
-      <tr><td>TiRex</td><td>cold b=64</td><td class=num>75.3902</td><td class=note>35M params, xLSTM, batched</td></tr>
-      <tr><td>TiRex</td><td>warm</td><td class=num>95.0422</td><td class=note>stateless: full re-forward</td></tr>
+      <tr><td>laplace (Rust) k=1</td><td>cold</td><td class=num>3.3897</td><td class=note>replays 256 points</td></tr>
+      <tr><td>laplace (Rust) k=1</td><td>warm</td><td class=num>0.0123</td><td class=note>one online update</td></tr>
+      <tr><td>laplace (Rust) k=12</td><td>cold</td><td class=num>42.6171</td><td class=note>replays 256 points</td></tr>
+      <tr><td>laplace (Rust) k=12</td><td>warm</td><td class=num>0.1511</td><td class=note>one online update</td></tr>
+      <tr><td>laplace (Python) k=1</td><td>cold</td><td class=num>67.0809</td><td class=note>replays 256 points</td></tr>
+      <tr><td>laplace (Python) k=1</td><td>warm</td><td class=num>0.2506</td><td class=note>one online update</td></tr>
+      <tr><td>Chronos-Bolt-small</td><td>cold b=1</td><td class=num>7.4409</td><td class=note>48M params, batched</td></tr>
+      <tr><td>Chronos-Bolt-small</td><td>cold b=16</td><td class=num>1.2924</td><td class=note>48M params, batched</td></tr>
+      <tr><td>Chronos-Bolt-small</td><td>cold b=64</td><td class=num>0.7215</td><td class=note>48M params, batched</td></tr>
+      <tr><td>Chronos-Bolt-small</td><td>warm</td><td class=num>7.4397</td><td class=note>stateless: full re-forward</td></tr>
+      <tr><td>TiRex</td><td>cold b=1</td><td class=num>96.4729</td><td class=note>35M params, xLSTM, batched</td></tr>
+      <tr><td>TiRex</td><td>cold b=16</td><td class=num>74.9486</td><td class=note>35M params, xLSTM, batched</td></tr>
+      <tr><td>TiRex</td><td>cold b=64</td><td class=num>76.3377</td><td class=note>35M params, xLSTM, batched</td></tr>
+      <tr><td>TiRex</td><td>warm</td><td class=num>95.6831</td><td class=note>stateless: full re-forward</td></tr>
       <tr><td>Sundial-base-128m</td><td>cold</td><td class=num>n/a</td><td class=note>unavailable: AttributeError: 'DynamicCache' object has no attribute 'seen_tokens'</td></tr>
-      <tr><td>TimesFM-2.5-200M</td><td>cold b=1</td><td class=num>318.4692</td><td class=note>200M params, batched</td></tr>
-      <tr><td>TimesFM-2.5-200M</td><td>cold b=16</td><td class=num>20.0734</td><td class=note>200M params, batched</td></tr>
-      <tr><td>TimesFM-2.5-200M</td><td>cold b=64</td><td class=num>4.9655</td><td class=note>200M params, batched</td></tr>
-      <tr><td>TimesFM-2.5-200M</td><td>warm</td><td class=num>319.1572</td><td class=note>stateless: full re-forward</td></tr>
-      <tr><td>AutoARIMA (refit)</td><td>cold</td><td class=num>62.7220</td><td class=note>fit on 256 points</td></tr>
-      <tr><td>AutoARIMA (refit)</td><td>warm</td><td class=num>62.7220</td><td class=note>refits from scratch every step</td></tr>
-      <tr><td>AutoETS (refit)</td><td>cold</td><td class=num>1.9604</td><td class=note>fit on 256 points</td></tr>
-      <tr><td>AutoETS (refit)</td><td>warm</td><td class=num>1.9604</td><td class=note>refits from scratch every step</td></tr>
-      <tr><td>Prophet (refit)</td><td>cold</td><td class=num>28.2250</td><td class=note>fit on 256 points</td></tr>
-      <tr><td>Prophet (refit)</td><td>warm</td><td class=num>28.2250</td><td class=note>refits from scratch every step</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td>cold b=1</td><td class=num>323.4401</td><td class=note>200M params, batched</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td>cold b=16</td><td class=num>20.2639</td><td class=note>200M params, batched</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td>cold b=64</td><td class=num>5.0996</td><td class=note>200M params, batched</td></tr>
+      <tr><td>TimesFM-2.5-200M</td><td>warm</td><td class=num>329.8290</td><td class=note>stateless: full re-forward</td></tr>
+      <tr><td>AutoARIMA (refit)</td><td>cold</td><td class=num>62.1336</td><td class=note>fit on 256 points</td></tr>
+      <tr><td>AutoARIMA (refit)</td><td>warm</td><td class=num>62.1336</td><td class=note>refits from scratch every step</td></tr>
+      <tr><td>AutoETS (refit)</td><td>cold</td><td class=num>1.9310</td><td class=note>fit on 256 points</td></tr>
+      <tr><td>AutoETS (refit)</td><td>warm</td><td class=num>1.9310</td><td class=note>refits from scratch every step</td></tr>
+      <tr><td>Prophet (refit)</td><td>cold</td><td class=num>29.9660</td><td class=note>fit on 256 points</td></tr>
+      <tr><td>Prophet (refit)</td><td>warm</td><td class=num>29.9660</td><td class=note>refits from scratch every step</td></tr>
     </table>
 
     <h2>Caveats</h2>
@@ -159,10 +162,24 @@
         foundation models need torch and hundreds of megabytes of weights.</li>
     </ul>
 
+    <h2>Reproducing this</h2>
+    <p>Every number on this page is generated, not typed. The script measures each
+      model and writes both this page and the machine-readable results beside it, so
+      re-running it refreshes the page and nothing here can drift from the data.</p>
+<pre><code>PYTHONPATH=src:benchmarks python benchmarks/perf_compare.py</code></pre>
+    <p class="links">
+      <a href="https://github.com/microprediction/skaters/blob/main/benchmarks/perf_compare.py">perf_compare.py</a> &mdash; the measurement script
+      &middot;
+      <a href="https://github.com/microprediction/skaters/blob/main/benchmarks/perf_results.json">perf_results.json</a> &mdash; these numbers as data
+    </p>
+    <p>Knobs, as environment variables: <code>PERF_L</code> context length,
+      <code>PERF_H</code> horizon, <code>PERF_N</code> series count,
+      <code>TORCH_THREADS</code> core budget for the neural models. Each model is warmed
+      up before timing and reported as the median of repeats.</p>
+
     <p class="stamp">Measured 2026-08-12 on Darwin arm64, Python
-      3.11.15, skaters 0.16.0+d778bdf, context 256
-      points, horizon 12, 64 series, median of repeats.
-      Regenerate with <code>benchmarks/perf_compare.py</code>.</p>
+      3.11.15, skaters 0.16.0+8ddc8d5, context 256
+      points, horizon 12, 64 series, median of repeats.</p>
   </main>
 
   <footer>


### PR DESCRIPTION
The page told you to "regenerate with `benchmarks/perf_compare.py`" in plain text. Now it links it.

Adds a **Reproducing this** section with:

- the exact command
- a link to [`perf_compare.py`](https://github.com/microprediction/skaters/blob/main/benchmarks/perf_compare.py), the measurement script
- a link to [`perf_results.json`](https://github.com/microprediction/skaters/blob/main/benchmarks/perf_results.json), the same numbers as data
- the environment knobs (`PERF_L` context, `PERF_H` horizon, `PERF_N` series, `TORCH_THREADS` core budget) and the warm-up-then-median protocol

Every number on the page is generated by that script, so the page cannot drift from the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)