### PR TITLE
Docs: score one step ahead, and say only what the code supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,18 @@ from skaters import laplace
 
 f = laplace(k=3)
 state = None
+forecast = None            # the fan issued LAST tick, aimed at this y
 for y in observations:
-    dists, state = f(y, state)
-    dists[0].mean              # point forecast
-    dists[0].std               # uncertainty
-    dists[0].quantile(0.975)   # upper edge of the central 95% band
-    dists[0].logpdf(y)         # log-likelihood
-    dists[0].cdf(y)            # CDF at y
+    if forecast is not None:
+        forecast[0].logpdf(y)          # one-step-ahead log score
+        forecast[0].cdf(y)             # one-step-ahead PIT
+    forecast, state = f(y, state)
+    forecast[0].mean                   # point forecast for the NEXT tick
+    forecast[0].std                    # uncertainty
+    forecast[0].quantile(0.975)        # upper edge of the central 95% band
 ```
 
-Every skater returns `list[Dist]` — a weighted Gaussian mixture for each horizon $h = 1, \ldots, k$. Point forecasts, uncertainty, density evaluation, and quantiles are all aspects of the same object.
+Score a forecast only against observations that arrive after it was issued; the predictive returned alongside `y` aims at the next tick, and the parade in `state["pit"]`/`state["z"]` does this bookkeeping for you. Every skater returns a list of predictive distributions, one for each horizon $h = 1, \ldots, k$. Point forecasts, uncertainty, density evaluation, and quantiles are all aspects of the same object.
 
 ## `laplace` — the general forecaster
 
@@ -83,7 +85,7 @@ differencing, drift, Holt, AR, fractional differencing, seasonal, a Yeo-Johnson
 (`k>1`) — an **Ornstein–Uhlenbeck mean-reversion** group). Three things are on by
 default, each a free or near-free win:
 
-- **model first, conform last** — the trunk is weighted by **likelihood**;
+- **model first, score-optimize last** — the trunk is weighted by **likelihood**;
   the terminal leaf is fit by **CRPS** (`objective="crps"`). On a
   2,500-series FRED study this matches a CRPS specialist on CRPS *and* lifts
   likelihood on real data. Switch back with `objective="likelihood"`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -70,14 +70,16 @@ from skaters import laplace
 
 f = laplace(k=1)          # general-purpose, online, the default
 state = None
+forecast = None           # the predictive issued LAST tick, aimed at this y
 for y in stream:
+    if forecast is not None:
+        forecast.logpdf(y) # <-- a real density: one-step-ahead log score
+        forecast.crps(y)   # ...and CRPS, same discipline
     dists, state = f(y, state)
-    d = dists[0]
-    d.mean                 # point forecast
-    d.std                  # uncertainty
-    d.quantile(0.975)      # upper edge of the central 95% band
-    d.logpdf(y)            # <-- a real density: scorable on log-likelihood
-    d.crps(y)              # ...and on CRPS
+    forecast = dists[0]
+    forecast.mean          # point forecast for the NEXT tick
+    forecast.std           # uncertainty
+    forecast.quantile(0.975)  # upper edge of the central 95% band
 ```
 
 For price/return series with volatility clustering, swap in the GARCH(1,1)-t
