### PR TITLE
Fix quantile(0.975) label: it is not the 95th percentile

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ for y in observations:
     dists, state = f(y, state)
     dists[0].mean              # point forecast
     dists[0].std               # uncertainty
-    dists[0].quantile(0.975)   # 95th percentile
+    dists[0].quantile(0.975)   # upper edge of the central 95% band
     dists[0].logpdf(y)         # log-likelihood
     dists[0].cdf(y)            # CDF at y
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -75,7 +75,7 @@ for y in stream:
     d = dists[0]
     d.mean                 # point forecast
     d.std                  # uncertainty
-    d.quantile(0.975)      # 95th percentile
+    d.quantile(0.975)      # upper edge of the central 95% band
     d.logpdf(y)            # <-- a real density: scorable on log-likelihood
     d.crps(y)              # ...and on CRPS
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,7 +149,7 @@ for y in observations:
     dists, state = f(y, state)
     dists[0].mean              # point forecast
     dists[0].std               # uncertainty
-    dists[0].quantile(0.975)   # 95th percentile
+    dists[0].quantile(0.975)   # upper edge of the central 95% band
     dists[0].logpdf(y)         # log-likelihood
     dists[0].cdf(y)            # CDF at y</code></pre>
     <p>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -547,7 +547,7 @@ for y in stream:
     d = dists[0]
     d.mean                 # point forecast
     d.std                  # uncertainty
-    d.quantile(0.975)      # 95th percentile
+    d.quantile(0.975)      # upper edge of the central 95% band
     d.logpdf(y)            # &lt;-- a real density: scorable on log-likelihood
     d.crps(y)              # ...and on CRPS
 ```


### PR DESCRIPTION
The quickstart snippet in README, SKILL.md, and the two docs pages that carry it labeled \`quantile(0.975)\` as the 95th percentile. It is the 97.5th, i.e. the upper edge of the central 95% band, which is presumably what the snippet meant to demonstrate. The code is unchanged; the comment now says what the number is.

All four copies of the snippet fixed; no other occurrence of the label remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)