### PR TITLE
Dist hardening: validate inputs, strict combine, expanding quantile bracket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+- `Dist` validates its inputs (#200): negative or nonfinite weights, nonfinite
+  means, and negative or nonfinite stds now raise `ValueError` instead of
+  producing an object whose pdf can go negative while logpdf silently ignores
+  the bad component. Zero weights (softmax underflow) and zero stds (lattice
+  point masses) remain legal. Validation raises rather than asserts, so it
+  survives `python -O`.
+- `Dist.combine` raises on a length mismatch between distributions and weights
+  instead of silently zip-dropping the extras, and rejects empty input and
+  nonpositive total weight.
+- `Dist.quantile` expands its bracket geometrically until it contains the
+  requested probability, instead of bisecting a fixed `mu +- 8 sigma` window
+  and silently converging to the endpoint when a small far component put the
+  true quantile outside it. `p` outside (0, 1) raises `ValueError`.
+- Parity-neutral: regenerated `parity/vectors.json` is byte-identical, so no
+  port is affected.
+
 ## Note for anyone upgrading from 0.14.0
 
 0.16.0 is the first release since **0.14.0** (2026-07-24). The `v0.15.0` tag

--- a/src/skaters/dist.py
+++ b/src/skaters/dist.py
@@ -12,7 +12,9 @@ All math uses only the standard library (math.erf, math.exp, math.log).
 No numpy, no scipy. Runs in Pyodide.
 
 A Dist is a list of components: [(weight, mean, std), ...].
-Weights are positive and sum to 1. Std is always > 0.
+Weights are nonnegative and sum to 1. Std is finite and >= 0; a std of 0 is
+a point mass (the lattice projection emits them). The constructor enforces
+this with ValueError, not assert, so validation survives ``python -O``.
 """
 
 from __future__ import annotations
@@ -31,11 +33,27 @@ class Dist:
     def __init__(self, components: list[tuple[float, float, float]]):
         """Create from a list of (weight, mean, std) tuples.
 
-        Weights must be positive. They will be normalized to sum to 1.
+        Weights must be nonnegative with a positive total; they are
+        normalized to sum to 1. Means must be finite. Stds must be finite
+        and nonnegative (std == 0 is a point mass, used by the lattice
+        projection). Validation raises ValueError rather than asserting,
+        so it survives ``python -O``; a negative weight or std would make
+        pdf/cdf silently stop being a probability distribution.
         """
-        assert len(components) > 0
+        if len(components) == 0:
+            raise ValueError("Dist needs at least one component")
+        for w, m, s in components:
+            if not (math.isfinite(w) and w >= 0.0):
+                raise ValueError(f"component weight must be finite and >= 0, got {w}")
+            if not math.isfinite(m):
+                raise ValueError(f"component mean must be finite, got {m}")
+            if not (math.isfinite(s) and s >= 0.0):
+                raise ValueError(f"component std must be finite and >= 0, got {s}")
+        # builtin sum, not a += loop: sum() compensates float error (Neumaier),
+        # and the normalization must stay bit-identical to the parity vectors.
         w_total = sum(w for w, _, _ in components)
-        assert w_total > 0
+        if not w_total > 0.0:
+            raise ValueError("total component weight must be positive")
         self.components = [(w / w_total, m, s) for w, m, s in components]
 
     # --- Constructors ---
@@ -52,9 +70,16 @@ class Dist:
         This is the correct way to ensemble distributional predictions.
         """
         n = len(dists)
+        if n == 0:
+            raise ValueError("combine needs at least one distribution")
         if weights is None:
             weights = [1.0 / n] * n
+        if len(weights) != n:
+            raise ValueError(
+                f"combine got {n} distributions but {len(weights)} weights")
         w_total = sum(weights)
+        if not (math.isfinite(w_total) and w_total > 0.0):
+            raise ValueError("combine weights must be finite with a positive total")
         components = []
         for d, w_outer in zip(dists, weights):
             for w_inner, m, s in d.components:
@@ -129,12 +154,35 @@ class Dist:
 
     def quantile(self, p: float, tol: float = 1e-9, max_iter: int = 100) -> float:
         """Inverse CDF via bisection."""
-        assert 0 < p < 1
-        # Initial bracket
+        if not 0 < p < 1:
+            raise ValueError(f"quantile needs 0 < p < 1, got {p}")
+        # Initial bracket. mu +- 8 sigma covers every ordinary mixture, but a
+        # small component far from the bulk can put the quantile outside it,
+        # and bisection against a bracket that excludes the answer converges
+        # to the endpoint with no signal. Expand geometrically until the
+        # bracket genuinely contains p; the expansion never fires for a
+        # bracket that was already sufficient, so existing results are
+        # bit-identical.
         mu = self.mean
         sigma = math.sqrt(self.var)
         lo = mu - 8 * sigma
         hi = mu + 8 * sigma
+        width = max(16 * sigma, 1e-12)
+        for _ in range(120):
+            if self.cdf(lo) <= p:
+                break
+            lo -= width
+            width *= 2.0
+        else:
+            raise ArithmeticError(f"could not bracket quantile p={p} from below")
+        width = max(16 * sigma, 1e-12)
+        for _ in range(120):
+            if self.cdf(hi) >= p:
+                break
+            hi += width
+            width *= 2.0
+        else:
+            raise ArithmeticError(f"could not bracket quantile p={p} from above")
         for _ in range(max_iter):
             mid = 0.5 * (lo + hi)
             if self.cdf(mid) < p:
@@ -176,13 +224,15 @@ class Dist:
 
     def scale(self, factor: float) -> Dist:
         """Scale location and spread by factor (for standardize inverse)."""
-        assert factor != 0
+        if factor == 0:
+            raise ValueError("scale factor must be nonzero")
         f = abs(factor)
         return Dist([(w, m * factor, s * f) for w, m, s in self.components])
 
     def affine(self, a: float, b: float) -> Dist:
         """Apply affine transform: x -> a*x + b."""
-        assert a != 0
+        if a == 0:
+            raise ValueError("affine multiplier must be nonzero")
         return Dist([(w, a * m + b, abs(a) * s) for w, m, s in self.components])
 
     # --- Pruning ---

--- a/tests/test_dist_validation.py
+++ b/tests/test_dist_validation.py
@@ -1,0 +1,117 @@
+"""Dist input validation and quantile bracketing (issue #200).
+
+Before these checks, Dist accepted objects that are not probability
+distributions (negative weights gave pdf(10) = -0.399 while logpdf ignored
+the negative component), combine() zip-dropped members on length mismatch,
+and quantile() bisected a fixed mu +- 8 sigma bracket, converging silently
+to the endpoint whenever the true quantile lay outside it.
+"""
+import math
+
+import pytest
+
+from skaters.dist import Dist
+
+
+# --- constructor -----------------------------------------------------------
+
+def test_negative_weight_rejected():
+    with pytest.raises(ValueError):
+        Dist([(2.0, 0.0, 1.0), (-1.0, 10.0, 1.0)])
+
+
+def test_negative_std_rejected():
+    with pytest.raises(ValueError):
+        Dist([(1.0, 0.0, -1.0)])
+
+
+def test_nonfinite_params_rejected():
+    for bad in [(math.nan, 0.0, 1.0), (1.0, math.inf, 1.0), (1.0, 0.0, math.nan)]:
+        with pytest.raises(ValueError):
+            Dist([bad])
+
+
+def test_empty_rejected():
+    with pytest.raises(ValueError):
+        Dist([])
+
+
+def test_zero_total_weight_rejected():
+    with pytest.raises(ValueError):
+        Dist([(0.0, 0.0, 1.0), (0.0, 1.0, 1.0)])
+
+
+def test_zero_weight_component_allowed():
+    # leaves can softmax-underflow a weight to exactly 0
+    d = Dist([(0.0, 0.0, 1.0), (1.0, 1.0, 1.0)])
+    assert abs(d.mean - 1.0) < 1e-12
+
+
+def test_point_mass_allowed():
+    # the lattice projection emits Dirac components
+    d = Dist([(0.5, 0.0, 1.0), (0.5, 2.0, 0.0)])
+    assert math.isfinite(d.mean)
+
+
+def test_pdf_matches_logpdf_on_valid_dist():
+    d = Dist([(0.6, 0.0, 1.0), (0.4, 3.0, 0.5)])
+    for x in (-2.0, 0.0, 1.5, 3.0, 10.0):
+        assert d.pdf(x) == pytest.approx(math.exp(d.logpdf(x)), rel=1e-12)
+
+
+# --- combine ---------------------------------------------------------------
+
+def test_combine_length_mismatch_rejected():
+    ds = [Dist.gaussian(0.0), Dist.gaussian(1.0), Dist.gaussian(2.0)]
+    with pytest.raises(ValueError):
+        Dist.combine(ds, weights=[0.5, 0.5])
+
+
+def test_combine_empty_rejected():
+    with pytest.raises(ValueError):
+        Dist.combine([])
+
+
+def test_combine_zero_weights_rejected():
+    ds = [Dist.gaussian(0.0), Dist.gaussian(1.0)]
+    with pytest.raises(ValueError):
+        Dist.combine(ds, weights=[0.0, 0.0])
+
+
+def test_combine_unchanged_for_valid_input():
+    ds = [Dist.gaussian(0.0, 1.0), Dist.gaussian(4.0, 2.0)]
+    d = Dist.combine(ds, weights=[0.25, 0.75])
+    assert d.mean == pytest.approx(3.0)
+
+
+# --- quantile --------------------------------------------------------------
+
+def test_quantile_p_out_of_range_rejected():
+    d = Dist.gaussian()
+    for p in (0.0, 1.0, -0.1, 1.1):
+        with pytest.raises(ValueError):
+            d.quantile(p)
+
+
+def test_quantile_far_component_bracket_expands():
+    # weight 0.001 at 1e6: the 0.9995 quantile is near 1e6, far outside
+    # mu +- 8 sigma (~2.5e5). The fixed bracket returned ~253856 here.
+    d = Dist([(0.999, 0.0, 1.0), (0.001, 1e6, 1.0)])
+    q = d.quantile(0.9995)
+    assert q > 9.9e5
+    assert d.cdf(q) == pytest.approx(0.9995, abs=1e-6)
+
+
+def test_quantile_far_component_lower_tail():
+    d = Dist([(0.001, -1e6, 1.0), (0.999, 0.0, 1.0)])
+    q = d.quantile(0.0005)
+    assert q < -9.9e5
+    assert d.cdf(q) == pytest.approx(0.0005, abs=1e-6)
+
+
+def test_quantile_ordinary_cases_unchanged():
+    # the expansion must not fire when the default bracket suffices
+    d = Dist([(0.5, 0.0, 1.0), (0.5, 2.0, 3.0)])
+    for p in (0.01, 0.25, 0.5, 0.75, 0.99):
+        q = d.quantile(p)
+        assert d.cdf(q) == pytest.approx(p, abs=1e-7)

--- a/tests/test_extreme_inputs.py
+++ b/tests/test_extreme_inputs.py
@@ -47,10 +47,18 @@ def test_1e100_spike_keeps_predictive_finite():
     assert _all_finite(dists)
 
 
-def test_prune_survives_nan_components():
-    d = Dist([(0.5, float("nan"), 1.0)] + [(0.5 / 30, float(i), 1.0)
+def test_nan_component_rejected_at_construction():
+    # This test used to assert that prune() survived a NaN mean, back when
+    # the constructor accepted one. The constructor now refuses nonfinite
+    # parameters outright (issue #200): a Dist with a NaN mean has NaN
+    # pdf/cdf/mean everywhere, so surviving prune only preserved the poison.
+    # The relentless-extremes torture tests above prove no internal path
+    # manufactures nonfinite components; the parade gate is the barrier for
+    # nonfinite inputs.
+    import pytest
+    with pytest.raises(ValueError):
+        Dist([(0.5, float("nan"), 1.0)] + [(0.5 / 30, float(i), 1.0)
                                            for i in range(30)])
-    assert len(d.prune(8)) <= 8
 
 
 def test_relentless_extremes():


### PR DESCRIPTION
Closes #200. The uncontroversial slice of the audit (#195-#205): every change either rejects input that was never a probability distribution or fixes an answer that was plainly wrong, and the whole thing is **verified parity-neutral**: `parity/vectors.json` regenerated before and after is byte-identical (`sha256 9e8923d2...`), so no port and no in-flight study is touched.

## Validation

`Dist([(2,0,1),(-1,10,1)])` was accepted and gave `pdf(10) = -0.399` while `logpdf` silently ignored the negative component. Weights must now be finite and nonnegative, means finite, stds finite and nonnegative, total weight positive, enforced with `ValueError` so the checks survive `python -O`. Two internal idioms stay legal on purpose: zero weights (leaf softmax underflow) and zero stds (the lattice projection emits Dirac atoms).

## combine

A length mismatch between distributions and weights silently zip-dropped the extras. Now raises, as do empty input and nonpositive total weight.

## quantile

Bisection ran against a fixed `mu +- 8 sigma` bracket and converged to the endpoint with no signal when a small far component put the true quantile outside it: on a 0.999/0.001 mixture split between 0 and 1e6, the 0.9995 quantile returned 253,856 with cdf 0.999. The bracket now expands geometrically until it contains `p`. The expansion is written so it never fires when the original bracket sufficed, which is what keeps the parity vectors bit-identical.

## One deliberate test change

`test_prune_survives_nan_components` pinned the old permissive constructor (a NaN mean surviving `prune`). Under validation a NaN mean cannot be constructed at all, which is strictly stronger protection, and the test now pins the `ValueError`. The relentless-extremes torture tests (`1e300` inputs) pass unchanged, so no internal path manufactures nonfinite components; the parade gate remains the barrier for nonfinite inputs. Flagging this in its own section since it is the one place the PR overrides an existing test's intent.

## A subtlety the neutrality check caught

The first draft summed weights with a manual `+=` loop and moved leaf quantiles by one ulp: builtin `sum()` uses compensated summation for floats. The total is computed with `sum()` exactly as before, and the byte-identical regeneration is the proof.

## Not in this PR, on purpose

The behavior-changing audit items stay open: #195/#196 (SplicedDist tails; and per Peter the negative-tau path in `_fit_ml` may be unfinished work, so it is untouched), #197 (multiscale targeting), #198 (missing-tick semantics), #199 (distribution protocol). Those change numbers or contracts and should not land under in-flight studies without their own decision.

Full suite: 1240 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)