### PR TITLE
TimesFM-3 arm: adapter, registry entries, and a weights-free preflight

### DIFF
--- a/benchmarks/arm_adapters.py
+++ b/benchmarks/arm_adapters.py
@@ -351,19 +351,24 @@ def make_registry(h=1):
         "TabPFN":      lambda ch: tabpfn_dists(ch, h),
         "Chronos":     lambda ch: fs.chronos_dists(ch, h),
         "TimesFM":     lambda ch: fs.timesfm_dists(ch, h),
+        "TimesFM3":    lambda ch: fs.timesfm3_dists(ch, h),
         "TimesFM+lap": _sandwich(fs.timesfm_dists, h),
+        "TimesFM3+lap": _sandwich(fs.timesfm3_dists, h),
         "TiRex+lap":   _sandwich(tirex_dists, h),
         "Chronos+lap": _sandwich(fs.chronos_dists, h),
         # adaptive: FM location + laplace conditional scale/tails on the residual
         "TimesFM~lap": _resid_sandwich(fs.timesfm_dists, h),
+        "TimesFM3~lap": _resid_sandwich(fs.timesfm3_dists, h),
         "TiRex~lap":   _resid_sandwich(tirex_dists, h),
         "Chronos~lap": _resid_sandwich(fs.chronos_dists, h),
         # PIT recalibration: laplace predicts in the FM's own CDF space, then inverts
         "TimesFM@lap": pit_sandwich(fs.timesfm_dists, h),
+        "TimesFM3@lap": pit_sandwich(fs.timesfm3_dists, h),
         "TiRex@lap":   pit_sandwich(tirex_dists, h),
         "Chronos@lap": pit_sandwich(fs.chronos_dists, h),
         # never-worse portfolio: laplace + PIT-recalibrated FM, online log-score blend
         "TimesFM&lap": portfolio_sandwich(fs.timesfm_dists, h=h),
+        "TimesFM3&lap": portfolio_sandwich(fs.timesfm3_dists, h=h),
         "TiRex&lap":   portfolio_sandwich(tirex_dists, h=h),
         "Chronos&lap": portfolio_sandwich(fs.chronos_dists, h=h),
     }

--- a/benchmarks/foundation_study.py
+++ b/benchmarks/foundation_study.py
@@ -293,9 +293,13 @@ def timesfm3_dists(ch, h=1):
                 f"(TEST={TEST} CTX={CTX} h={h}), got {n}")
         inputs = [np.asarray(ch[t - sh - CTX:t - sh], dtype=np.float32)
                   for t in range(start, n)]
+        # make_positive=False: the evaluator's benchmark default clamps
+        # forecasts nonnegative, and these are signed change series.
+        # univariate=True is a no-op for 1-D contexts but pins the intent.
         outs = list(_timesfm3.predict_batch(
             inputs, horizon=h, return_quantiles=True,
-            use_symmetric_averaging=False))
+            use_symmetric_averaging=False,
+            make_positive=False, univariate=True))
         levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         dists = []
         for o in outs:

--- a/benchmarks/foundation_study.py
+++ b/benchmarks/foundation_study.py
@@ -260,9 +260,60 @@ def timesfm_dists(ch, h=1):
         print(f"  timesfm failed: {e}", flush=True); return None
 
 
+_timesfm3 = None
+def timesfm3_dists(ch, h=1):
+    """TimesFM 3.0 zero-shot, univariate mode; 9-decile quantile output ->
+    quantile_dist. Same windowing contract as timesfm_dists: for h>1 the
+    context ends h steps before each target and the horizon-h row is scored.
+
+    Weights (google/timesfm-3.0-pytorch) are under timesfm-non-commercial
+    -license-v1.0: research benchmarking only, no production use. The 3.0
+    API lives in the timesfm3 namespace of the same pip package; contexts
+    are a list of 1-D float32 arrays and predict_batch returns one output
+    per context with .quantiles of shape [h, 9] (deciles 0.1..0.9)."""
+    global _timesfm3
+    try:
+        from timesfm3 import TimesFM3Evaluator, ModelConfig
+        if _timesfm3 is None:
+            try:
+                from importlib.metadata import version as _pkgver
+                _v = _pkgver("timesfm")
+            except Exception:               # noqa: BLE001
+                _v = "?"
+            print(f"  timesfm package {_v}, "
+                  f"checkpoint google/timesfm-3.0-pytorch, device {DEVICE}",
+                  flush=True)
+            _timesfm3 = TimesFM3Evaluator(ModelConfig(
+                checkpoint_path="google/timesfm-3.0-pytorch",
+                per_core_batch_size=32, device=DEVICE))
+        n = len(ch); start = n - TEST; sh = h - 1
+        if start - sh - CTX < 0:
+            raise ValueError(
+                f"series too short: need >= {TEST + CTX + sh} changes "
+                f"(TEST={TEST} CTX={CTX} h={h}), got {n}")
+        inputs = [np.asarray(ch[t - sh - CTX:t - sh], dtype=np.float32)
+                  for t in range(start, n)]
+        outs = list(_timesfm3.predict_batch(
+            inputs, horizon=h, return_quantiles=True,
+            use_symmetric_averaging=False))
+        levels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+        dists = []
+        for o in outs:
+            q = np.asarray(o.quantiles, dtype=float)   # [h, 9] univariate
+            if q.ndim == 3:                            # [1, h, 9] defensive
+                q = q[0]
+            dists.append(quantile_dist(levels, q[h - 1]))
+        if len(dists) != TEST:
+            raise ValueError(f"expected {TEST} outputs, got {len(dists)}")
+        return dists
+    except Exception as e:                  # noqa: BLE001
+        print(f"  timesfm3 failed: {e}", flush=True); return None
+
+
 # ---------------------------------------------------------------- runner
 _ALL_MODELS = [("Chronos", chronos_dists), ("Moirai", moirai_dists),
-               ("Lag-Llama", lagllama_dists), ("TimesFM", timesfm_dists)]
+               ("Lag-Llama", lagllama_dists), ("TimesFM", timesfm_dists),
+               ("TimesFM3", timesfm3_dists)]
 _SEL = os.environ.get("FM_MODELS", "")      # comma list; empty = all
 MODELS = [(n, f) for n, f in _ALL_MODELS if not _SEL or n in _SEL.split(",")]
 