@@ -97,7 +99,7 @@ f = laplace(k=20)              # multi-scale: strides {1, 5, 20}
 f = laplace(k=20, scales=[1])  # single-scale native fan-out
 ```
 
-Defaults worth knowing: `laplace` runs *model first, conform last* (likelihood
+Defaults worth knowing: `laplace` runs *model first, score-optimize last* (likelihood
 trunk + CRPS leaf), a near-Dirac **lattice projection** for series that revisit
 exact values (`sticky=True`, free on continuous data), and online Yeo–Johnson
 **coordinate** learning. Turn the leaf objective back to pure likelihood with

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -128,8 +128,12 @@
     </p>
 
     <h2>Reproducibility</h2>
-    <p>All studies are reproducible end-to-end from
-      <a href="https://github.com/microprediction/skaters/tree/main/benchmarks">skaters/benchmarks</a>.
+    <p>Every study's harness and committed results live in
+      <a href="https://github.com/microprediction/skaters/tree/main/benchmarks">skaters/benchmarks</a>,
+      beside the statements filed before results existed. The smaller studies
+      regenerate from committed inputs alone; the paper-scale tables also need
+      the full FRED cache, which is larger than the repository carries, so
+      each study's README says what its rerun requires.
       The papers behind them are on the <a href="/papers.html">papers page</a>.</p>
   </main>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -85,7 +85,7 @@
 
     <p>
       On 894 continuous non-price FRED series, scored one step ahead per series,
-      <code>laplace</code> has the best held-out log-likelihood in the field, ahead of
+      <code>laplace</code> has the best held-out log-likelihood among the tested baselines, ahead of
       AutoARIMA, AutoETS, SARIMAX, conformal methods, the heavy-tail GARCH-t, and four
       zero-shot foundation models. It gives up ground only on CRPS, to the CRPS
       specialists, and on price and return series, where GARCH-t is the better choice.
@@ -94,8 +94,8 @@
 
     <p>
       Each language is an independent, parity-locked port, checked against the reference to
-      1e-6 (Python also has a Rust backend for speed). A fitted model serialises to JSON, so
-      one fit on a server resumes unchanged in the browser.
+      1e-6 (Python also has a Rust backend for speed). Model specifications serialise to
+      JSON, and fitted state checkpoints and resumes within a language.
       <a href="/languages.html">The languages →</a>
     </p>
 
@@ -145,15 +145,20 @@
 
 f = laplace(k=3)
 state = None
+forecast = None            # the fan issued LAST tick, aimed at this y
 for y in observations:
-    dists, state = f(y, state)
-    dists[0].mean              # point forecast
-    dists[0].std               # uncertainty
-    dists[0].quantile(0.975)   # upper edge of the central 95% band
-    dists[0].logpdf(y)         # log-likelihood
-    dists[0].cdf(y)            # CDF at y</code></pre>
+    if forecast is not None:
+        forecast[0].logpdf(y)          # one-step-ahead log score
+        forecast[0].cdf(y)             # one-step-ahead PIT
+    forecast, state = f(y, state)
+    forecast[0].mean                   # point forecast for the NEXT tick
+    forecast[0].std                    # uncertainty
+    forecast[0].quantile(0.975)        # upper edge of the central 95% band</code></pre>
     <p>
-      Every skater returns <code>list[Dist]</code> &mdash; one weighted mixture per horizon
+      Score a forecast only against observations that arrive after it was issued; the
+      predictive returned alongside $y$ aims at the next tick, and the parade in
+      <code>state["pit"]</code>/<code>state["z"]</code> does this bookkeeping for you. Every
+      skater returns a list of predictive distributions, one per horizon
       $h = 1, \ldots, k$. Point forecasts, uncertainty, density evaluation, and quantiles are all
       facets of the same object.
     </p>

--- a/docs/performance.html
+++ b/docs/performance.html
@@ -150,8 +150,9 @@
         Streaming, laplace is orders of magnitude cheaper. Which number applies depends
         entirely on whether you are scoring a benchmark or running a service.</li>
       <li><strong>Rust and Python differ by roughly 18&times;.</strong> Ratios here are
-        against the Rust core (<code>skaters_fast</code>), which is what ships; the
-        pure-Python reference is correspondingly slower.</li>
+        against the Rust core (<code>skaters_fast</code>), the opt-in accelerator; the
+        pure-Python reference, which is what <code>pip install skaters</code> serves,
+        is correspondingly slower.</li>
       <li><strong>Horizon costs laplace.</strong> Going from k=1 to k=12 costs it roughly
         an order of magnitude, because the multi-scale ensemble runs a full candidate pool
         per decimation stride per horizon.</li>

--- a/docs/sandwich.html
+++ b/docs/sandwich.html
@@ -4,11 +4,11 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>skaters — the sandwich</title>
-  <meta name="description" content="Every model improved by the laplace sandwich: run it in laplace's coordinates, map back exactly. Forecasters and detectors, with the measured lifts." />
+  <meta name="description" content="The laplace sandwich: run any model in laplace's coordinates, map back exactly. Forecasters and detectors, with the measured lifts and the measured limits." />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="skaters" />
   <meta property="og:title" content="skaters — the sandwich" />
-  <meta property="og:description" content="Every model improved by the laplace sandwich, with the measured lifts." />
+  <meta property="og:description" content="The laplace sandwich: any model in laplace's coordinates, with the measured lifts and limits." />
   <meta property="og:url" content="https://skaters.microprediction.org/sandwich.html" />
   <meta name="twitter:card" content="summary" />
   <link rel="stylesheet" href="./academic.css" />
@@ -59,7 +59,9 @@
   <main>
     <h1>The sandwich</h1>
     <p class="subtitle">Run any model in laplace's coordinates, map back
-      exactly. Everyone improves.</p>
+      exactly. Forecasters converge to laplace plus whatever they see that it
+      missed; detectors that want stationary input improve, template matchers
+      do not.</p>
 
     <svg viewBox="0 0 720 240" role="img" aria-label="The laplace sandwich: transform bread, any model as filling, exact inverse bread"
          style="max-width:680px;width:100%;display:block;margin:18px auto;">
@@ -130,9 +132,10 @@
       positive epsilon spans the whole universe rather than one stratum:
       ahead of laplace on 65% of series, +0.04 nats median, filed as its
       pre-registered convergence hypothesis. The z stream also suits
-      Bayesian machinery unusually well. Its marginal is N(0,1) by
-      construction, so priors centred at no structure and unit scale are
-      exactly right rather than guesswork, and a single pre-test ADVI fit
+      Bayesian machinery unusually well. To the extent laplace's predictive
+      cdf is right, the z stream is close to standard normal (that is what the
+      PIT tables measure), so priors centred at no structure and unit scale
+      are a measured default rather than guesswork, and a single pre-test ADVI fit
       frozen through all 150 test steps still ties laplace to the third
       decimal: in these coordinates, batch-refit staleness costs almost
       nothing. One pooled hierarchical fit across all 226 series lost to

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -542,14 +542,16 @@ from skaters import laplace
 
 f = laplace(k=1)          # general-purpose, online, the default
 state = None
+forecast = None           # the predictive issued LAST tick, aimed at this y
 for y in stream:
+    if forecast is not None:
+        forecast.logpdf(y) # &lt;-- a real density: one-step-ahead log score
+        forecast.crps(y)   # ...and CRPS, same discipline
     dists, state = f(y, state)
-    d = dists[0]
-    d.mean                 # point forecast
-    d.std                  # uncertainty
-    d.quantile(0.975)      # upper edge of the central 95% band
-    d.logpdf(y)            # &lt;-- a real density: scorable on log-likelihood
-    d.crps(y)              # ...and on CRPS
+    forecast = dists[0]
+    forecast.mean          # point forecast for the NEXT tick
+    forecast.std           # uncertainty
+    forecast.quantile(0.975)  # upper edge of the central 95% band
 ```
 
 For **price/return series** with volatility clustering, there's no free lunch —
@@ -557,7 +559,7 @@ use a fitted **GARCH-t** rather than `laplace`. (`laplace(leaf=garch_leaf)` is t
 dependency-free option that recovers roughly half the gap, but the specialist
 still wins on returns.)
 
-Defaults worth knowing: `laplace` runs *model first, conform last* (likelihood
+Defaults worth knowing: `laplace` runs *model first, score-optimize last* (likelihood
 trunk + CRPS leaf), a near-Dirac **lattice projection** for series that revisit
 exact values (`sticky=True`, free on continuous data), and online Yeo–Johnson
 **coordinate** learning. Turn the leaf objective back to pure likelihood with


### PR DESCRIPTION
Supersedes #207, which was auto-closed when its base branch (#194's, now merged) was deleted; the branch is rebased onto main with identical content. The wording half of the audit, closing #202 and #205 and the wording part of #203. No code changes; the corrected quick-start snippet is exercised against the real package.

## The look-ahead quick start (#202)

README, SKILL.md, index.html, and skills.html all scored `dists[0]` on the y it had just consumed. That predictive aims at the next observation, so the published pattern was look-ahead scoring, and the package's own parade does the correct bookkeeping. All four snippets now hold the previous forecast and score it when y arrives, with a sentence stating the discipline.

## Copy corrections (#205), each verified before editing

- **"Everyone improves"** (sandwich subtitle and page meta): contradicted by the page's own detector table. Now: forecasters converge to laplace plus what they see that it missed; template matchers do not improve.
- **"Its marginal is N(0,1) by construction"**: true only when the predictive cdf is correct; now conditioned on that, pointing at the PIT tables as the measurement.
- **"model first, conform last"**: the CRPS leaf is exponentiated-gradient weight optimization, not conformal prediction, and the site compares against real conformal methods elsewhere. Renamed "score-optimize last".
- **Rust "is what ships"** (performance.html) versus opt-in (languages.html): now says the pure-Python reference is what `pip install skaters` serves and the Rust core is the opt-in accelerator.
- **"A fitted model serialises to JSON"**: `spec.py` serializes the symbolic spec, and `json.dumps(state)` raises on deques (verified against a fitted `laplace(k=2)`). Now: specs serialise to JSON; fitted state checkpoints and resumes within a language.
- **"best held-out log-likelihood in the field"**: scoped to "among the tested baselines".
- **"All studies are reproducible end-to-end"** (benchmarks.html): now distinguishes studies that regenerate from committed inputs from paper-scale tables needing the external FRED cache (#203).

## Left open on purpose

#204 (the not-worse statistic) and the errata page half of #203 need protocol decisions, not wording, and the studies in flight on the other machine should not have their scoring definitions changed underneath them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