--- a/benchmarks/preds
+++ b/benchmarks/preds
@@ -1,0 +1,1 @@
+/Users/petercotton/github/skaters/benchmarks/preds

--- a/benchmarks/smoke_timesfm3.py
+++ b/benchmarks/smoke_timesfm3.py
@@ -56,7 +56,9 @@ def install_fake_timesfm3():
 
     def predict_batch(self, contexts, horizon, past_only_covariates=None,
                       past_future_covariates=None, return_quantiles=True,
-                      use_symmetric_averaging=False):
+                      use_symmetric_averaging=False, make_positive=False,
+                      univariate=False):
+        assert not make_positive, "signed changes: make_positive must be False"
         for c in contexts:
             c = np.asarray(c, dtype=np.float32)
             assert c.ndim == 1, "adapter must send univariate 1-D contexts"

--- a/benchmarks/smoke_timesfm3.py
+++ b/benchmarks/smoke_timesfm3.py
@@ -1,0 +1,122 @@
+"""Preflight for the TimesFM-3 arm. Two modes:
+
+    PYTHONPATH=src:benchmarks python benchmarks/smoke_timesfm3.py --fake
+        No weights, no torch: injects a stand-in timesfm3 module and checks
+        the adapter's windowing, alignment, output count, and that the
+        resulting Dists score. Runs on any machine; run it after editing
+        the adapter.
+
+    PYTHONPATH=src:benchmarks python benchmarks/smoke_timesfm3.py
+        Loads the real checkpoint (google/timesfm-3.0-pytorch; ~1.3GB on
+        first run) and scores one synthetic series end to end. Run once on
+        the study machine before ARM_METHODS=TimesFM3. FM_DEVICE selects
+        cpu | mps | cuda.
+
+License note: the 3.0 weights are timesfm-non-commercial-license-v1.0,
+research benchmarking only.
+"""
+from __future__ import annotations
+import math
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import numpy as np
+
+
+def install_fake_timesfm3():
+    """A stand-in that mimics the 3.0 API shape: predict_batch yields one
+    output per context with .forecast [h] and .quantiles [h, 9], where the
+    quantiles are deciles of a Gaussian centered on the context's last value.
+    The center encodes the LAST CONTEXT VALUE so the test can prove which
+    window each output came from (the alignment property the adapter must
+    preserve: for horizon h the context ends h steps before the target)."""
+    mod = types.ModuleType("timesfm3")
+
+    class ModelConfig:
+        def __init__(self, checkpoint_path, per_core_batch_size=32, device="cpu"):
+            self.checkpoint_path = checkpoint_path
+            self.device = device
+
+    class _Out:
+        def __init__(self, forecast, quantiles):
+            self.forecast = forecast
+            self.quantiles = quantiles
+
+    class TimesFM3Evaluator:
+        def __init__(self, config):
+            self.config = config
+
+    # symmetric deciles of a unit Gaussian, hardcoded (no scipy dependency)
+    DECILE_Z = [-1.2815515655446004, -0.8416212335729143, -0.5244005127080407,
+                -0.2533471031357997, 0.0, 0.2533471031357997,
+                0.5244005127080407, 0.8416212335729143, 1.2815515655446004]
+
+    def predict_batch(self, contexts, horizon, past_only_covariates=None,
+                      past_future_covariates=None, return_quantiles=True,
+                      use_symmetric_averaging=False):
+        for c in contexts:
+            c = np.asarray(c, dtype=np.float32)
+            assert c.ndim == 1, "adapter must send univariate 1-D contexts"
+            center = float(c[-1])
+            fc = np.full((horizon,), center, dtype=np.float32)
+            q = np.array([[center + z for z in DECILE_Z]] * horizon,
+                         dtype=np.float32)
+            yield _Out(fc, q)
+
+    TimesFM3Evaluator.predict_batch = predict_batch
+    mod.ModelConfig = ModelConfig
+    mod.TimesFM3Evaluator = TimesFM3Evaluator
+    sys.modules["timesfm3"] = mod
+
+
+def main():
+    fake = "--fake" in sys.argv
+    if fake:
+        install_fake_timesfm3()
+
+    import foundation_study as fs
+    from skaters.dist import Dist  # noqa: F401
+
+    # long enough for the sandwich arms, which extend TEST by a warmup
+    n = fs.CTX + fs.TEST + 300
+    rng = np.random.default_rng(7)
+    ch = list(np.cumsum(rng.standard_normal(n)) * 0.01 + np.sin(np.arange(n) / 9))
+
+    for h in (1, 3):
+        fs._timesfm3 = None
+        dists = fs.timesfm3_dists(ch, h=h)
+        assert dists is not None, f"adapter returned None at h={h}"
+        assert len(dists) == fs.TEST, (len(dists), fs.TEST)
+        y = ch[len(ch) - fs.TEST:]
+        lps = [d.logpdf(v) for d, v in zip(dists, y)]
+        assert all(math.isfinite(v) for v in lps), "non-finite log scores"
+        if fake:
+            # Alignment proof: the fake centers each predictive on the last
+            # context value, which for target index t is ch[t - h]. The
+            # median of dists[i] must equal ch[start + i - h] to float32.
+            start = len(ch) - fs.TEST
+            for i in (0, fs.TEST // 2, fs.TEST - 1):
+                med = dists[i].quantile(0.5)
+                want = ch[start + i - h]
+                assert abs(med - want) < 1e-4, (h, i, med, want)
+        print(f"h={h}: {len(dists)} dists, mean logpdf {np.mean(lps):+.3f}"
+              + (", alignment verified" if fake else ""))
+
+    if fake:
+        import arm_adapters as aa
+        reg = aa.make_registry(1)
+        for name in ("TimesFM3", "TimesFM3+lap", "TimesFM3~lap",
+                     "TimesFM3@lap", "TimesFM3&lap"):
+            assert name in reg, name
+            out = reg[name](ch)
+            assert out is not None and len(out) == fs.TEST, name
+            print(f"registry {name}: ok ({len(out)} dists)")
+
+    print("SMOKE OK" + (" (fake backend)" if fake else " (real checkpoint)"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Sets up #209 to run through the canonical pipeline (run_arm.py + arm_adapters.REGISTRY). No study is run here; the study machine pulls this branch.

## What's in it

- `foundation_study.timesfm3_dists`: TimesFM 3.0 zero-shot adapter, univariate mode, same windowing contract as the 2.5 adapter (context ends h steps before the target). The 3.0 API moved to `timesfm3.TimesFM3Evaluator.predict_batch(contexts, horizon, return_quantiles=True)` returning `.quantiles [h, 9]` deciles, which feed the existing `quantile_dist` path unchanged. Prints package version, checkpoint, and device at init per the version-stamping convention. Raises loudly if a series is too short for TEST+CTX+h-1 instead of silently mis-slicing, an exposure the 2.5 adapter shares but real HIST=1000 series never trigger.
- Registry entries: `TimesFM3` plus the full sandwich family `TimesFM3+lap`, `TimesFM3~lap`, `TimesFM3@lap`, `TimesFM3&lap`, one line each beside the TimesFM 2.5 rows.
- `benchmarks/smoke_timesfm3.py`: preflight with two modes. `--fake` injects a stand-in `timesfm3` module and proves windowing alignment (the fake encodes each context's last value as the predictive median, so the test verifies dists[i] came from exactly the window ending h steps before target i), output counts at h=1 and h=3, finite scoring, and all five registry arms end to end. Verified green on this machine. Default mode loads the real checkpoint and scores one synthetic series, to be run once on the study machine.

## On the study machine

```
pip install -U "timesfm[torch]"    # 3.0 lives in the same package, new timesfm3 namespace
PYTHONPATH=src:benchmarks python benchmarks/smoke_timesfm3.py          # real-checkpoint preflight (~1.3GB download)
PYTHONPATH=src:benchmarks ARM_METHODS=TimesFM3 ARM_CORPUS=monthly \
  PRED_OUT=preds_timesfm3.csv FM_DEVICE=cuda python benchmarks/run_arm.py
```

Note upgrading the package for 3.0 shares the env with the 2.5 adapter; the README says 2.5 code stays under `src/timesfm`, but if the upgrade breaks `TimesFM_2p5_200M_torch`, run the two arms from separate envs via the FM_TAG/PRED_OUT machinery as usual.

## License

The 3.0 weights are `timesfm-non-commercial-license-v1.0` (research benchmarking only, no production use). The adapter docstring and the smoke script both carry the note; any results page rows should too. 2.5 weights remain Apache and stay the production-relevant comparison.

Pre-registration statement for the actual study is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)